### PR TITLE
Add migrations and config for player claims feature

### DIFF
--- a/config/initializers/player_claims.rb
+++ b/config/initializers/player_claims.rb
@@ -1,0 +1,2 @@
+Rails.application.config.player_claims = ActiveSupport::OrderedOptions.new
+Rails.application.config.player_claims.require_approval = true

--- a/db/migrate/20260223053232_add_player_id_to_users.rb
+++ b/db/migrate/20260223053232_add_player_id_to_users.rb
@@ -1,0 +1,5 @@
+class AddPlayerIdToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :users, :player, null: true, foreign_key: true, index: { unique: true }
+  end
+end

--- a/db/migrate/20260223053244_create_player_claims.rb
+++ b/db/migrate/20260223053244_create_player_claims.rb
@@ -1,0 +1,16 @@
+class CreatePlayerClaims < ActiveRecord::Migration[8.1]
+  def change
+    create_table :player_claims do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :player, null: false, foreign_key: true
+      t.string :status, null: false, default: "pending"
+      t.text :rejection_reason
+      t.references :reviewed_by, null: true, foreign_key: { to_table: :users }
+      t.datetime :reviewed_at
+      t.timestamps
+    end
+
+    add_index :player_claims, [ :user_id, :player_id ], unique: true
+    add_index :player_claims, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_17_121948) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_23_053244) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -74,6 +74,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_17_121948) do
     t.index ["player_id"], name: "index_player_awards_on_player_id"
   end
 
+  create_table "player_claims", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "player_id", null: false
+    t.text "rejection_reason"
+    t.datetime "reviewed_at"
+    t.integer "reviewed_by_id"
+    t.string "status", default: "pending", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["player_id"], name: "index_player_claims_on_player_id"
+    t.index ["reviewed_by_id"], name: "index_player_claims_on_reviewed_by_id"
+    t.index ["status"], name: "index_player_claims_on_status"
+    t.index ["user_id", "player_id"], name: "index_player_claims_on_user_id_and_player_id", unique: true
+    t.index ["user_id"], name: "index_player_claims_on_user_id"
+  end
+
   create_table "players", force: :cascade do |t|
     t.text "comment"
     t.datetime "created_at", null: false
@@ -109,11 +125,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_17_121948) do
     t.datetime "created_at", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
+    t.integer "player_id"
     t.datetime "remember_created_at"
     t.datetime "reset_password_sent_at"
     t.string "reset_password_token"
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["player_id"], name: "index_users_on_player_id", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
@@ -121,7 +139,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_17_121948) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "player_awards", "awards"
   add_foreign_key "player_awards", "players"
+  add_foreign_key "player_claims", "players"
+  add_foreign_key "player_claims", "users"
+  add_foreign_key "player_claims", "users", column: "reviewed_by_id"
   add_foreign_key "ratings", "games"
   add_foreign_key "ratings", "players"
   add_foreign_key "ratings", "roles", column: "role_code", primary_key: "code"
+  add_foreign_key "users", "players"
 end


### PR DESCRIPTION
Create player_id reference on users (nullable, unique) for 1:1 player linking, and player_claims table for tracking claim requests with approval workflow. Add initializer with require_approval config toggle.