### PR TITLE
91: Add missing index on awards.staff

### DIFF
--- a/db/migrate/20260228194523_add_index_to_awards_staff.rb
+++ b/db/migrate/20260228194523_add_index_to_awards_staff.rb
@@ -1,0 +1,5 @@
+class AddIndexToAwardsStaff < ActiveRecord::Migration[8.1]
+  def change
+    add_index :awards, :staff
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_28_153643) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_28_194523) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -46,6 +46,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_28_153643) do
     t.boolean "staff", default: false
     t.string "title", null: false
     t.datetime "updated_at", null: false
+    t.index ["staff"], name: "index_awards_on_staff"
   end
 
   create_table "feature_toggles", force: :cascade do |t|


### PR DESCRIPTION
## Summary
- Adds a database index on `awards.staff` to support the `Award.for_players` and `Award.for_staff` scopes which filter by this boolean column
- Note: `player_awards.award_id` was identified as a candidate but already has an index (`index_player_awards_on_award_id`), so only the `awards.staff` index was truly missing

## Test plan
- [x] Migration runs successfully (`bin/rails db:migrate`)
- [x] All 451 existing specs pass
- [x] Schema updated with `index_awards_on_staff`
- [x] Rubocop clean on migration file

🤖 Generated with [Claude Code](https://claude.com/claude-code)