### PR TITLE
351: Remove legacy season/series columns from news table

### DIFF
--- a/app/controllers/admin/news_controller.rb
+++ b/app/controllers/admin/news_controller.rb
@@ -85,6 +85,6 @@ class Admin::NewsController < ApplicationController
   end
 
   def news_params
-    params.require(:news).permit(:title, :content, :game_id, :season, :series)
+    params.require(:news).permit(:title, :content, :game_id)
   end
 end

--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -14,15 +14,9 @@ class News < ApplicationRecord
   validates :title, presence: true
   validates :status, presence: true
 
-  validates :series, presence: true, if: -> { season.present? }
-  validates :season, presence: true, if: -> { series.present? }
-  validates :season, numericality: { only_integer: true }, allow_nil: true
-  validates :series, numericality: { only_integer: true }, allow_nil: true
-
   scope :recent, -> { order(Arel.sql("published_at IS NULL, published_at DESC, id DESC")) }
   scope :for_game, ->(game) { where(game:) }
   scope :for_competition, ->(competition) { where(competition: competition) }
-  scope :for_series, ->(season, series) { where(season: season, series: series) }
   scope :by_author, ->(user) { where(author: user) }
   scope :mentioning_player, ->(player) {
     published

--- a/app/views/admin/news/_form.html.erb
+++ b/app/views/admin/news/_form.html.erb
@@ -23,16 +23,6 @@
     </div>
 
     <div class="flex flex-col sm:flex-row items-start px-4 py-3 gap-2">
-      <%= f.label :season, t("admin_news.form.season"), class: "w-40 font-semibold text-sm text-right pt-2" %>
-      <%= f.number_field :season, class: "w-full border border-gray-300 rounded-md px-3 py-2 text-sm", min: 1 %>
-    </div>
-
-    <div class="flex flex-col sm:flex-row items-start px-4 py-3 gap-2">
-      <%= f.label :series, t("admin_news.form.series"), class: "w-40 font-semibold text-sm text-right pt-2" %>
-      <%= f.number_field :series, class: "w-full border border-gray-300 rounded-md px-3 py-2 text-sm", min: 1 %>
-    </div>
-
-    <div class="flex flex-col sm:flex-row items-start px-4 py-3 gap-2">
       <%= f.label :game_id, t("admin_news.form.game"), class: "w-40 font-semibold text-sm text-right pt-2" %>
       <%= f.select :game_id,
             options_from_collection_for_select(@games, :id, :full_name, f.object.game_id),

--- a/app/views/admin/news/show.html.erb
+++ b/app/views/admin/news/show.html.erb
@@ -13,9 +13,6 @@
 
   <div class="text-sm text-gray-500 mb-4">
     <%= t("admin_news.show.by_author", author: @news.author.email) %>
-    <% if @news.season && @news.series %>
-      · <%= t("admin_news.show.linked_series", season: @news.season, series: @news.series) %>
-    <% end %>
     <% if @news.game %>
       · <%= t("admin_news.show.linked_game", game: @news.game.full_name) %>
     <% end %>

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -171,15 +171,12 @@ ru:
     show:
       back: "← К списку новостей"
       by_author: "Автор: %{author}"
-      linked_series: "Сезон %{season}, Серия %{series}"
       linked_game: "Игра: %{game}"
       edit: "Редактировать"
       publish: "Опубликовать"
       delete: "Удалить"
       delete_confirm: "Вы уверены, что хотите удалить эту новость?"
     form:
-      season: "Сезон"
-      series: "Серия"
       game: "Игра"
       submit_create: "Создать"
       submit_update: "Сохранить"

--- a/db/migrate/20260320182818_remove_season_series_from_news.rb
+++ b/db/migrate/20260320182818_remove_season_series_from_news.rb
@@ -1,0 +1,7 @@
+class RemoveSeasonSeriesFromNews < ActiveRecord::Migration[8.1]
+  def change
+    remove_index :news, [ :season, :series ], name: "index_news_on_season_and_series"
+    remove_column :news, :season, :integer
+    remove_column :news, :series, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_20_173402) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_20_182818) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -123,8 +123,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_20_173402) do
     t.datetime "created_at", null: false
     t.integer "game_id"
     t.datetime "published_at"
