### PR TITLE
Re-include acceptance tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           RAILS_ENV: test
           # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           # REDIS_URL: redis://localhost:6379/0
-        run: bundle exec rspec --exclude-pattern "spec/{system,acceptance}/**/*_spec.rb"
+        run: bundle exec rspec --exclude-pattern "spec/system/**/*_spec.rb"
 
   system-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Remove `acceptance` from the rspec exclude pattern in CI, now that all 5 public page views are implemented
- All 22 acceptance tests pass locally

## Test plan
- [x] `bundle exec rspec spec/acceptance/` — 22 examples, 0 failures
- [x] CI should now run acceptance tests alongside unit/request specs

Closes vanilla-mafia-38

🤖 Generated with [Claude Code](https://claude.com/claude-code)