### PR TITLE
Extract query logic into service objects

### DIFF
--- a/app/controllers/hall_of_fame_controller.rb
+++ b/app/controllers/hall_of_fame_controller.rb
@@ -1,6 +1,7 @@
 class HallOfFameController < ApplicationController
   def show
-    @player_awards = PlayerAward.includes(:player, :award).where(award: Award.for_players).ordered.load
-    @staff_awards = PlayerAward.includes(:player, :award).where(award: Award.for_staff).ordered.load
+    result = HallOfFameService.call
+    @player_awards = result.player_awards
+    @staff_awards = result.staff_awards
   end
 end

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -1,7 +1,8 @@
 class PlayersController < ApplicationController
   def show
-    @player = Player.find(params[:id])
-    @games_by_season = @player.games.ordered.group_by(&:season)
-    @player_awards = @player.player_awards.ordered.includes(:award).load
+    result = PlayerProfileService.call(player_id: params[:id])
+    @player = result.player
+    @games_by_season = result.games_by_season
+    @player_awards = result.player_awards
   end
 end

--- a/app/controllers/seasons_controller.rb
+++ b/app/controllers/seasons_controller.rb
@@ -1,7 +1,8 @@
 class SeasonsController < ApplicationController
   def show
     @season = params[:number].to_i
-    @games_by_series = Game.for_season(@season).ordered.group_by(&:series)
-    @players = Player.with_stats_for_season(@season).ranked
+    result = SeasonOverviewService.call(season: @season)
+    @games_by_series = result.games_by_series
+    @players = result.players
   end
 end

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -2,8 +2,9 @@ class SeriesController < ApplicationController
   def show
     @season = params[:season_number].to_i
     @series = params[:number].to_i
-    @games = Game.for_season(@season).where(series: @series).ordered
-    @ratings_by_player = Rating.where(game: @games).includes(:player).group_by(&:player)
-    @players_sorted = @ratings_by_player.keys.sort_by { |p| [ -@ratings_by_player[p].sum(&:total), p.id ] }
+    result = SeriesAggregationService.call(season: @season, series: @series)
+    @games = result.games
+    @ratings_by_player = result.ratings_by_player
+    @players_sorted = result.players_sorted
   end
 end

--- a/app/services/hall_of_fame_service.rb
+++ b/app/services/hall_of_fame_service.rb
@@ -1,0 +1,14 @@
+class HallOfFameService
+  Result = Data.define(:player_awards, :staff_awards)
+
+  def self.call
+    new.call
+  end
+
+  def call
+    Result.new(
+      player_awards: PlayerAward.includes(:player, :award).where(award: Award.for_players).ordered.load,
+      staff_awards: PlayerAward.includes(:player, :award).where(award: Award.for_staff).ordered.load
+    )
+  end
+end

--- a/app/services/player_profile_service.rb
+++ b/app/services/player_profile_service.rb
@@ -1,0 +1,20 @@
+class PlayerProfileService
+  Result = Data.define(:player, :games_by_season, :player_awards)
+
+  def self.call(player_id:)
+    new(player_id).call
+  end
+
+  def initialize(player_id)
+    @player_id = player_id
+  end
+
+  def call
+    player = Player.find(@player_id)
+    Result.new(
+      player: player,
+      games_by_season: player.games.ordered.group_by(&:season),
+      player_awards: player.player_awards.ordered.includes(:award).load
+    )
+  end
+end

--- a/app/services/season_overview_service.rb
+++ b/app/services/season_overview_service.rb
@@ -1,0 +1,18 @@
+class SeasonOverviewService
+  Result = Data.define(:games_by_series, :players)
+
+  def self.call(season:)
+    new(season).call
+  end
+
+  def initialize(season)
+    @season = season
+  end
+
+  def call
+    Result.new(
+      games_by_series: Game.for_season(@season).ordered.group_by(&:series),
+      players: Player.with_stats_for_season(@season).ranked
+    )
+  end
+end