-    t.integer "season"
-    t.integer "series"
     t.string "status", default: "draft", null: false
     t.string "title", null: false
     t.datetime "updated_at", null: false
@@ -132,7 +130,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_20_173402) do
     t.index ["competition_id"], name: "index_news_on_competition_id"
     t.index ["game_id"], name: "index_news_on_game_id"
     t.index ["published_at"], name: "index_news_on_published_at"
-    t.index ["season", "series"], name: "index_news_on_season_and_series"
   end
 
   create_table "player_awards", force: :cascade do |t|

--- a/spec/models/news_spec.rb
+++ b/spec/models/news_spec.rb
@@ -14,27 +14,6 @@ RSpec.describe News, type: :model do
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:status) }
     it { is_expected.to define_enum_for(:status).with_values(draft: "draft", published: "published").backed_by_column_of_type(:string) }
-
-    context "when season is present" do
-      subject { build(:news, season: 1, series: nil) }
-
-      it { is_expected.to validate_presence_of(:series) }
-    end
-
-    context "when series is present" do
-      subject { build(:news, season: nil, series: 1) }
-
-      it { is_expected.to validate_presence_of(:season) }
-    end
-
-    context "when both are blank" do
-      subject { build(:news, season: nil, series: nil) }
-
-      it { is_expected.to be_valid }
-    end
-
-    it { is_expected.to validate_numericality_of(:season).only_integer.allow_nil }
-    it { is_expected.to validate_numericality_of(:series).only_integer.allow_nil }
   end
 
   describe '.recent' do
@@ -57,19 +36,6 @@ RSpec.describe News, type: :model do
     it 'returns news for the given game' do
       expect(described_class.for_game(game)).to include(linked)
       expect(described_class.for_game(game)).not_to include(unlinked)
-    end
-  end
-
-  describe '.for_series' do
-    let_it_be(:author) { create(:user) }
-    let_it_be(:linked) { create(:news, author:, season: 1, series: 2) }
-    let_it_be(:other_series) { create(:news, author:, season: 1, series: 3) }
-    let_it_be(:unlinked) { create(:news, author:) }
-
-    it 'returns news for the given season and series' do
-      result = described_class.for_series(1, 2)
-      expect(result).to include(linked)
-      expect(result).not_to include(other_series, unlinked)
     end
   end
 

--- a/spec/requests/admin/news_spec.rb
+++ b/spec/requests/admin/news_spec.rb
@@ -145,17 +145,6 @@ RSpec.describe "Admin::News" do
         end
       end
 
-      context "with series params" do
-        let(:series_params) { { news: { title: "Series News", content: "Content", season: 1, series: 2 } } }
-
-        it "creates a news article linked to a series in a season" do
-          post admin_news_index_path, params: series_params
-          article = News.last
-          expect(article.season).to eq(1)
-          expect(article.series).to eq(2)
-        end
-      end
-
       context "with invalid params" do
         let(:invalid_params) { { news: { title: "" } } }
 
@@ -280,15 +269,6 @@ RSpec.describe "Admin::News" do
         it "redirects to show" do
           patch admin_news_path(article), params: { news: { title: "Updated Title" } }
           expect(response).to redirect_to(admin_news_path(article))
-        end
-      end
-
-      context "with series params" do
-        it "updates the season/series association" do
-          patch admin_news_path(article), params: { news: { season: 3, series: 5 } }
-          article.reload
-          expect(article.season).to eq(3)
-          expect(article.series).to eq(5)
         end
       end
 


### PR DESCRIPTION
## Summary
- Drop `season` and `series` integer columns and composite index from `news` table
- Remove season/series validations and `for_series` scope from News model
- Remove season/series from admin news form fields, show view, permitted params, and i18n keys
- Clean up related specs (validation tests, scope test, series params contexts)

Closes #351

## Test plan
- [x] Full suite passes (955 examples, 0 failures)
- [x] Rubocop clean
- [ ] Verify admin news create/edit forms no longer show season/series fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)