### PR TITLE
88: Add pagy gem and base configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "bcrypt", "~> 3.1.7"
 
 gem "avo"
 gem "devise"
+gem "pagy"
 gem "pundit"
 gem "rails-i18n"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -608,6 +608,7 @@ DEPENDENCIES
   importmap-rails
   kamal
   mutant-rspec
+  pagy
   propshaft
   puma (>= 5.0)
   pundit

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  include Pagy::Backend
   include SetLocale
 
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,3 @@
 module ApplicationHelper
+  include Pagy::Frontend
 end

--- a/app/views/shared/_pagy_nav.html.erb
+++ b/app/views/shared/_pagy_nav.html.erb
@@ -1,0 +1,39 @@
+<%# Tailwind-styled pagination nav for pagy.
+     Usage: render "shared/pagy_nav", pagy: @pagy %>
+<% if pagy.pages > 1 %>
+  <%
+    link_classes      = "px-3 py-1.5 text-sm rounded border border-neutral-300 " \
+                        "text-neutral-700 hover:bg-neutral-100 transition-colors"
+    current_classes    = "px-3 py-1.5 text-sm rounded border border-maroon " \
+                        "bg-maroon text-white"
+    disabled_classes   = "px-3 py-1.5 text-sm rounded border border-neutral-200 " \
+                        "text-neutral-400 cursor-default"
+    gap_classes        = "px-2 py-1.5 text-sm text-neutral-400"
+  %>
+  <nav class="flex items-center justify-center gap-1 mt-8" aria-label="<%= pagy_t("pagy.aria_label.nav", count: pagy.pages) %>">
+    <% if pagy.prev %>
+      <%= link_to pagy_t("pagy.prev"), pagy_url_for(pagy, pagy.prev), class: link_classes,
+            aria: { label: pagy_t("pagy.aria_label.prev") } %>
+    <% else %>
+      <span class="<%= disabled_classes %>" aria-disabled="true"><%= pagy_t("pagy.prev") %></span>
+    <% end %>
+
+    <% pagy.series.each do |item| %>
+      <% case item
+         when Integer %>
+        <%= link_to item, pagy_url_for(pagy, item), class: link_classes %>
+      <% when String %>
+        <span class="<%= current_classes %>" aria-current="page"><%= item %></span>
+      <% when :gap %>
+        <span class="<%= gap_classes %>">&hellip;</span>
+      <% end %>
+    <% end %>
+
+    <% if pagy.next %>
+      <%= link_to pagy_t("pagy.next"), pagy_url_for(pagy, pagy.next), class: link_classes,
+            aria: { label: pagy_t("pagy.aria_label.next") } %>
+    <% else %>
+      <span class="<%= disabled_classes %>" aria-disabled="true"><%= pagy_t("pagy.next") %></span>
+    <% end %>
+  </nav>
+<% end %>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Pagy initializer (9.4.0)
+
+# Items per page
+Pagy::DEFAULT[:limit] = 25
+
+# Use the overflow extra to handle out-of-range pages gracefully
+require "pagy/extras/overflow"
+Pagy::DEFAULT[:overflow] = :last_page
+
+# Use the standard I18n gem so pagy respects the app locale (ru / en)
+require "pagy/extras/i18n"
+
+Pagy::DEFAULT.freeze


### PR DESCRIPTION
## Summary
- Install pagy 9.4.0 gem for pagination support
- Configure defaults: 25 items per page, overflow handling (redirect to last page), and i18n extra for ru/en locale support
- Include `Pagy::Backend` in `ApplicationController` and `Pagy::Frontend` in `ApplicationHelper`
- Add a Tailwind-styled pagination nav partial at `app/views/shared/_pagy_nav.html.erb` matching the app's maroon brand color

## Test plan
- [x] All 451 existing specs pass with no failures
- [x] Rubocop clean on all changed files
- [ ] Verify pagination partial renders correctly when wired to a paginated collection in a future PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)