### PR TITLE
Add request specs for admin resource endpoints

### DIFF
--- a/spec/requests/avo_resources_spec.rb
+++ b/spec/requests/avo_resources_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Avo admin resources" do
+  let_it_be(:admin) { create(:user, admin: true) }
+  let_it_be(:non_admin) { create(:user, admin: false) }
+  let_it_be(:player) { create(:player) }
+  let_it_be(:game) { create(:game) }
+  let_it_be(:role) { create(:role) }
+  let_it_be(:award) { create(:award) }
+  let_it_be(:rating) { create(:rating, game: game, player: player) }
+  let_it_be(:player_award) { create(:player_award, player: player, award: award) }
+
+  shared_examples "admin-only endpoint" do
+    context "when not signed in" do
+      it "redirects to sign in" do
+        make_request
+        expect(response).to redirect_to("/users/sign_in")
+      end
+    end
+
+    context "when signed in as non-admin" do
+      before { sign_in non_admin }
+
+      it "denies access" do
+        make_request
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "when signed in as admin" do
+      before { sign_in admin }
+
+      it "grants access" do
+        make_request
+        follow_redirect! while response.redirect?
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  {
+    "players" => :player,
+    "games" => :game,
+    "roles" => :role,
+    "awards" => :award,
+    "ratings" => :rating,
+    "player_awards" => :player_award,
+    "users" => :admin
+  }.each do |resource_name, record_method|
+    describe resource_name do
+      describe "GET /avo/resources/#{resource_name}" do
+        define_method(:make_request) { get "/avo/resources/#{resource_name}" }
+
+        include_examples "admin-only endpoint"
+      end
+
+      describe "GET /avo/resources/#{resource_name}/:id" do
+        define_method(:make_request) { get "/avo/resources/#{resource_name}/#{send(record_method).id}" }
+
+        include_examples "admin-only endpoint"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Request specs testing authentication and authorization on all 7 Avo resources (players, games, roles, awards, ratings, player_awards, users)
- Tests both index and show endpoints for each resource
- Covers three auth states: unauthenticated (redirect to sign-in), non-admin (404), admin (200)
- Uses shared examples and iteration to keep 42 examples DRY

## Test plan
- [x] All 198 specs pass
- [x] Rubocop: 0 offenses

Closes vanilla-mafia-29

🤖 Generated with [Claude Code](https://claude.com/claude-code)