### PR TITLE
Add Новый протокол link to Avo sidebar

### DIFF
--- a/config/initializers/avo.rb
+++ b/config/initializers/avo.rb
@@ -144,19 +144,15 @@ Avo.configure do |config|
   # end
 
   ## == Menus ==
-  # config.main_menu = -> {
-  #   section "Dashboards", icon: "avo/dashboards" do
-  #     all_dashboards
-  #   end
+  config.main_menu = -> {
+    section "Resources", icon: "avo/resources" do
+      all_resources
+    end
 
-  #   section "Resources", icon: "avo/resources" do
-  #     all_resources
-  #   end
-
-  #   section "Tools", icon: "avo/tools" do
-  #     all_tools
-  #   end
-  # }
+    section "Tools", icon: "avo/tools" do
+      link "Новый протокол", path: "/avo/game_protocols/new", icon: "heroicons/outline/document-plus"
+    end
+  }
   # config.profile_menu = -> {
   #   link "Profile", path: "/avo/profile", icon: "heroicons/outline/user-circle"
   # }


### PR DESCRIPTION
## Summary
- Configures `Avo.main_menu` to add a "Новый протокол" link under a Tools section in the Avo sidebar
- Without this, the game protocol form at `/avo/game_protocols/new` was unreachable from the UI

## Test plan
- [ ] Visit `/avo` — sidebar shows "Tools" section with "Новый протокол" link
- [ ] Click the link — navigates to the new protocol form
- [ ] All existing resources still appear in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)