### PR TITLE
Refactor specs to use let declarations and context blocks (#39)

### DIFF
--- a/spec/helpers/seasons_helper_spec.rb
+++ b/spec/helpers/seasons_helper_spec.rb
@@ -2,28 +2,36 @@ require 'rails_helper'
 
 RSpec.describe SeasonsHelper, type: :helper do
   describe '#win_percentage' do
-    it 'calculates the percentage of wins' do
-      player = double(games_count: 10, wins_count: 7)
+    context 'when player has wins' do
+      let(:player) { double(games_count: 10, wins_count: 7) }
 
-      expect(helper.win_percentage(player)).to eq(70.0)
+      it 'calculates the percentage of wins' do
+        expect(helper.win_percentage(player)).to eq(70.0)
+      end
     end
 
-    it 'returns 0 when games_count is zero' do
-      player = double(games_count: 0)
+    context 'when games_count is zero' do
+      let(:player) { double(games_count: 0) }
 
-      expect(helper.win_percentage(player)).to eq(0)
+      it 'returns 0' do
+        expect(helper.win_percentage(player)).to eq(0)
+      end
     end
 
-    it 'rounds to one decimal place' do
-      player = double(games_count: 3, wins_count: 1)
+    context 'when result needs rounding' do
+      let(:player) { double(games_count: 3, wins_count: 1) }
 
-      expect(helper.win_percentage(player)).to eq(33.3)
+      it 'rounds to one decimal place' do
+        expect(helper.win_percentage(player)).to eq(33.3)
+      end
     end
 
-    it 'returns 100.0 when all games are wins' do
-      player = double(games_count: 5, wins_count: 5)
+    context 'when all games are wins' do
+      let(:player) { double(games_count: 5, wins_count: 5) }
 
-      expect(helper.win_percentage(player)).to eq(100.0)
+      it 'returns 100.0' do
+        expect(helper.win_percentage(player)).to eq(100.0)
+      end
     end
   end
 end

--- a/spec/models/award_spec.rb
+++ b/spec/models/award_spec.rb
@@ -11,31 +11,31 @@ RSpec.describe Award, type: :model do
   end
 
   describe '.for_players' do
-    it 'returns awards where staff is false' do
-      player_award = create(:award, staff: false)
-      staff_award = create(:award, staff: true)
+    let_it_be(:player_award) { create(:award, staff: false) }
+    let_it_be(:staff_award) { create(:award, staff: true) }
 
+    it 'returns awards where staff is false' do
       expect(described_class.for_players).to include(player_award)
       expect(described_class.for_players).not_to include(staff_award)
     end
   end
 
   describe '.for_staff' do
-    it 'returns awards where staff is true' do
-      player_award = create(:award, staff: false)
-      staff_award = create(:award, staff: true)
+    let_it_be(:player_award) { create(:award, staff: false) }
+    let_it_be(:staff_award) { create(:award, staff: true) }
 
+    it 'returns awards where staff is true' do
       expect(described_class.for_staff).to include(staff_award)
       expect(described_class.for_staff).not_to include(player_award)
     end
   end
 
   describe '.ordered' do
-    it 'orders by position ascending' do
-      third = create(:award, position: 3)
-      first = create(:award, position: 1)
-      second = create(:award, position: 2)
+    let_it_be(:third) { create(:award, position: 3) }
+    let_it_be(:first) { create(:award, position: 1) }
+    let_it_be(:second) { create(:award, position: 2) }
 
+    it 'orders by position ascending' do
       expect(described_class.ordered).to eq([ first, second, third ])
     end
   end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -19,49 +19,55 @@ RSpec.describe Game, type: :model do
   end
 
   describe '.for_season' do
-    it 'returns games for the given season' do
-      game_s1 = create(:game, season: 1)
-      game_s2 = create(:game, season: 2)
+    let_it_be(:game_s1) { create(:game, season: 1) }
+    let_it_be(:game_s2) { create(:game, season: 2) }
 
+    it 'returns games for the given season' do
       expect(described_class.for_season(1)).to include(game_s1)
       expect(described_class.for_season(1)).not_to include(game_s2)
     end
   end
 
   describe '.ordered' do
-    it 'orders by played_on, series, game_number ascending' do
-      third = create(:game, played_on: Date.new(2026, 1, 2), season: 1, series: 1, game_number: 1)
-      first = create(:game, played_on: Date.new(2026, 1, 1), season: 1, series: 1, game_number: 2)
-      second = create(:game, played_on: Date.new(2026, 1, 1), season: 1, series: 2, game_number: 1)
+    let_it_be(:third) { create(:game, played_on: Date.new(2026, 1, 2), season: 1, series: 1, game_number: 1) }
+    let_it_be(:first) { create(:game, played_on: Date.new(2026, 1, 1), season: 1, series: 1, game_number: 2) }
+    let_it_be(:second) { create(:game, played_on: Date.new(2026, 1, 1), season: 1, series: 2, game_number: 1) }
 
+    it 'orders by played_on, series, game_number ascending' do
       expect(described_class.ordered).to eq([ first, second, third ])
     end
   end
 
   describe '#full_name' do
-    it 'includes all parts when all fields are present' do
-      game = build(:game, played_on: Date.new(2026, 1, 15), season: 1, series: 2, game_number: 3, name: "Финал")
+    context 'when all fields are present' do
+      let(:game) { build(:game, played_on: Date.new(2026, 1, 15), season: 1, series: 2, game_number: 3, name: "Финал") }
 
-      expect(game.full_name).to eq("2026-01-15 Сезон 1 Серия 2 Игра 3 Финал")
+      it 'includes all parts' do
+        expect(game.full_name).to eq("2026-01-15 Сезон 1 Серия 2 Игра 3 Финал")
+      end
     end
 
-    it 'omits played_on when nil' do
-      game = build(:game, played_on: nil, season: 1, series: 2, game_number: 3, name: "Финал")
+    context 'when played_on is nil' do
+      let(:game) { build(:game, played_on: nil, season: 1, series: 2, game_number: 3, name: "Финал") }
 
-      expect(game.full_name).to eq("Сезон 1 Серия 2 Игра 3 Финал")
+      it 'omits played_on' do
+        expect(game.full_name).to eq("Сезон 1 Серия 2 Игра 3 Финал")
+      end
     end
 
-    it 'omits name when nil' do
-      game = build(:game, played_on: Date.new(2026, 1, 15), season: 1, series: 2, game_number: 3, name: nil)
+    context 'when name is nil' do
+      let(:game) { build(:game, played_on: Date.new(2026, 1, 15), season: 1, series: 2, game_number: 3, name: nil) }
 
-      expect(game.full_name).to eq("2026-01-15 Сезон 1 Серия 2 Игра 3")
+      it 'omits name' do
+        expect(game.full_name).to eq("2026-01-15 Сезон 1 Серия 2 Игра 3")
+      end
     end
   end
 
   describe '#in_season_name' do
-    it 'returns series and game number' do
-      game = build(:game, series: 3, game_number: 5)
+    let(:game) { build(:game, series: 3, game_number: 5) }
 
+    it 'returns series and game number' do
       expect(game.in_season_name).to eq("Серия 3 Игра 5")
     end
   end

--- a/spec/models/player_award_spec.rb
+++ b/spec/models/player_award_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe PlayerAward, type: :model do
   end
 
   describe '.ordered' do
-    it 'orders by position ascending' do
-      player = create(:player)
-      third = create(:player_award, player: player, position: 3)
-      first = create(:player_award, player: player, position: 1)
-      second = create(:player_award, player: player, position: 2)
+    let_it_be(:player) { create(:player) }
+    let_it_be(:third) { create(:player_award, player: player, position: 3) }
+    let_it_be(:first) { create(:player_award, player: player, position: 1) }
+    let_it_be(:second) { create(:player_award, player: player, position: 2) }
 
+    it 'orders by position ascending' do
       expect(described_class.ordered).to eq([ first, second, third ])
     end
   end

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -17,42 +17,53 @@ RSpec.describe Rating, type: :model do
   end
 
   describe '#total' do
-    it 'returns plus minus minus' do
-      rating = build(:rating, plus: 3, minus: 1)
+    context 'when plus and minus are present' do
+      let(:rating) { build(:rating, plus: 3, minus: 1) }
 
-      expect(rating.total).to eq(2)
+      it 'returns plus minus minus' do
+        expect(rating.total).to eq(2)
+      end
     end
 
-    it 'treats nil plus as zero' do
-      rating = build(:rating, plus: nil, minus: 2)
+    context 'when plus is nil' do
+      let(:rating) { build(:rating, plus: nil, minus: 2) }
 
-      expect(rating.total).to eq(-2)
+      it 'treats nil plus as zero' do
+        expect(rating.total).to eq(-2)
+      end
     end
 
-    it 'treats nil minus as zero' do
-      rating = build(:rating, plus: 5, minus: nil)
+    context 'when minus is nil' do
+      let(:rating) { build(:rating, plus: 5, minus: nil) }
 
-      expect(rating.total).to eq(5)
+      it 'treats nil minus as zero' do
+        expect(rating.total).to eq(5)
+      end
     end
 
-    it 'returns zero when both are nil' do
-      rating = build(:rating, plus: nil, minus: nil)
+    context 'when both are nil' do
+      let(:rating) { build(:rating, plus: nil, minus: nil) }
 
-      expect(rating.total).to eq(0)
+      it 'returns zero' do
+        expect(rating.total).to eq(0)
+      end
     end
 
-    it 'includes extra_points in the total' do
-      rating = build(:rating, plus: 3, minus: 1)
-      allow(rating).to receive(:extra_points).and_return(2)
+    context 'when extra_points is non-zero' do
+      let(:rating) { build(:rating, plus: 3, minus: 1) }
 
-      expect(rating.total).to eq(4)
+      before { allow(rating).to receive(:extra_points).and_return(2) }
+
+      it 'includes extra_points in the total' do
+        expect(rating.total).to eq(4)
+      end
     end
   end
 
   describe '#extra_points' do
-    it 'returns zero' do
-      rating = build(:rating)
+    let(:rating) { build(:rating) }
 
+    it 'returns zero' do
       expect(rating.extra_points).to eq(0)
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,16 +10,20 @@ RSpec.describe User, type: :model do
   end
 
   describe '#admin?' do
-    it 'returns true when admin is true' do
-      user = build(:user, admin: true)
+    context 'when admin is true' do
+      let(:user) { build(:user, admin: true) }
 
-      expect(user.admin?).to be true
+      it 'returns true' do
+        expect(user.admin?).to be true
+      end
     end
 
-    it 'returns false when admin is false' do
-      user = build(:user, admin: false)
+    context 'when admin is false' do
+      let(:user) { build(:user, admin: false) }
 
-      expect(user.admin?).to be false
+      it 'returns false' do
+        expect(user.admin?).to be false
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- Extract inline variable declarations from `it` blocks into `let`/`let_it_be` at describe/context level across all model and helper specs
- Add `context` blocks for different scenarios: `game#full_name` (all fields, nil played_on, nil name), `rating#total` (present/nil/both nil/extra_points), `user#admin?` (true/false), `player.ranked` (different stats/equal totals), `player.with_stats_for_season` (single season/multi season/nil values), `win_percentage` (normal/zero/rounding/100%)
- Use `let_it_be` for DB records (`create`), `let` for in-memory objects (`build`/`double`)

## Test plan
- [x] 159 specs pass, 0 failures
- [x] Rubocop: 0 offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)