### PR TITLE
Disable SSL proxy until a real domain is configured

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -22,9 +22,9 @@ servers:
 # Don't use this when deploying to multiple web servers (then you have to terminate SSL at your load balancer).
 #
 # TODO: Replace with your actual domain name once chosen
-proxy:
-  ssl: true
-  host: app.example.com
+# proxy:
+#   ssl: true
+#   host: app.example.com
 
 registry:
   server: ghcr.io


### PR DESCRIPTION
## Summary
- Comment out `proxy` config (ssl + host) so the app is accessible by IP over HTTP
- Re-enable when a domain is pointed at the server

Without this, kamal-proxy rejects requests that don't match `app.example.com` and redirects to HTTPS which has no valid cert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)