### PR TITLE
252: Complete Avo Competition resource with all fields

### DIFF
--- a/app/avo/resources/competition.rb
+++ b/app/avo/resources/competition.rb
@@ -11,6 +11,10 @@ class Avo::Resources::Competition < Avo::BaseResource
     field :kind, as: :select, enum: ::Competition.kinds
     field :position, as: :number
     field :parent, as: :belongs_to, required: false
+    field :started_on, as: :date
+    field :ended_on, as: :date
+    field :featured, as: :boolean
+    field :children, as: :has_many
     field :games, as: :has_many
   end
 end

--- a/spec/avo/resources/competition_spec.rb
+++ b/spec/avo/resources/competition_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Avo::Resources::Competition do
+  subject(:resource) { described_class.new(record: competition, view: :index) }
+
+  let_it_be(:competition) { create(:competition, :season) }
+
+  before { resource.detect_fields }
+
+  let(:items) { resource.items }
+
+  describe "fields" do
+    it "includes name as text" do
+      field = items.find { |f| f.id == :name }
+
+      expect(field).to be_a(Avo::Fields::TextField)
+    end
+
+    it "includes slug as text" do
+      field = items.find { |f| f.id == :slug }
+
+      expect(field).to be_a(Avo::Fields::TextField)
+    end
+
+    it "includes kind as select" do
+      field = items.find { |f| f.id == :kind }
+
+      expect(field).to be_a(Avo::Fields::SelectField)
+    end
+
+    it "includes position as number" do
+      field = items.find { |f| f.id == :position }
+
+      expect(field).to be_a(Avo::Fields::NumberField)
+    end
+
+    it "includes parent as optional belongs_to" do
+      field = items.find { |f| f.id == :parent }
+
+      expect(field).to be_a(Avo::Fields::BelongsToField)
+      expect(field.required).to be(false)
+    end
+
+    it "includes started_on as date" do
+      field = items.find { |f| f.id == :started_on }
+
+      expect(field).to be_a(Avo::Fields::DateField)
+    end
+
+    it "includes ended_on as date" do
+      field = items.find { |f| f.id == :ended_on }
+
+      expect(field).to be_a(Avo::Fields::DateField)
+    end
+
+    it "includes featured as boolean" do
+      field = items.find { |f| f.id == :featured }
+
+      expect(field).to be_a(Avo::Fields::BooleanField)
+    end
+
+    it "includes children as has_many" do
+      field = items.find { |f| f.id == :children }
+
+      expect(field).to be_a(Avo::Fields::HasManyField)
+    end
+
+    it "includes games as has_many" do
+      field = items.find { |f| f.id == :games }
+
+      expect(field).to be_a(Avo::Fields::HasManyField)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add missing fields to Avo Competition resource: `started_on`, `ended_on`, `featured` (boolean), `children` (has_many)
- Add resource spec verifying all field types and associations

Closes #252

## Mutation testing
No `def` methods to mutate — Avo resource is purely declarative DSL.

## Test plan
- [x] Avo resource spec passes (10 examples)
- [x] Full suite passes (963 examples)
- [ ] Verify Competition CRUD in Avo admin UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)