### PR TITLE
Add test-prof gem and use let_it_be in specs (#40)

### DIFF
--- a/.claude-on-rails/context.md
+++ b/.claude-on-rails/context.md
@@ -28,8 +28,9 @@ When working on this project:
 
 ### RSpec Style
 
-Write specs using `let`/`let!` declarations and nested `context` blocks:
-- Declare all test data with `let`/`let!` at the top of the describe/context block
+Write specs using `let_it_be`/`let`/`let!` declarations and nested `context` blocks:
+- Prefer `let_it_be` (from test-prof) over `let!` for test data that does not need to be recreated per example — this creates records once per describe/context group
+- Use `let!` only when records are redefined in nested contexts or mutated by examples
 - Use `context` blocks to group scenarios (e.g., `context "when games_count is zero"`)
 - Do **not** declare variables inside `it` blocks — use `let` instead
 - Keep `it` blocks focused on expectations only

--- a/Gemfile
+++ b/Gemfile
@@ -75,4 +75,5 @@ group :test do
   gem "simplecov", require: false
   gem "database_cleaner-active_record"
   gem "mutant-rspec"
+  gem "test-prof"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -510,6 +510,7 @@ GEM
     tailwindcss-ruby (4.1.18-aarch64-linux-musl)
     tailwindcss-ruby (4.1.18-x86_64-linux-gnu)
     tailwindcss-ruby (4.1.18-x86_64-linux-musl)
+    test-prof (1.5.2)
     thor (1.5.0)
     thruster (0.1.18)
     thruster (0.1.18-aarch64-linux)
@@ -588,6 +589,7 @@ DEPENDENCIES
   sqlite3 (>= 2.1)
   stimulus-rails
   tailwindcss-rails
+  test-prof
   thruster
   turbo-rails
   tzinfo-data
@@ -778,6 +780,7 @@ CHECKSUMS
   tailwindcss-ruby (4.1.18-aarch64-linux-musl) sha256=3c8426674718a2c98a0649c825ac0b3286ff52acd0b4052d7d19126cd74904f3
   tailwindcss-ruby (4.1.18-x86_64-linux-gnu) sha256=e0a2220163246fe0126c5c5bafb95bc6206e7d21fce2a2878fd9c9a359137534
   tailwindcss-ruby (4.1.18-x86_64-linux-musl) sha256=d957cf545b09d2db7eb6267450cc1fc589e126524066537a0c4d5b99d701f4b2
+  test-prof (1.5.2) sha256=185839fb7d3745b3770ec48e3e5718eff9e28c327a50a1e18a3a9ef1060f8576
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   thruster (0.1.18) sha256=f025103bc7c8e6747436bb9de058c366840d2871560574ea7070a9bc8608a889
   thruster (0.1.18-aarch64-linux) sha256=16f3d49468d76a9a5de86b7bdedf535b7b80da7c16495ca8ec96cfdc256870e2

--- a/spec/acceptance/game_details_spec.rb
+++ b/spec/acceptance/game_details_spec.rb
@@ -1,18 +1,18 @@
 require "rails_helper"
 
 RSpec.describe "Game details" do
-  let!(:role) { create(:role, code: "peace", name: "Мирный") }
-  let!(:game) do
+  let_it_be(:role) { create(:role, code: "peace", name: "Мирный") }
+  let_it_be(:game) do
     create(:game, season: 5, series: 1, game_number: 1,
            played_on: Date.new(2025, 1, 10), name: "Финал")
   end
-  let!(:player1) { create(:player, name: "Алексей") }
-  let!(:player2) { create(:player, name: "Борис") }
-  let!(:rating1) do
+  let_it_be(:player1) { create(:player, name: "Алексей") }
+  let_it_be(:player2) { create(:player, name: "Борис") }
+  let_it_be(:rating1) do
     create(:rating, game: game, player: player1, role_code: "peace",
            plus: 3.0, minus: 0.5, best_move: 0.5, win: true)
   end
-  let!(:rating2) do
+  let_it_be(:rating2) do
     create(:rating, game: game, player: player2, role_code: "peace",
            plus: 1.0, minus: 1.5, best_move: nil, win: false)
   end

--- a/spec/acceptance/hall_of_fame_spec.rb
+++ b/spec/acceptance/hall_of_fame_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "Hall of Fame" do
-  let!(:player) { create(:player, name: "Алексей") }
-  let!(:organizer) { create(:player, name: "Ведущий") }
-  let!(:award) { create(:award, title: "Лучший игрок", staff: false) }
-  let!(:staff_award) { create(:award, title: "Лучший ведущий", staff: true) }
+  let_it_be(:player) { create(:player, name: "Алексей") }
+  let_it_be(:organizer) { create(:player, name: "Ведущий") }
+  let_it_be(:award) { create(:award, title: "Лучший игрок", staff: false) }
+  let_it_be(:staff_award) { create(:award, title: "Лучший ведущий", staff: true) }
 
   before do
     create(:player_award, player: player, award: award, season: 5)

--- a/spec/acceptance/player_profile_spec.rb
+++ b/spec/acceptance/player_profile_spec.rb
@@ -1,14 +1,14 @@
 require "rails_helper"
 
 RSpec.describe "Player profile" do
-  let!(:player) { create(:player, name: "Алексей") }
-  let!(:game) do
+  let_it_be(:player) { create(:player, name: "Алексей") }
+  let_it_be(:game) do
     create(:game, season: 5, series: 1, game_number: 1,
            played_on: Date.new(2025, 1, 10))
   end
-  let!(:rating) { create(:rating, game: game, player: player, plus: 3.0, minus: 0.5, win: true) }
-  let!(:award) { create(:award, title: "Лучший игрок", staff: false) }
-  let!(:player_award) { create(:player_award, player: player, award: award, season: 5) }
+  let_it_be(:rating) { create(:rating, game: game, player: player, plus: 3.0, minus: 0.5, win: true) }
+  let_it_be(:award) { create(:award, title: "Лучший игрок", staff: false) }
+  let_it_be(:player_award) { create(:player_award, player: player, award: award, season: 5) }
 
   before { visit player_path(player) }
 

--- a/spec/acceptance/season_overview_spec.rb
+++ b/spec/acceptance/season_overview_spec.rb
@@ -1,12 +1,12 @@
 require "rails_helper"
 
 RSpec.describe "Season overview" do
-  let!(:game1) { create(:game, season: 5, series: 1, game_number: 1, played_on: Date.new(2025, 1, 10)) }
-  let!(:game2) { create(:game, season: 5, series: 1, game_number: 2, played_on: Date.new(2025, 1, 17)) }
-  let!(:game3) { create(:game, season: 5, series: 2, game_number: 1, played_on: Date.new(2025, 2, 7)) }
+  let_it_be(:game1) { create(:game, season: 5, series: 1, game_number: 1, played_on: Date.new(2025, 1, 10)) }
+  let_it_be(:game2) { create(:game, season: 5, series: 1, game_number: 2, played_on: Date.new(2025, 1, 17)) }
+  let_it_be(:game3) { create(:game, season: 5, series: 2, game_number: 1, played_on: Date.new(2025, 2, 7)) }
 
-  let!(:player1) { create(:player, name: "Алексей") }
-  let!(:player2) { create(:player, name: "Борис") }
+  let_it_be(:player1) { create(:player, name: "Алексей") }
+  let_it_be(:player2) { create(:player, name: "Борис") }
 
   before do
     create(:rating, game: game1, player: player1, plus: 3.0, minus: 0.5, win: true)

--- a/spec/acceptance/series_totals_spec.rb
+++ b/spec/acceptance/series_totals_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "Series totals" do
-  let!(:game1) { create(:game, season: 5, series: 1, game_number: 1) }
-  let!(:game2) { create(:game, season: 5, series: 1, game_number: 2) }
-  let!(:player1) { create(:player, name: "Алексей") }
-  let!(:player2) { create(:player, name: "Борис") }
+  let_it_be(:game1) { create(:game, season: 5, series: 1, game_number: 1) }
+  let_it_be(:game2) { create(:game, season: 5, series: 1, game_number: 2) }
+  let_it_be(:player1) { create(:player, name: "Алексей") }
+  let_it_be(:player2) { create(:player, name: "Борис") }
 
   before do
     create(:rating, game: game1, player: player1, plus: 3.0, minus: 0.5)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ require_relative '../config/environment'
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 require 'shoulda-matchers'
+require 'test_prof/recipes/rspec/let_it_be'
 
 Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
 

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -2,11 +2,11 @@ require "rails_helper"
 
 RSpec.describe GamesController do
   describe "GET /games/:id" do
-    let!(:game) { create(:game, season: 1, series: 1, game_number: 1) }
+    let_it_be(:game) { create(:game, season: 1, series: 1, game_number: 1) }
 
     context "when game exists" do
-      let!(:role) { create(:role, code: "peace", name: "Мирный") }
-      let!(:rating) { create(:rating, game: game, role_code: "peace", plus: 2.0, minus: 0.5) }
+      let_it_be(:role) { create(:role, code: "peace", name: "Мирный") }
+      let_it_be(:rating) { create(:rating, game: game, role_code: "peace", plus: 2.0, minus: 0.5) }
 
       before { get game_path(game) }
 

--- a/spec/requests/hall_of_fame_spec.rb
+++ b/spec/requests/hall_of_fame_spec.rb
@@ -3,12 +3,12 @@ require "rails_helper"
 RSpec.describe HallOfFameController do
   describe "GET /hall" do
     context "when awards exist" do
-      let!(:player) { create(:player, name: "Алексей") }
-      let!(:organizer) { create(:player, name: "Ведущий") }
-      let!(:award) { create(:award, title: "Лучший игрок", staff: false) }
-      let!(:staff_award) { create(:award, title: "Лучший ведущий", staff: true) }
-      let!(:player_award) { create(:player_award, player: player, award: award, season: 5) }
-      let!(:staff_player_award) { create(:player_award, player: organizer, award: staff_award, season: 5) }
+      let_it_be(:player) { create(:player, name: "Алексей") }
+      let_it_be(:organizer) { create(:player, name: "Ведущий") }
+      let_it_be(:award) { create(:award, title: "Лучший игрок", staff: false) }
+      let_it_be(:staff_award) { create(:award, title: "Лучший ведущий", staff: true) }
+      let_it_be(:player_award) { create(:player_award, player: player, award: award, season: 5) }
+      let_it_be(:staff_player_award) { create(:player_award, player: organizer, award: staff_award, season: 5) }
 
       before { get hall_path }
 

--- a/spec/requests/players_spec.rb
+++ b/spec/requests/players_spec.rb
@@ -3,11 +3,11 @@ require "rails_helper"
 RSpec.describe PlayersController do
   describe "GET /players/:id" do
     context "when player exists" do
-      let!(:player) { create(:player, name: "Алексей") }
-      let!(:game) { create(:game, season: 5, series: 1, game_number: 1) }
-      let!(:rating) { create(:rating, game: game, player: player) }
-      let!(:award) { create(:award, title: "Лучший игрок") }
-      let!(:player_award) { create(:player_award, player: player, award: award, season: 5) }
+      let_it_be(:player) { create(:player, name: "Алексей") }
+      let_it_be(:game) { create(:game, season: 5, series: 1, game_number: 1) }
+      let_it_be(:rating) { create(:rating, game: game, player: player) }
+      let_it_be(:award) { create(:award, title: "Лучший игрок") }
+      let_it_be(:player_award) { create(:player_award, player: player, award: award, season: 5) }
 
       before { get player_path(player) }
 

--- a/spec/requests/seasons_spec.rb
+++ b/spec/requests/seasons_spec.rb
@@ -3,13 +3,13 @@ require "rails_helper"
 RSpec.describe SeasonsController do
   describe "GET /seasons/:number" do
     context "when season has games and players" do
-      let!(:game1) { create(:game, season: 5, series: 1, game_number: 1) }
-      let!(:game2) { create(:game, season: 5, series: 2, game_number: 1) }
-      let!(:player1) { create(:player, name: "Алексей") }
-      let!(:player2) { create(:player, name: "Борис") }
-      let!(:rating1) { create(:rating, game: game1, player: player1, plus: 3.0, minus: 0.5, win: true) }
-      let!(:rating2) { create(:rating, game: game1, player: player2, plus: 1.0, minus: 1.5, win: false) }
-      let!(:rating3) { create(:rating, game: game2, player: player2, plus: 4.0, minus: 0.0, win: true) }
+      let_it_be(:game1) { create(:game, season: 5, series: 1, game_number: 1) }
+      let_it_be(:game2) { create(:game, season: 5, series: 2, game_number: 1) }
+      let_it_be(:player1) { create(:player, name: "Алексей") }
+      let_it_be(:player2) { create(:player, name: "Борис") }
+      let_it_be(:rating1) { create(:rating, game: game1, player: player1, plus: 3.0, minus: 0.5, win: true) }
+      let_it_be(:rating2) { create(:rating, game: game1, player: player2, plus: 1.0, minus: 1.5, win: false) }
+      let_it_be(:rating3) { create(:rating, game: game2, player: player2, plus: 4.0, minus: 0.0, win: true) }
 
       before { get season_path(number: 5) }
 

--- a/spec/requests/series_spec.rb
+++ b/spec/requests/series_spec.rb
@@ -3,14 +3,14 @@ require "rails_helper"
 RSpec.describe SeriesController do
   describe "GET /seasons/:season_number/series/:number" do
     context "when series has games" do
-      let!(:game1) { create(:game, season: 5, series: 1, game_number: 1) }
-      let!(:game2) { create(:game, season: 5, series: 1, game_number: 2) }
-      let!(:player1) { create(:player, name: "Алексей") }
-      let!(:player2) { create(:player, name: "Борис") }
-      let!(:rating1) { create(:rating, game: game1, player: player1, plus: 3.0, minus: 0.5) }
-      let!(:rating2) { create(:rating, game: game1, player: player2, plus: 1.0, minus: 1.5) }
-      let!(:rating3) { create(:rating, game: game2, player: player1, plus: 2.0, minus: 1.0) }
-      let!(:rating4) { create(:rating, game: game2, player: player2, plus: 5.0, minus: 0.0) }
+      let_it_be(:game1) { create(:game, season: 5, series: 1, game_number: 1) }
+      let_it_be(:game2) { create(:game, season: 5, series: 1, game_number: 2) }
+      let_it_be(:player1) { create(:player, name: "Алексей") }
+      let_it_be(:player2) { create(:player, name: "Борис") }
+      let_it_be(:rating1) { create(:rating, game: game1, player: player1, plus: 3.0, minus: 0.5) }
+      let_it_be(:rating2) { create(:rating, game: game1, player: player2, plus: 1.0, minus: 1.5) }
+      let_it_be(:rating3) { create(:rating, game: game2, player: player1, plus: 2.0, minus: 1.0) }
+      let_it_be(:rating4) { create(:rating, game: game2, player: player2, plus: 5.0, minus: 0.0) }
 
       before { get season_series_path(season_number: 5, number: 1) }
 

--- a/spec/services/hall_of_fame_service_spec.rb
+++ b/spec/services/hall_of_fame_service_spec.rb
@@ -2,16 +2,16 @@ require "rails_helper"
 
 RSpec.describe HallOfFameService do
   describe ".call" do
-    let!(:player1) { create(:player, name: "Алексей") }
-    let!(:player2) { create(:player, name: "Борис") }
-    let!(:organizer1) { create(:player, name: "Ведущий") }
-    let!(:organizer2) { create(:player, name: "Главный") }
-    let!(:player_award_type) { create(:award, title: "Лучший игрок", staff: false) }
-    let!(:staff_award_type) { create(:award, title: "Лучший ведущий", staff: true) }
-    let!(:player_award2) { create(:player_award, player: player2, award: player_award_type, season: 5, position: 2) }
-    let!(:player_award1) { create(:player_award, player: player1, award: player_award_type, season: 4, position: 1) }
-    let!(:staff_award2) { create(:player_award, player: organizer2, award: staff_award_type, season: 5, position: 2) }
-    let!(:staff_award1) { create(:player_award, player: organizer1, award: staff_award_type, season: 4, position: 1) }
+    let_it_be(:player1) { create(:player, name: "Алексей") }
+    let_it_be(:player2) { create(:player, name: "Борис") }
+    let_it_be(:organizer1) { create(:player, name: "Ведущий") }
+    let_it_be(:organizer2) { create(:player, name: "Главный") }
+    let_it_be(:player_award_type) { create(:award, title: "Лучший игрок", staff: false) }
+    let_it_be(:staff_award_type) { create(:award, title: "Лучший ведущий", staff: true) }
+    let_it_be(:player_award2) { create(:player_award, player: player2, award: player_award_type, season: 5, position: 2) }
+    let_it_be(:player_award1) { create(:player_award, player: player1, award: player_award_type, season: 4, position: 1) }
+    let_it_be(:staff_award2) { create(:player_award, player: organizer2, award: staff_award_type, season: 5, position: 2) }
+    let_it_be(:staff_award1) { create(:player_award, player: organizer1, award: staff_award_type, season: 4, position: 1) }
     let(:result) { described_class.call }
 
     it "returns a Result" do

--- a/spec/services/player_profile_service_spec.rb
+++ b/spec/services/player_profile_service_spec.rb
@@ -2,17 +2,17 @@ require "rails_helper"
 
 RSpec.describe PlayerProfileService do
   describe ".call" do
-    let!(:player) { create(:player, name: "Алексей") }
-    let!(:game2) { create(:game, season: 5, series: 1, game_number: 2) }
-    let!(:game1) { create(:game, season: 5, series: 1, game_number: 1) }
-    let!(:game3) { create(:game, season: 6, series: 1, game_number: 1) }
-    let!(:rating2) { create(:rating, game: game2, player: player) }
-    let!(:rating1) { create(:rating, game: game1, player: player) }
-    let!(:rating3) { create(:rating, game: game3, player: player) }
-    let!(:award1) { create(:award, title: "Лучший игрок") }
-    let!(:award2) { create(:award, title: "Лучший стратег") }
-    let!(:player_award1) { create(:player_award, player: player, award: award1, season: 5, position: 2) }
-    let!(:player_award2) { create(:player_award, player: player, award: award2, season: 5, position: 1) }
+    let_it_be(:player) { create(:player, name: "Алексей") }
+    let_it_be(:game2) { create(:game, season: 5, series: 1, game_number: 2) }
+    let_it_be(:game1) { create(:game, season: 5, series: 1, game_number: 1) }
+    let_it_be(:game3) { create(:game, season: 6, series: 1, game_number: 1) }
+    let_it_be(:rating2) { create(:rating, game: game2, player: player) }
+    let_it_be(:rating1) { create(:rating, game: game1, player: player) }
+    let_it_be(:rating3) { create(:rating, game: game3, player: player) }
+    let_it_be(:award1) { create(:award, title: "Лучший игрок") }
+    let_it_be(:award2) { create(:award, title: "Лучший стратег") }
+    let_it_be(:player_award1) { create(:player_award, player: player, award: award1, season: 5, position: 2) }
+    let_it_be(:player_award2) { create(:player_award, player: player, award: award2, season: 5, position: 1) }
     let(:result) { described_class.call(player_id: player.id) }
 
     it "returns a Result" do
@@ -44,7 +44,7 @@ RSpec.describe PlayerProfileService do
     end
 
     context "when player has no games or awards" do
-      let!(:lonely_player) { create(:player, name: "Одинокий") }
+      let_it_be(:lonely_player) { create(:player, name: "Одинокий") }
       let(:lonely_result) { described_class.call(player_id: lonely_player.id) }
 
       it "returns empty games_by_season" do

--- a/spec/services/season_overview_service_spec.rb
+++ b/spec/services/season_overview_service_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 RSpec.describe SeasonOverviewService do
   describe ".call" do
-    let!(:game2) { create(:game, season: 5, series: 1, game_number: 2) }
-    let!(:game1) { create(:game, season: 5, series: 1, game_number: 1) }
-    let!(:game3) { create(:game, season: 5, series: 2, game_number: 1) }
-    let!(:other_season_game) { create(:game, season: 6, series: 1, game_number: 1) }
-    let!(:player2) { create(:player, name: "Борис") }
-    let!(:player1) { create(:player, name: "Алексей") }
-    let!(:rating1) { create(:rating, game: game1, player: player1, plus: 3.0, minus: 0.5, win: true) }
-    let!(:rating2) { create(:rating, game: game1, player: player2, plus: 1.0, minus: 1.5, win: false) }
+    let_it_be(:game2) { create(:game, season: 5, series: 1, game_number: 2) }
+    let_it_be(:game1) { create(:game, season: 5, series: 1, game_number: 1) }
+    let_it_be(:game3) { create(:game, season: 5, series: 2, game_number: 1) }
+    let_it_be(:other_season_game) { create(:game, season: 6, series: 1, game_number: 1) }
+    let_it_be(:player2) { create(:player, name: "Борис") }
+    let_it_be(:player1) { create(:player, name: "Алексей") }
+    let_it_be(:rating1) { create(:rating, game: game1, player: player1, plus: 3.0, minus: 0.5, win: true) }
+    let_it_be(:rating2) { create(:rating, game: game1, player: player2, plus: 1.0, minus: 1.5, win: false) }
     let(:result) { described_class.call(season: 5) }
 
     it "returns a Result" do

--- a/spec/services/series_aggregation_service_spec.rb
+++ b/spec/services/series_aggregation_service_spec.rb
@@ -2,12 +2,12 @@ require "rails_helper"
 
 RSpec.describe SeriesAggregationService do
   describe ".call" do
-    let!(:game2) { create(:game, season: 5, series: 1, game_number: 2) }
-    let!(:game1) { create(:game, season: 5, series: 1, game_number: 1) }
-    let!(:other_series_game) { create(:game, season: 5, series: 2, game_number: 1) }
-    let!(:other_season_game) { create(:game, season: 6, series: 1, game_number: 1) }
-    let!(:player1) { create(:player, name: "Алексей") }
-    let!(:player2) { create(:player, name: "Борис") }
+    let_it_be(:game2) { create(:game, season: 5, series: 1, game_number: 2) }
+    let_it_be(:game1) { create(:game, season: 5, series: 1, game_number: 1) }
+    let_it_be(:other_series_game) { create(:game, season: 5, series: 2, game_number: 1) }
+    let_it_be(:other_season_game) { create(:game, season: 6, series: 1, game_number: 1) }
+    let_it_be(:player1) { create(:player, name: "Алексей") }
+    let_it_be(:player2) { create(:player, name: "Борис") }
     let!(:rating1) { create(:rating, game: game1, player: player1, plus: 3.0, minus: 0.5) }
     let!(:rating2) { create(:rating, game: game1, player: player2, plus: 1.0, minus: 1.5) }
     let!(:rating3) { create(:rating, game: game2, player: player1, plus: 2.0, minus: 1.0) }


### PR DESCRIPTION
## Summary
- Add `test-prof` gem and configure `let_it_be` in rails_helper
- Replace `let!` with `let_it_be` across all acceptance, request, and service specs
- Kept `let!` for ratings in `series_aggregation_service_spec` where nested context redefines them
- Update `.claude-on-rails/context.md` RSpec style guide to prefer `let_it_be`

## Test plan
- [x] 159 specs pass, 0 failures
- [x] Rubocop: 0 offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)