### PR TITLE
Move deploy secrets to job-level env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
+      KAMAL_REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+      RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+      DEPLOY_SERVER: ${{ secrets.DEPLOY_SERVER }}
+      ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
+      ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
 
     steps:
       - name: Checkout code
@@ -30,10 +35,4 @@ jobs:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Deploy with Kamal
-        env:
-          KAMAL_REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
-          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-          DEPLOY_SERVER: ${{ secrets.DEPLOY_SERVER }}
-          ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
-          ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
         run: bin/kamal deploy


### PR DESCRIPTION
## Summary
- Move secret env vars from step-level to job-level in deploy workflow
- Kamal sources `.kamal/secrets` in a subshell that inherits job-level env but not step-level env
- This caused `DEPLOY_SERVER` to be empty, making Kamal try to connect to literal `%{DEPLOY_SERVER}`

## Context
The previous deploy run (v0.1.4) successfully built and pushed the Docker image to ghcr.io, but failed when trying to SSH to the VPS because `DEPLOY_SERVER` was not resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)