### PR TITLE
208: Process Telegram message background job

### DIFF
--- a/app/jobs/process_telegram_webhook_job.rb
+++ b/app/jobs/process_telegram_webhook_job.rb
@@ -7,9 +7,10 @@ class ProcessTelegramWebhookJob < ApplicationJob
     parsed = Telegram::MessageParser.call(payload)
     return if parsed.nil?
     return unless parsed.news?
-    return unless TelegramAuthor.whitelisted?(parsed.from_id)
+    return if parsed.text.blank?
 
     author = TelegramAuthor.find_by_telegram_user_id(parsed.from_id)
+    return if author.nil?
     return if author.user.nil?
 
     News.create!(

--- a/spec/jobs/process_telegram_webhook_job_spec.rb
+++ b/spec/jobs/process_telegram_webhook_job_spec.rb
@@ -106,6 +106,40 @@ RSpec.describe ProcessTelegramWebhookJob do
       end
     end
 
+    context "when message text is only the news tag" do
+      let(:payload) do
+        {
+          "update_id" => 7,
+          "message" => {
+            "text" => "#news",
+            "from" => { "id" => 12345, "username" => "reporter", "first_name" => "Alex" },
+            "chat" => { "id" => -100123 }
+          }
+        }
+      end
+
+      it "does not create a news article" do
+        expect { described_class.new.perform(payload) }.not_to change(News, :count)
+      end
+    end
+
+    context "when message text is news tag with only whitespace" do
+      let(:payload) do
+        {
+          "update_id" => 8,
+          "message" => {
+            "text" => "#news   ",
+            "from" => { "id" => 12345, "username" => "reporter", "first_name" => "Alex" },
+            "chat" => { "id" => -100123 }
+          }
+        }
+      end
+
+      it "does not create a news article" do
+        expect { described_class.new.perform(payload) }.not_to change(News, :count)
+      end
+    end
+
     context "when message title would be too long" do
       let(:payload) do
         {


### PR DESCRIPTION
## Summary
- Implement `ProcessTelegramWebhookJob#perform` to process incoming Telegram messages
- Parses message, checks whitelist + news tag, creates draft News article
- Skips when sender not whitelisted, no news tag, or telegram author has no linked user
- Truncates title to 255 chars for long messages

Closes #208

## Mutation Testing
- Evilution: 100% (27/27 mutants killed) — v0.5.0 with parallel execution, auto spec targeting, clean source
- Mutant: 98.92% (92/93 killed, 1 DB-default equivalent)
- Additional mutants caught by mutant only: 0

## Test plan
- [x] Creates draft news when whitelisted sender sends #news message
- [x] Sets correct title, content, author, and draft status
- [x] Skips when sender not whitelisted
- [x] Skips when no news tag
- [x] Skips when no message in payload
- [x] Skips when telegram author has no linked user
- [x] Truncates long titles
- [x] Full suite passes (857 examples, 0 failures)
- [x] Rubocop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)