### PR TITLE
Write acceptance tests for public pages (ATDD)

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,0 +1,4 @@
+class GamesController < ApplicationController
+  def show
+  end
+end

--- a/app/controllers/hall_of_fame_controller.rb
+++ b/app/controllers/hall_of_fame_controller.rb
@@ -1,0 +1,4 @@
+class HallOfFameController < ApplicationController
+  def show
+  end
+end

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -1,0 +1,4 @@
+class PlayersController < ApplicationController
+  def show
+  end
+end

--- a/app/controllers/seasons_controller.rb
+++ b/app/controllers/seasons_controller.rb
@@ -1,0 +1,4 @@
+class SeasonsController < ApplicationController
+  def show
+  end
+end

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -1,0 +1,4 @@
+class SeriesController < ApplicationController
+  def show
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,16 @@
 Rails.application.routes.draw do
   devise_for :users
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
+  root "seasons#show", defaults: { number: 5 }
+
+  resources :seasons, only: [ :show ], param: :number do
+    resources :series, only: [ :show ], param: :number
+  end
+
+  resources :games, only: [ :show ]
+  resources :players, only: [ :show ]
+
+  get "hall", to: "hall_of_fame#show"
+
   get "up" => "rails/health#show", as: :rails_health_check
-
-  # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
-  # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-  # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-
-  # Defines the root path route ("/")
-  # root "posts#index"
 end

--- a/spec/acceptance/game_details_spec.rb
+++ b/spec/acceptance/game_details_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe "Game details" do
+  let!(:role) { create(:role, code: "peace", name: "Мирный") }
+  let!(:game) do
+    create(:game, season: 5, series: 1, game_number: 1,
+           played_on: Date.new(2025, 1, 10), name: "Финал")
+  end
+  let!(:player1) { create(:player, name: "Алексей") }
+  let!(:player2) { create(:player, name: "Борис") }
+  let!(:rating1) do
+    create(:rating, game: game, player: player1, role_code: "peace",
+           plus: 3.0, minus: 0.5, best_move: 0.5, win: true)
+  end
+  let!(:rating2) do
+    create(:rating, game: game, player: player2, role_code: "peace",
+           plus: 1.0, minus: 1.5, best_move: nil, win: false)
+  end
+
+  before { visit game_path(game) }
+
+  it "displays game header with full name" do
+    expect(page).to have_content(game.full_name)
+  end
+
+  it "displays player names in the rating table" do
+    expect(page).to have_content("Алексей")
+    expect(page).to have_content("Борис")
+  end
+
+  it "displays role names" do
+    expect(page).to have_content("Мирный")
+  end
+
+  it "displays rating values" do
+    expect(page).to have_content("3.0")
+    expect(page).to have_content("0.5")
+  end
+
+  it "displays rating table headers" do
+    expect(page).to have_content("Роль")
+    expect(page).to have_content("Плюс")
+    expect(page).to have_content("Минус")
+    expect(page).to have_content("Лучший ход")
+    expect(page).to have_content("Итого")
+  end
+end

--- a/spec/acceptance/hall_of_fame_spec.rb
+++ b/spec/acceptance/hall_of_fame_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "Hall of Fame" do
+  let!(:player) { create(:player, name: "Алексей") }
+  let!(:organizer) { create(:player, name: "Ведущий") }
+  let!(:award) { create(:award, title: "Лучший игрок", staff: false) }
+  let!(:staff_award) { create(:award, title: "Лучший ведущий", staff: true) }
+
+  before do
+    create(:player_award, player: player, award: award, season: 5)
+    create(:player_award, player: organizer, award: staff_award, season: 5)
+
+    visit hall_path
+  end
+
+  it "displays the hall of fame title" do
+    expect(page).to have_content("Зал Славы")
+  end
+
+  it "displays awarded players with their awards" do
+    expect(page).to have_content("Алексей")
+    expect(page).to have_content("Лучший игрок")
+  end
+
+  it "displays staff/organizer section separately" do
+    expect(page).to have_content("Организаторы")
+    expect(page).to have_content("Ведущий")
+    expect(page).to have_content("Лучший ведущий")
+  end
+end

--- a/spec/acceptance/player_profile_spec.rb
+++ b/spec/acceptance/player_profile_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "Player profile" do
+  let!(:player) { create(:player, name: "Алексей") }
+  let!(:game) do
+    create(:game, season: 5, series: 1, game_number: 1,
+           played_on: Date.new(2025, 1, 10))
+  end
+  let!(:rating) { create(:rating, game: game, player: player, plus: 3.0, minus: 0.5, win: true) }
+  let!(:award) { create(:award, title: "Лучший игрок", staff: false) }
+  let!(:player_award) { create(:player_award, player: player, award: award, season: 5) }
+
+  before { visit player_path(player) }
+
+  it "displays player name" do
+    expect(page).to have_content("Алексей")
+  end
+
+  it "displays per-season stats" do
+    expect(page).to have_content("Сезон 5")
+  end
+
+  it "links to games in the game history" do
+    expect(page).to have_link(href: game_path(game))
+  end
+
+  it "displays awards" do
+    expect(page).to have_content("Лучший игрок")
+  end
+end

