### PR TITLE
Fix deploy: use ENV[] for RESEND_API_KEY

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,7 +59,7 @@ Rails.application.configure do
     address: "smtp.resend.com",
     port: 465,
     user_name: "resend",
-    password: ENV.fetch("RESEND_API_KEY"),
+    password: ENV["RESEND_API_KEY"],
     authentication: :plain,
     tls: true
   }


### PR DESCRIPTION
## Summary
- Replace `ENV.fetch("RESEND_API_KEY")` with `ENV["RESEND_API_KEY"]` in production config
- `ENV.fetch` raises `KeyError` during Docker `assets:precompile` step where the secret isn't available
- `ENV[]` returns nil at build time, gets the real value at runtime from Kamal secrets

## Test plan
- [ ] Deploy succeeds without KeyError

🤖 Generated with [Claude Code](https://claude.com/claude-code)