### PR TITLE
Fix deploy: skip Telegram credential checks during asset precompilation

### DIFF
--- a/config/initializers/telegram.rb
+++ b/config/initializers/telegram.rb
@@ -2,12 +2,14 @@ Rails.application.config.x.telegram = ActiveSupport::OrderedOptions.new
 bot_token = Rails.application.credentials.dig(:telegram, :bot_token)
 webhook_secret = Rails.application.credentials.dig(:telegram, :webhook_secret)
 
-if Rails.env.production? && bot_token.blank?
-  raise "Telegram bot token is missing or blank. Please set credentials.telegram.bot_token."
-end
+unless ENV["SECRET_KEY_BASE_DUMMY"]
+  if Rails.env.production? && bot_token.blank?
+    raise "Telegram bot token is missing or blank. Please set credentials.telegram.bot_token."
+  end
 
-if Rails.env.production? && webhook_secret.blank?
-  raise "Telegram webhook secret is missing or blank. Please set credentials.telegram.webhook_secret."
+  if Rails.env.production? && webhook_secret.blank?
+    raise "Telegram webhook secret is missing or blank. Please set credentials.telegram.webhook_secret."
+  end
 end
 
 Rails.application.config.x.telegram.bot_token = bot_token


### PR DESCRIPTION
## Summary
- Docker build fails because `rails assets:precompile` loads the Rails environment in production mode, triggering the Telegram initializer's credential validation — but credentials aren't available during the build step (`SECRET_KEY_BASE_DUMMY=1`)
- Skip the bot_token and webhook_secret presence checks when `SECRET_KEY_BASE_DUMMY` is set

## Test plan
- [x] Full suite: 783 examples, 0 failures
- [x] Rubocop: no offenses
- [ ] Verify deploy succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)