### PR TITLE
Fix DEPLOY_SERVER: use ERB interpolation in Kamal config

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -8,10 +8,10 @@ image: port-royal/vanilla_mafia
 servers:
   web:
     hosts:
-      - "%{DEPLOY_SERVER}"
+      - <%= ENV['DEPLOY_SERVER'] %>
   # job:
   #   hosts:
-  #     - "%{DEPLOY_SERVER}"
+  #     - <%= ENV['DEPLOY_SERVER'] %>
   #   cmd: bin/jobs
 
 # Enable SSL auto certification via Let's Encrypt and allow for multiple apps on a single web server.


### PR DESCRIPTION
## Summary
- Replace `%{DEPLOY_SERVER}` with `<%= ENV['DEPLOY_SERVER'] %>` in `config/deploy.yml`
- Kamal uses ERB for config interpolation, not `%{}` syntax
- The literal string `%{DEPLOY_SERVER}` was being used as a hostname, causing DNS resolution failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)