--- a/app/services/series_aggregation_service.rb
+++ b/app/services/series_aggregation_service.rb
@@ -1,0 +1,20 @@
+class SeriesAggregationService
+  Result = Data.define(:games, :ratings_by_player, :players_sorted)
+
+  def self.call(season:, series:)
+    new(season, series).call
+  end
+
+  def initialize(season, series)
+    @season = season
+    @series = series
+  end
+
+  def call
+    games = Game.for_season(@season).where(series: @series).ordered
+    ratings_by_player = Rating.where(game: games).includes(:player).group_by(&:player)
+    players_sorted = ratings_by_player.keys.sort_by { |p| [ -ratings_by_player[p].sum(&:total), p.id ] }
+
+    Result.new(games:, ratings_by_player:, players_sorted:)
+  end
+end

--- a/spec/services/hall_of_fame_service_spec.rb
+++ b/spec/services/hall_of_fame_service_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+RSpec.describe HallOfFameService do
+  describe ".call" do
+    let!(:player1) { create(:player, name: "Алексей") }
+    let!(:player2) { create(:player, name: "Борис") }
+    let!(:organizer1) { create(:player, name: "Ведущий") }
+    let!(:organizer2) { create(:player, name: "Главный") }
+    let!(:player_award_type) { create(:award, title: "Лучший игрок", staff: false) }
+    let!(:staff_award_type) { create(:award, title: "Лучший ведущий", staff: true) }
+    let!(:player_award2) { create(:player_award, player: player2, award: player_award_type, season: 5, position: 2) }
+    let!(:player_award1) { create(:player_award, player: player1, award: player_award_type, season: 4, position: 1) }
+    let!(:staff_award2) { create(:player_award, player: organizer2, award: staff_award_type, season: 5, position: 2) }
+    let!(:staff_award1) { create(:player_award, player: organizer1, award: staff_award_type, season: 4, position: 1) }
+    let(:result) { described_class.call }
+
+    it "returns a Result" do
+      expect(result).to be_a(described_class::Result)
+    end
+
+    it "returns player awards ordered by position" do
+      expect(result.player_awards).to eq([ player_award1, player_award2 ])
+    end
+
+    it "returns staff awards ordered by position" do
+      expect(result.staff_awards).to eq([ staff_award1, staff_award2 ])
+    end
+
+    it "does not include staff awards in player awards" do
+      expect(result.player_awards).not_to include(staff_award1)
+    end
+
+    it "does not include player awards in staff awards" do
+      expect(result.staff_awards).not_to include(player_award1)
+    end
+
+    it "eager loads player association on player awards" do
+      expect(result.player_awards.first.association(:player)).to be_loaded
+    end
+
+    it "eager loads award association on player awards" do
+      expect(result.player_awards.first.association(:award)).to be_loaded
+    end
+
+    it "eager loads player association on staff awards" do
+      expect(result.staff_awards.first.association(:player)).to be_loaded
+    end
+
+    it "eager loads award association on staff awards" do
+      expect(result.staff_awards.first.association(:award)).to be_loaded
+    end
+
+    it "returns a loaded relation for player_awards" do
+      expect(result.player_awards).to be_loaded
+    end
+
+    it "returns a loaded relation for staff_awards" do
+      expect(result.staff_awards).to be_loaded
+    end
+
+    context "when no awards exist" do
+      let(:empty_result) { described_class.call }
+
+      before do
+        PlayerAward.destroy_all
+      end
+
+      it "returns empty player_awards" do
+        expect(empty_result.player_awards).to be_empty
+      end
+
+      it "returns empty staff_awards" do
+        expect(empty_result.staff_awards).to be_empty
+      end
+    end
+  end
+end

