### PR TITLE
Exclude test gems from production Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update -qq && \
 ENV RAILS_ENV="production" \
     BUNDLE_DEPLOYMENT="1" \
     BUNDLE_PATH="/usr/local/bundle" \
-    BUNDLE_WITHOUT="development" \
+    BUNDLE_WITHOUT="development:test" \
     LD_PRELOAD="/usr/local/lib/libjemalloc.so"
 
 # Throw-away build stage to reduce size of final image


### PR DESCRIPTION
## Summary
- Change `BUNDLE_WITHOUT="development"` to `BUNDLE_WITHOUT="development:test"` in Dockerfile
- Removes capybara, selenium-webdriver, shoulda-matchers, simplecov, database_cleaner, mutant-rspec, test-prof, debug, brakeman, rubocop, rspec, factory_bot and all their transitive dependencies from the production image

## Test plan
- [ ] CI passes (no impact — CI doesn't use the Dockerfile)
- [ ] Next deploy builds a smaller image

Closes vanilla-mafia-74

🤖 Generated with [Claude Code](https://claude.com/claude-code)