### PR TITLE
Enhance Award Avo resource for admin CRUD

### DIFF
--- a/app/avo/resources/award.rb
+++ b/app/avo/resources/award.rb
@@ -1,11 +1,18 @@
 class Avo::Resources::Award < Avo::BaseResource
+  self.title = :title
+  self.default_view_type = :table
+
+  self.search = {
+    query: -> { query.where("title ILIKE ?", "%#{params[:q]}%") }
+  }
+
   def fields
     field :id, as: :id
-    field :title, as: :text
+    field :title, as: :text, required: true, sortable: true
     field :description, as: :textarea
-    field :staff, as: :boolean
-    field :position, as: :number
-    field :icon, as: :file
+    field :staff, as: :boolean, sortable: true
+    field :position, as: :number, sortable: true
+    field :icon, as: :file, is_image: true
     field :player_awards, as: :has_many
   end
 end


### PR DESCRIPTION
## Summary
- Add `self.title = :title` to Award resource for readable record display
- Add search by title (case-insensitive)
- Mark title as required, add sorting to title/staff/position
- Enable image preview for icon field with `is_image: true`

## Test plan
- [x] `bundle exec rubocop` — 0 offenses
- [x] `bundle exec rspec` — 162 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)