### PR TITLE
206: Telegram message parser service

### DIFF
--- a/app/services/telegram/message_parser.rb
+++ b/app/services/telegram/message_parser.rb
@@ -21,7 +21,7 @@ module Telegram
 
       raw_text = @message["text"] || @message["caption"] || ""
       news = NEWS_TAG_PATTERN.match?(raw_text)
-      text = raw_text.gsub(NEWS_TAG_PATTERN, "").strip
+      text = raw_text.gsub(NEWS_TAG_PATTERN, "").squish
 
       from = @message["from"]
 

--- a/spec/services/telegram/message_parser_spec.rb
+++ b/spec/services/telegram/message_parser_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe Telegram::MessageParser do
 
       it "strips the tag regardless of case" do
         result = described_class.call(payload)
-        expect(result.text).to eq("Update  here")
+        expect(result.text).to eq("Update here")
       end
     end
   end


### PR DESCRIPTION
## Summary
- Add `Telegram::MessageParser` service that extracts data from Telegram webhook payloads
- Parses: message text, sender info (user_id, username, first_name), chat_id, photo file_ids
- Detects `#news` hashtag (case-insensitive) in text/captions and strips it from the returned text
- Supports regular messages, edited messages, and photo messages with captions
- Returns `nil` for payloads without a message (e.g. callback queries)

## Test plan
- [x] 19 specs covering text messages, photos, edited messages, #news detection, missing fields
- [x] 756 full suite specs pass
- [x] 96.6% mutation coverage (surviving mutants are equivalent — `.fetch` vs `[]`, `|| ""` vs `|| nil`)
- [x] Rubocop clean

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)