### PR TITLE
Fix SQL injection in import rake task

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -153,10 +153,12 @@ end
 
 def phase5_reset_sequences
   puts "--- Phase 5: Resetting SQLite sequences ---"
-  %w[games players].each do |table|
-    max_id = ActiveRecord::Base.connection.select_value("SELECT MAX(id) FROM #{table}") || 0
-    ActiveRecord::Base.connection.execute(
-      "UPDATE sqlite_sequence SET seq = #{max_id} WHERE name = '#{table}'"
+  conn = ActiveRecord::Base.connection
+  [ Game, Player ].each do |model|
+    table = model.table_name
+    max_id = model.maximum(:id) || 0
+    conn.execute(
+      "UPDATE sqlite_sequence SET seq = #{conn.quote(max_id)} WHERE name = #{conn.quote(table)}"
     )
     puts "Reset #{table} sequence to #{max_id}"
   end


### PR DESCRIPTION
## Summary
- Replace raw string interpolation in `phase5_reset_sequences` with `connection.quote` for parameterized values
- Use model classes (`Game`, `Player`) instead of raw table name strings
- Use `model.maximum(:id)` instead of raw `SELECT MAX(id)` query

## Test plan
- [x] `bundle exec rspec` — 256 examples, 0 failures
- [x] `bundle exec rubocop` — 0 offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)