--- a/spec/services/player_profile_service_spec.rb
+++ b/spec/services/player_profile_service_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe PlayerProfileService do
+  describe ".call" do
+    let!(:player) { create(:player, name: "Алексей") }
+    let!(:game2) { create(:game, season: 5, series: 1, game_number: 2) }
+    let!(:game1) { create(:game, season: 5, series: 1, game_number: 1) }
+    let!(:game3) { create(:game, season: 6, series: 1, game_number: 1) }
+    let!(:rating2) { create(:rating, game: game2, player: player) }
+    let!(:rating1) { create(:rating, game: game1, player: player) }
+    let!(:rating3) { create(:rating, game: game3, player: player) }
+    let!(:award1) { create(:award, title: "Лучший игрок") }
+    let!(:award2) { create(:award, title: "Лучший стратег") }
+    let!(:player_award1) { create(:player_award, player: player, award: award1, season: 5, position: 2) }
+    let!(:player_award2) { create(:player_award, player: player, award: award2, season: 5, position: 1) }
+    let(:result) { described_class.call(player_id: player.id) }
+
+    it "returns a Result" do
+      expect(result).to be_a(described_class::Result)
+    end
+
+    it "returns the player" do
+      expect(result.player).to eq(player)
+    end
+
+    it "groups games by season" do
+      expect(result.games_by_season.keys).to contain_exactly(5, 6)
+    end
+
+    it "orders games within each season" do
+      expect(result.games_by_season[5]).to eq([ game1, game2 ])
+    end
+
+    it "returns player awards ordered by position" do
+      expect(result.player_awards).to eq([ player_award2, player_award1 ])
+    end
+
+    it "eager loads award association" do
+      expect(result.player_awards.first.association(:award)).to be_loaded
+    end
+
+    it "returns a loaded relation for player_awards" do
+      expect(result.player_awards).to be_loaded
+    end
+
+    context "when player has no games or awards" do
+      let!(:lonely_player) { create(:player, name: "Одинокий") }
+      let(:lonely_result) { described_class.call(player_id: lonely_player.id) }
+
+      it "returns empty games_by_season" do
+        expect(lonely_result.games_by_season).to be_empty
+      end
+
+      it "returns empty player_awards" do
+        expect(lonely_result.player_awards).to be_empty
+      end
+    end
+
+    context "when player does not exist" do
+      it "raises ActiveRecord::RecordNotFound" do
+        expect { described_class.call(player_id: -1) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/spec/services/season_overview_service_spec.rb
+++ b/spec/services/season_overview_service_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe SeasonOverviewService do
+  describe ".call" do
+    let!(:game2) { create(:game, season: 5, series: 1, game_number: 2) }
+    let!(:game1) { create(:game, season: 5, series: 1, game_number: 1) }
+    let!(:game3) { create(:game, season: 5, series: 2, game_number: 1) }
+    let!(:other_season_game) { create(:game, season: 6, series: 1, game_number: 1) }
+    let!(:player2) { create(:player, name: "Борис") }
+    let!(:player1) { create(:player, name: "Алексей") }
+    let!(:rating1) { create(:rating, game: game1, player: player1, plus: 3.0, minus: 0.5, win: true) }
+    let!(:rating2) { create(:rating, game: game1, player: player2, plus: 1.0, minus: 1.5, win: false) }
+    let(:result) { described_class.call(season: 5) }
+
+    it "returns a Result" do
+      expect(result).to be_a(described_class::Result)
+    end
+
+    it "groups games by series" do
+      expect(result.games_by_series.keys).to contain_exactly(1, 2)
+    end
+
+    it "orders games within each series" do
+      expect(result.games_by_series[1]).to eq([ game1, game2 ])
+    end
+
+    it "excludes games from other seasons" do
+      all_games = result.games_by_series.values.flatten
+      expect(all_games).not_to include(other_season_game)
+    end
+
+    it "returns players ranked by total rating descending" do
+      expect(result.players).to eq([ player1, player2 ])
+    end
+
+    it "computes games_count for players" do
+      player = result.players.find { |p| p.id == player1.id }
+      expect(player.games_count).to eq(1)
+    end
+
+    it "computes wins_count for players" do
+      player = result.players.find { |p| p.id == player1.id }
+      expect(player.wins_count).to eq(1)
+    end
+
+    it "computes total_rating for players" do
+      player = result.players.find { |p| p.id == player1.id }
+      expect(player.total_rating).to eq(2.5)
+    end
+
+    context "when season has no games" do
+      let(:empty_result) { described_class.call(season: 99) }
+
+      it "returns empty games_by_series" do
+        expect(empty_result.games_by_series).to be_empty
+      end
+
+      it "returns empty players" do
+        expect(empty_result.players).to be_empty
+      end
+    end
+  end
+end

--- a/spec/services/series_aggregation_service_spec.rb
+++ b/spec/services/series_aggregation_service_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe SeriesAggregationService do
+  describe ".call" do
+    let!(:game2) { create(:game, season: 5, series: 1, game_number: 2) }
+    let!(:game1) { create(:game, season: 5, series: 1, game_number: 1) }
+    let!(:other_series_game) { create(:game, season: 5, series: 2, game_number: 1) }
+    let!(:other_season_game) { create(:game, season: 6, series: 1, game_number: 1) }
+    let!(:player1) { create(:player, name: "Алексей") }
+    let!(:player2) { create(:player, name: "Борис") }
+    let!(:rating1) { create(:rating, game: game1, player: player1, plus: 3.0, minus: 0.5) }
+    let!(:rating2) { create(:rating, game: game1, player: player2, plus: 1.0, minus: 1.5) }
+    let!(:rating3) { create(:rating, game: game2, player: player1, plus: 2.0, minus: 1.0) }
+    let!(:rating4) { create(:rating, game: game2, player: player2, plus: 5.0, minus: 0.0) }
+    let!(:other_season_rating) { create(:rating, game: other_season_game, player: player1, plus: 10.0, minus: 0.0) }
+    let(:result) { described_class.call(season: 5, series: 1) }
+
+    it "returns a Result" do
+      expect(result).to be_a(described_class::Result)
+    end
+
+    it "returns games ordered by game_number" do
+      expect(result.games).to eq([ game1, game2 ])
+    end
+
+    it "excludes games from other series" do
+      expect(result.games).not_to include(other_series_game)
+    end
+
+    it "excludes games from other seasons" do
+      expect(result.games).not_to include(other_season_game)
+    end
+
+    it "groups ratings by player" do
+      expect(result.ratings_by_player.keys).to contain_exactly(player1, player2)
+    end
+
+    it "includes all ratings for each player" do
+      expect(result.ratings_by_player[player1]).to contain_exactly(rating1, rating3)
+      expect(result.ratings_by_player[player2]).to contain_exactly(rating2, rating4)
+    end
+
+    it "eager loads player association on ratings" do
+      first_rating = result.ratings_by_player.values.first.first
+      expect(first_rating.association(:player)).to be_loaded
+    end
+
+    it "sorts players by total rating descending" do
+      # player2 total: (1.0 - 1.5) + (5.0 - 0.0) = 4.5
+      # player1 total: (3.0 - 0.5) + (2.0 - 1.0) = 3.5
+      expect(result.players_sorted).to eq([ player2, player1 ])
+    end
+
+    context "when players have equal totals" do
+      let!(:rating1) { create(:rating, game: game1, player: player2, plus: 2.0, minus: 0.0) }
+      let!(:rating2) { create(:rating, game: game1, player: player1, plus: 0.0, minus: 0.0) }
+      let!(:rating3) { create(:rating, game: game2, player: player2, plus: 0.0, minus: 0.0) }
+      let!(:rating4) { create(:rating, game: game2, player: player1, plus: 2.0, minus: 0.0) }
+      let!(:other_season_rating) { create(:rating, game: other_season_game, player: player1) }
+
+      it "breaks ties by player id ascending" do
+        expect(result.players_sorted).to eq([ player1, player2 ])
+      end
+    end
+
+    context "when series has no games" do
+      let(:empty_result) { described_class.call(season: 99, series: 99) }
+
+      it "returns empty games" do
+        expect(empty_result.games).to be_empty
+      end
+
+      it "returns empty ratings_by_player" do
+        expect(empty_result.ratings_by_player).to be_empty
+      end
+
+      it "returns empty players_sorted" do
+        expect(empty_result.players_sorted).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Extract inline controller queries into 4 service objects: `SeasonOverviewService`, `PlayerProfileService`, `SeriesAggregationService`, `HallOfFameService`
- Each service uses a `Data.define` result value object and a `.call` class method
- Controllers delegate to services and unpack results into ivars — no view changes needed
- `GamesController` left as-is (simple `find` + `includes`)

## Test plan
- [x] `bundle exec rspec spec/services/` — 45 service specs pass
- [x] `bundle exec rspec spec/requests/` — 30 request specs pass (no regressions)
- [x] `bundle exec rspec spec/acceptance/` — 22 acceptance tests pass
- [x] `bundle exec rubocop` — 0 offenses on all changed files
- [x] `bundle exec mutant run` — 100% on 3 services, 93.8% on SeriesAggregationService (remaining are unkillable: `includes` perf optimization, `[]`/`fetch` semantic equivalent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)