### PR TITLE
246: Competition show view (replaces seasons/series)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           RAILS_ENV: test
           # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           # REDIS_URL: redis://localhost:6379/0
-        run: bundle exec rspec --exclude-pattern "spec/{system,acceptance}/**/*_spec.rb"
+        run: bundle exec rspec --exclude-pattern "spec/system/**/*_spec.rb"
 
   system-test:
     runs-on: ubuntu-latest

--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -3,6 +3,14 @@ class CompetitionsController < ApplicationController
     @competition = Competition.find_by!(slug: params[:slug])
     result = CompetitionOverviewService.call(competition: @competition)
     @parent_view = result.parent_view
-    @games_by_child = result.games_by_child
+
+    if @parent_view
+      @games_by_child = result.games_by_child
+      @pagy, @players = pagy(result.players, limit: 25, count: result.player_count)
+    else
+      @games = result.games
+      @participations_by_player = result.participations_by_player
+      @players_sorted = result.players_sorted
+    end
   end
 end

--- a/app/helpers/competitions_helper.rb
+++ b/app/helpers/competitions_helper.rb
@@ -1,0 +1,7 @@
+module CompetitionsHelper
+  def win_percentage(player)
+    return 0.0 if player.games_count.zero?
+
+    (player.wins_count.to_f / player.games_count * 100).round(1)
+  end
+end

--- a/app/views/competitions/show.html.erb
+++ b/app/views/competitions/show.html.erb
@@ -1,7 +1,91 @@
 <h1 class="text-2xl font-bold mb-6"><%= @competition.name %></h1>
 
 <% if @parent_view %>
-  <% @games_by_child.each do |child, games| %>
-    <h2 class="text-xl font-semibold mt-4 mb-2"><%= child.name %></h2>
-  <% end %>
+  <section class="mb-10">
+    <h2 class="text-2xl font-bold text-maroon mb-4"><%= t(".by_children") %></h2>
+
+    <div class="scroll-wrapper">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th><%= t(".player") %></th>
+            <th><%= t(".games") %></th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @games_by_child.each do |child, games| %>
+            <tr>
+              <td><%= child.name %></td>
+              <td>
+                <% games.each do |game| %>
+                  <span><%= link_to game.game_number, game_path(game), class: "text-maroon hover:underline" %></span>
+                <% end %>
+              </td>
+              <td><%= link_to t(".view"), competition_path(slug: child.slug),
+                    class: "text-maroon hover:underline" %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section>
+    <h2 class="text-2xl font-bold text-maroon mb-4"><%= t(".by_players") %></h2>
+
+    <div class="scroll-wrapper">
+      <table id="players-table" class="data-table">
+        <thead>
+          <tr>
+            <th><%= t(".rank") %></th>
+            <th><%= t(".player") %></th>
+            <th><%= t(".rating") %></th>
+            <th><%= t(".games") %></th>
+            <th><%= t(".win_rate") %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @players.each_with_index do |player, index| %>
+            <tr>
+              <td><%= @pagy.from + index %></td>
+              <td><%= link_to player.name, player_path(player) %></td>
+              <td><%= player.total_rating %></td>
+              <td><%= player.games_count %></td>
+              <td><%= win_percentage(player) %>%</td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+
+    <%= render "shared/pagy_nav", pagy: @pagy %>
+  </section>
+<% else %>
+  <div class="scroll-wrapper">
+    <table class="data-table">
+      <thead>
+        <tr>
+          <th><%= t(".player") %></th>
+          <% @games.each do |game| %>
+            <th><%= t("common.game") %> <%= game.game_number %></th>
+          <% end %>
+          <th><%= t(".total") %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @players_sorted.each do |player| %>
+          <% participations = @participations_by_player[player] %>
+          <% participations_by_game = participations.index_by(&:game_id) %>
+          <tr>
+            <td><%= player.name %></td>
+            <% @games.each do |game| %>
+              <td><%= participations_by_game[game.id]&.total %></td>
+            <% end %>
+            <td><%= participations.sum(&:total) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,6 +130,17 @@ en:
     sign_in: "Sign in"
     sign_out: "Sign out"
     admin: "Admin"
+  competitions:
+    show:
+      by_children: "By series and games"
+      by_players: "By players"
+      rank: "Rank"
+      player: "Player"
+      rating: "Rating"
+      games: "Games"
+      win_rate: "Win rate"
+      view: "Result"
+      total: "Total"
   seasons:
     show:
       date: "Date"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -50,6 +50,17 @@ ru:
         title: "Название"
         description: "Описание"
         staff: "Организаторская"
+  competitions:
+    show:
+      by_children: "По сериям и играм"
+      by_players: "По игрокам"
+      rank: "Место"
+      player: "Игрок"
+      rating: "Рейтинг"
+      games: "Игры"
+      win_rate: "Процент побед"
+      view: "Итог"
+      total: "Итого"
   seasons:
     show:
       date: "Дата"