--- a/spec/acceptance/season_overview_spec.rb
+++ b/spec/acceptance/season_overview_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe "Season overview" do
+  let!(:game1) { create(:game, season: 5, series: 1, game_number: 1, played_on: Date.new(2025, 1, 10)) }
+  let!(:game2) { create(:game, season: 5, series: 1, game_number: 2, played_on: Date.new(2025, 1, 17)) }
+  let!(:game3) { create(:game, season: 5, series: 2, game_number: 1, played_on: Date.new(2025, 2, 7)) }
+
+  let!(:player1) { create(:player, name: "Алексей") }
+  let!(:player2) { create(:player, name: "Борис") }
+
+  before do
+    create(:rating, game: game1, player: player1, plus: 3.0, minus: 0.5, win: true)
+    create(:rating, game: game1, player: player2, plus: 1.0, minus: 1.5, win: false)
+    create(:rating, game: game2, player: player1, plus: 2.0, minus: 1.0, win: true)
+    create(:rating, game: game3, player: player2, plus: 4.0, minus: 0.0, win: true)
+
+    visit season_path(number: 5)
+  end
+
+  it "displays games grouped by series" do
+    expect(page).to have_content("Серия 1")
+    expect(page).to have_content("Серия 2")
+  end
+
+  it "links to individual games" do
+    expect(page).to have_link(href: game_path(game1))
+    expect(page).to have_link(href: game_path(game2))
+    expect(page).to have_link(href: game_path(game3))
+  end
+
+  it "links to series pages" do
+    expect(page).to have_link(href: season_series_path(season_number: 5, number: 1))
+    expect(page).to have_link(href: season_series_path(season_number: 5, number: 2))
+  end
+
+  it "displays player rankings table headers" do
+    expect(page).to have_content("Место")
+    expect(page).to have_content("Игрок")
+    expect(page).to have_content("Рейтинг")
+    expect(page).to have_content("Игры")
+    expect(page).to have_content("Процент побед")
+  end
+
+  it "links player names to their profiles" do
+    expect(page).to have_link("Алексей", href: player_path(player1))
+    expect(page).to have_link("Борис", href: player_path(player2))
+  end
+
+  it "displays player statistics" do
+    within("table") do
+      expect(page).to have_content("Алексей")
+      expect(page).to have_content("Борис")
+    end
+  end
+end

--- a/spec/acceptance/series_totals_spec.rb
+++ b/spec/acceptance/series_totals_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe "Series totals" do
+  let!(:game1) { create(:game, season: 5, series: 1, game_number: 1) }
+  let!(:game2) { create(:game, season: 5, series: 1, game_number: 2) }
+  let!(:player1) { create(:player, name: "Алексей") }
+  let!(:player2) { create(:player, name: "Борис") }
+
+  before do
+    create(:rating, game: game1, player: player1, plus: 3.0, minus: 0.5)
+    create(:rating, game: game1, player: player2, plus: 1.0, minus: 1.5)
+    create(:rating, game: game2, player: player1, plus: 2.0, minus: 1.0)
+    create(:rating, game: game2, player: player2, plus: 5.0, minus: 0.0)
+
+    visit season_series_path(season_number: 5, number: 1)
+  end
+
+  it "displays player names" do
+    expect(page).to have_content("Алексей")
+    expect(page).to have_content("Борис")
+  end
+
+  it "displays game columns" do
+    expect(page).to have_content("Игра 1")
+    expect(page).to have_content("Игра 2")
+  end
+
+  it "displays a total column" do
+    expect(page).to have_content("Итого")
+  end
+
+  it "sorts players by total descending" do
+    expect(page.text).to match(/Борис.*Алексей/m)
+  end
+end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,7 @@
+require "capybara/rspec"
+
+RSpec.configure do |config|
+  config.define_derived_metadata(file_path: %r{spec/acceptance/}) do |metadata|
+    metadata[:type] = :feature
+  end
+end


### PR DESCRIPTION
## Summary

- Add public routes for seasons, games, players, series, and hall of fame
- Create stub controllers (empty `show` actions) so routes resolve
- Configure Capybara to map `spec/acceptance/` to `:feature` type
- Write 22 acceptance tests across 5 spec files describing expected page behavior

## Acceptance tests (all expected to fail — no views yet)

| Spec | Examples | Covers |
|------|----------|--------|
| `season_overview_spec.rb` | 6 | Games by series, series links, rankings table, player links |
| `game_details_spec.rb` | 5 | Game header, players, roles, rating values, table headers |
| `player_profile_spec.rb` | 4 | Name, per-season stats, game links, awards |
| `series_totals_spec.rb` | 4 | Player names, game columns, total column, sort order |
| `hall_of_fame_spec.rb` | 3 | Title, awarded players, staff/organizer section |

## Test plan

- [x] `bundle exec rubocop` — 0 offenses
- [x] All 22 tests fail with `*Controller#show is missing a template` (expected for ATDD)
- [x] Existing model tests still pass
- [ ] Tasks vanilla-mafia-14 through 18 will implement views to make these pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)