### PR TITLE
311: Avo Competition resource: add slug and position fields

### DIFF
--- a/app/avo/resources/competition.rb
+++ b/app/avo/resources/competition.rb
@@ -7,7 +7,9 @@ class Avo::Resources::Competition < Avo::BaseResource
   def fields
     field :id, as: :id
     field :name, as: :text
+    field :slug, as: :text
     field :kind, as: :select, enum: ::Competition.kinds
+    field :position, as: :number
     field :parent, as: :belongs_to, required: false
     field :games, as: :has_many
   end

--- a/app/controllers/avo/competitions_controller.rb
+++ b/app/controllers/avo/competitions_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/3.0/controllers.html
+class Avo::CompetitionsController < Avo::ResourcesController
+end

--- a/spec/acceptance/admin/competitions_spec.rb
+++ b/spec/acceptance/admin/competitions_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "Admin Competitions CRUD" do
+  let_it_be(:admin) { create(:user, :admin) }
+
+  before { sign_in_as_admin(admin) }
+
+  describe "create" do
+    it "creates a new competition with slug and position" do
+      visit "/avo/resources/competitions/new"
+      fill_in "Name", with: "Сезон 7"
+      select "season", from: "Kind"
+      fill_in "Slug", with: "season-7"
+      fill_in "Position", with: "7"
+      click_on "Сохранить"
+
+      expect(Competition.find_by(name: "Сезон 7")).to have_attributes(
+        slug: "season-7",
+        position: 7
+      )
+    end
+  end
+
+  describe "edit" do
+    let!(:competition) { create(:competition, :season, name: "Сезон 6", slug: "season-6", position: 6) }
+
+    it "updates slug and position" do
+      visit "/avo/resources/competitions/#{competition.slug}/edit"
+      fill_in "Slug", with: "season-6-updated"
+      fill_in "Position", with: "10"
+      click_on "Сохранить"
+
+      expect(competition.reload).to have_attributes(
+        slug: "season-6-updated",
+        position: 10
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `slug` and `position` fields to Avo Competition resource so admins can manage competitions properly
- Add `Avo::CompetitionsController` (required for Avo resource routes)
- Add acceptance specs for competition create and edit in admin

## Test plan
- [x] 2 acceptance specs pass (create with slug/position, edit slug/position)
- [x] 869 total specs pass
- [x] Rubocop clean

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)