--- a/spec/acceptance/season_overview_spec.rb
+++ b/spec/acceptance/season_overview_spec.rb
@@ -1,9 +1,12 @@
 require "rails_helper"
 
 RSpec.describe "Season overview" do
-  let_it_be(:game1) { create(:game, season: 5, series: 1, game_number: 1, played_on: Date.new(2025, 1, 10)) }
-  let_it_be(:game2) { create(:game, season: 5, series: 1, game_number: 2, played_on: Date.new(2025, 1, 17)) }
-  let_it_be(:game3) { create(:game, season: 5, series: 2, game_number: 1, played_on: Date.new(2025, 2, 7)) }
+  let_it_be(:season) { create(:competition, :season, name: "Сезон 5", slug: "season-5", legacy_season: 5) }
+  let_it_be(:series1) { create(:competition, :series, name: "Серия 1", slug: "season-5-series-1", parent: season, position: 1, legacy_season: 5, legacy_series: 1) }
+  let_it_be(:series2) { create(:competition, :series, name: "Серия 2", slug: "season-5-series-2", parent: season, position: 2, legacy_season: 5, legacy_series: 2) }
+  let_it_be(:game1) { create(:game, competition: series1, season: 5, series: 1, game_number: 1, played_on: Date.new(2025, 1, 10)) }
+  let_it_be(:game2) { create(:game, competition: series1, season: 5, series: 1, game_number: 2, played_on: Date.new(2025, 1, 17)) }
+  let_it_be(:game3) { create(:game, competition: series2, season: 5, series: 2, game_number: 1, played_on: Date.new(2025, 2, 7)) }
 
   let_it_be(:player1) { create(:player, name: "Алексей") }
   let_it_be(:player2) { create(:player, name: "Борис") }
@@ -23,9 +26,9 @@ RSpec.describe "Season overview" do
     expect(page).to have_link(href: game_path(game3))
   end
 
-  it "links to series pages" do
-    expect(page).to have_link(href: season_series_path(season_number: 5, number: 1))
-    expect(page).to have_link(href: season_series_path(season_number: 5, number: 2))
+  it "links to child competition pages" do
+    expect(page).to have_link(href: competition_path(slug: series1.slug))
+    expect(page).to have_link(href: competition_path(slug: series2.slug))
   end
 
   it "displays player rankings table headers" do

--- a/spec/acceptance/series_totals_spec.rb
+++ b/spec/acceptance/series_totals_spec.rb
@@ -1,8 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "Series totals" do
-  let_it_be(:game1) { create(:game, season: 5, series: 1, game_number: 1) }
-  let_it_be(:game2) { create(:game, season: 5, series: 1, game_number: 2) }
+  let_it_be(:season) { create(:competition, :season, legacy_season: 5) }
+  let_it_be(:series) { create(:competition, :series, parent: season, slug: "season-5-series-1", legacy_season: 5, legacy_series: 1) }
+  let_it_be(:game1) { create(:game, competition: series, season: 5, series: 1, game_number: 1) }
+  let_it_be(:game2) { create(:game, competition: series, season: 5, series: 1, game_number: 2) }
   let_it_be(:player1) { create(:player, name: "Алексей") }
   let_it_be(:player2) { create(:player, name: "Борис") }
 

--- a/spec/helpers/competitions_helper_spec.rb
+++ b/spec/helpers/competitions_helper_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe CompetitionsHelper do
+  describe "#win_percentage" do
+    let(:player) { Data.define(:wins_count, :games_count).new(wins_count: wins, games_count: games) }
+
+    context "when player has no games" do
+      let(:wins) { 0 }
+      let(:games) { 0 }
+
+      it "returns 0.0" do
+        expect(helper.win_percentage(player)).to eq(0.0)
+      end
+    end
+
+    context "when player has won all games" do
+      let(:wins) { 3 }
+      let(:games) { 3 }
+
+      it "returns 100.0" do
+        expect(helper.win_percentage(player)).to eq(100.0)
+      end
+    end
+
+    context "when player has partial wins" do
+      let(:wins) { 1 }
+      let(:games) { 3 }
+
+      it "returns the rounded percentage" do
+        expect(helper.win_percentage(player)).to eq(33.3)
+      end
+    end
+  end
+end

--- a/spec/requests/competitions_spec.rb
+++ b/spec/requests/competitions_spec.rb
@@ -7,8 +7,12 @@ RSpec.describe CompetitionsController do
       let_it_be(:child1) { create(:competition, :series, name: "Series 1", parent: parent, position: 1) }
       let_it_be(:child2) { create(:competition, :series, name: "Series 2", parent: parent, position: 2) }
       let_it_be(:game1) { create(:game, competition: child1, game_number: 1) }
