### PR TITLE
Fix Kamal secrets syntax for admin credentials

### DIFF
--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -14,18 +14,6 @@ DEPLOY_SERVER=$(printenv DEPLOY_SERVER)
 # Rails master key (prefer ENV, fallback to local file)
 RAILS_MASTER_KEY=$(printenv RAILS_MASTER_KEY || cat config/master.key)
 
-# Admin credentials for db:seed from ENV (required)
-ADMIN_EMAIL=$(
-  if [ -z "${ADMIN_EMAIL:-}" ]; then
-    echo "ERROR: ADMIN_EMAIL environment variable must be set for db:seed" >&2
-    exit 1
-  fi
-  printf '%s\n' "$ADMIN_EMAIL"
-)
-ADMIN_PASSWORD=$(
-  if [ -z "${ADMIN_PASSWORD:-}" ]; then
-    echo "ERROR: ADMIN_PASSWORD environment variable must be set for db:seed" >&2
-    exit 1
-  fi
-  printf '%s\n' "$ADMIN_PASSWORD"
-)
+# Admin credentials for db:seed from ENV
+ADMIN_EMAIL=$(printenv ADMIN_EMAIL)
+ADMIN_PASSWORD=$(printenv ADMIN_PASSWORD)


### PR DESCRIPTION
## Summary
- Replace incompatible `${VAR:-}` bash parameter expansion in `.kamal/secrets` with simple `$(printenv VAR)` pattern
- Kamal's secrets parser does NOT support `${VAR:-fallback}` syntax — this was causing ADMIN_EMAIL and ADMIN_PASSWORD to not reach the container properly, breaking `db:seed` and `import:scrape`

## Test plan
- [ ] Merge and tag a new version to trigger deploy
- [ ] SSH into VPS and verify: `bin/kamal app exec 'bin/rails runner "puts ENV[\"ADMIN_EMAIL\"]"'`
- [ ] Run `bin/kamal app exec 'bin/rails import:scrape'` and confirm `db:seed` passes

Closes vanilla-mafia-73

🤖 Generated with [Claude Code](https://claude.com/claude-code)