### PR TITLE
239: Add competition association and scope to News model

### DIFF
--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -1,5 +1,6 @@
 class News < ApplicationRecord
   belongs_to :author, class_name: "User"
+  belongs_to :competition, optional: true
   belongs_to :game, optional: true
 
   has_many :taggings, as: :taggable, dependent: :destroy
@@ -19,6 +20,7 @@ class News < ApplicationRecord
 
   scope :recent, -> { order(Arel.sql("published_at IS NULL, published_at DESC, id DESC")) }
   scope :for_game, ->(game) { where(game:) }
+  scope :for_competition, ->(competition) { where(competition: competition) }
   scope :for_series, ->(season, series) { where(season: season, series: series) }
   scope :by_author, ->(user) { where(author: user) }
 

--- a/spec/models/news_spec.rb
+++ b/spec/models/news_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe News, type: :model do
   describe 'associations' do
     it { is_expected.to belong_to(:author).class_name("User") }
     it { is_expected.to belong_to(:game).optional }
+    it { is_expected.to belong_to(:competition).optional }
     it { is_expected.to have_many(:taggings).dependent(:destroy) }
     it { is_expected.to have_many(:tags).through(:taggings) }
     it { is_expected.to have_rich_text(:content) }
@@ -69,6 +70,21 @@ RSpec.describe News, type: :model do
       result = described_class.for_series(1, 2)
       expect(result).to include(linked)
       expect(result).not_to include(other_series, unlinked)
+    end
+  end
+
+  describe '.for_competition' do
+    let_it_be(:competition) { create(:competition, :series) }
+    let_it_be(:other_competition) { create(:competition, :series) }
+    let_it_be(:author) { create(:user) }
+    let_it_be(:linked) { create(:news, author:, competition: competition) }
+    let_it_be(:other) { create(:news, author:, competition: other_competition) }
+    let_it_be(:unlinked) { create(:news, author:) }
+
+    it 'returns news for the given competition' do
+      result = described_class.for_competition(competition)
+      expect(result).to include(linked)
+      expect(result).not_to include(other, unlinked)
     end
   end
 


### PR DESCRIPTION
## Summary
- Add `belongs_to :competition, optional: true` to News model
- Add `for_competition` scope to filter news by competition
- Specs for association and scope

Closes #239

## Mutation Testing
- Evilution: 100% (4/4 mutants killed)
- Mutant: 100% (15/15 mutants killed)
- Additional mutants caught by mutant only: 0

## Test plan
- [x] Association spec passes
- [x] `for_competition` scope returns correct results
- [x] All existing news specs still pass
- [x] Rubocop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)