-      let_it_be(:player) { create(:player, name: "Алексей") }
-      let_it_be(:participation) { create(:game_participation, game: game1, player: player, plus: 3.0, minus: 0.5, win: true) }
+      let_it_be(:game2) { create(:game, competition: child1, game_number: 2) }
+      let_it_be(:game3) { create(:game, competition: child2, game_number: 1) }
+      let_it_be(:player1) { create(:player, name: "Алексей") }
+      let_it_be(:player2) { create(:player, name: "Борис") }
+      let_it_be(:participation1) { create(:game_participation, game: game1, player: player1, plus: 3.0, minus: 0.5, win: true) }
+      let_it_be(:participation2) { create(:game_participation, game: game1, player: player2, plus: 1.0, minus: 1.5, win: false) }
 
       before { get competition_path(slug: parent.slug) }
 
@@ -20,22 +24,68 @@ RSpec.describe CompetitionsController do
         expect(response.body).to include("Season 5")
       end
 
-      it "assigns child competitions" do
+      it "renders child competition names" do
         expect(response.body).to include("Series 1")
         expect(response.body).to include("Series 2")
+      end
+
+      it "renders game links" do
+        expect(response.body).to include(game_path(game1))
+        expect(response.body).to include(game_path(game2))
+      end
+
+      it "renders child competition links" do
+        expect(response.body).to include(competition_path(slug: child1.slug))
+      end
+
+      it "renders player rankings" do
+        expect(response.body).to include("Алексей")
+        expect(response.body).to include("Борис")
+      end
+
+      it "renders ranking table headers" do
+        expect(response.body).to include(I18n.t("competitions.show.rank"))
+        expect(response.body).to include(I18n.t("competitions.show.rating"))
+      end
+
+      it "links player names to profiles" do
+        expect(response.body).to include(player_path(player1))
       end
     end
 
     context "when competition is a leaf" do
       let_it_be(:competition) { create(:competition, :series, name: "Series 1", slug: "series-1") }
-      let_it_be(:game) { create(:game, competition: competition, game_number: 1) }
-      let_it_be(:player) { create(:player, name: "Борис") }
-      let_it_be(:participation) { create(:game_participation, game: game, player: player, plus: 2.0, minus: 0.5) }
+      let_it_be(:game1) { create(:game, competition: competition, game_number: 1) }
+      let_it_be(:game2) { create(:game, competition: competition, game_number: 2) }
+      let_it_be(:player1) { create(:player, name: "Виктор") }
+      let_it_be(:player2) { create(:player, name: "Галина") }
+      let_it_be(:p1) { create(:game_participation, game: game1, player: player1, plus: 3.0, minus: 0.5) }
+      let_it_be(:p2) { create(:game_participation, game: game1, player: player2, plus: 1.0, minus: 1.5) }
+      let_it_be(:p3) { create(:game_participation, game: game2, player: player1, plus: 2.0, minus: 1.0) }
+      let_it_be(:p4) { create(:game_participation, game: game2, player: player2, plus: 5.0, minus: 0.0) }
 
       before { get competition_path(slug: competition.slug) }
 
       it "returns success" do
         expect(response).to have_http_status(:ok)
+      end
+
+      it "renders player names" do
+        expect(response.body).to include("Виктор")
+        expect(response.body).to include("Галина")
+      end
+
+      it "renders game columns" do
+        expect(response.body).to include(I18n.t("common.game") + " 1")
+        expect(response.body).to include(I18n.t("common.game") + " 2")
+      end
+
+      it "renders total column" do
+        expect(response.body).to include(I18n.t("competitions.show.total"))
+      end
+
+      it "sorts players by total descending" do
+        expect(response.body).to match(/Галина.*Виктор/m)
       end
     end
 


### PR DESCRIPTION
## Summary
- Expand `CompetitionsController#show` to expose all needed ivars for parent (paginated player rankings + games-by-child table) and leaf (game-by-game totals) view modes
- Build full `competitions/show.html.erb` view replacing both `seasons/show` and `series/show`
- Add `CompetitionsHelper#win_percentage` with unit specs
- Add i18n keys (`competitions.show.*`) in both `ru.yml` and `en.yml`
- Update acceptance specs (`season_overview`, `series_totals`) to create Competition records so legacy redirects work end-to-end
- Re-enable acceptance specs in CI (all views now render correctly)

## Mutation Testing
- Evilution (controller): 95.24% (20/21 killed, 1 survivor: pagination limit `25` vs `26`)
- Evilution (helper): 21.43% — false negatives (evilution doesn't detect helper spec connection)
- Mutant (controller): 98.66% (74/75 killed, 1 neutral — `let_it_be` slug uniqueness in fork)
- Mutant (helper): 1.88% — known limitation with Rails helper spec integration
- Additional mutants caught by mutant only: 0

## Test plan
- [x] 15 request specs pass (parent view: 8, leaf view: 5, empty: 1, not found: 1)
- [x] 3 helper unit specs pass
- [x] 9 acceptance specs pass (season overview: 5, series totals: 4)
- [x] 867 total specs pass (full CI suite)
- [x] Rubocop clean

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)