### PR TITLE
Fix ghcr.io registry username to match PAT owner

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -28,7 +28,7 @@ proxy:
 
 registry:
   server: ghcr.io
-  username: port-royal
+  username: marinazzio
   password:
     - KAMAL_REGISTRY_PASSWORD
 


### PR DESCRIPTION
## Summary
- Change registry username from `port-royal` (org) to `marinazzio` (PAT owner)
- Classic PATs authenticate as the user, not the org

Fixes the `denied` error on `docker login ghcr.io` during deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)