### PR TITLE
Change builder arch to arm64 for Hetzner ARM VPS

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -76,7 +76,7 @@ asset_path: /rails/public/assets
 
 # Configure the image builder.
 builder:
-  arch: amd64
+  arch: arm64
 
   # # Build image via remote server (useful for faster amd64 builds on arm64 computers)
   # remote: ssh://docker@docker-builder-server


### PR DESCRIPTION
## Summary
- Change `builder.arch` from `amd64` to `arm64`
- The Hetzner VPS is ARM64 (CAX series), image pull fails with `no matching manifest for linux/arm64/v8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)