### PR TITLE
Debug: test registry login before Kamal deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,11 @@ jobs:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Test registry login
-        run: echo "$KAMAL_REGISTRY_PASSWORD" | docker login ghcr.io -u marinazzio --password-stdin
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: marinazzio
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Deploy with Kamal
         run: bin/kamal deploy


### PR DESCRIPTION
Diagnostic PR — adds a direct docker login step to isolate whether the ghcr.io auth failure is a credentials issue or a Kamal issue.