### PR TITLE
Disable SSL settings until HTTPS is configured

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,13 +25,15 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  config.assume_ssl = true
+  # TODO: re-enable when a real domain with HTTPS is configured
+  # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  # TODO: re-enable when a real domain with HTTPS is configured
+  # config.force_ssl = true
 
   # Skip http-to-https redirect for the default health check endpoint.
-  config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
+  # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
## Summary
- Disable `config.assume_ssl` and `config.force_ssl` in production config
- These settings mark session cookies as `Secure`, preventing them from being sent over plain HTTP
- This causes CSRF token verification to fail with 422 on login/sign-up forms
- Re-enable when a domain with HTTPS is pointed at the server

## Test plan
- [ ] Deploy and verify login works over HTTP
- [ ] Verify flash messages appear on successful sign-in/sign-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)