### PR TITLE
376: Add grant associations and has_grant? to User model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,12 +4,18 @@ class User < ApplicationRecord
   belongs_to :player, optional: true
   has_many :player_claims, dependent: :destroy
   has_many :news, foreign_key: :author_id, inverse_of: :author, dependent: :restrict_with_exception
+  has_many :user_grants, dependent: :destroy
+  has_many :grants, through: :user_grants
 
   enum :role, { user: "user", judge: "judge", editor: "editor", admin: "admin" }
 
   validates :locale, inclusion: { in: I18n.available_locales.map(&:to_s) }
   validates :player_id, uniqueness: true, allow_nil: true
   validates :role, presence: true
+
+  def has_grant?(code)
+    grants.exists?(code: code)
+  end
 
   def can_manage_protocols?
     admin? || judge?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,12 +1,14 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe User, type: :model do
-  describe 'associations' do
+  describe "associations" do
     it { is_expected.to belong_to(:player).optional }
     it { is_expected.to have_many(:player_claims).dependent(:destroy) }
+    it { is_expected.to have_many(:user_grants).dependent(:destroy) }
+    it { is_expected.to have_many(:grants).through(:user_grants) }
   end
 
-  describe 'validations' do
+  describe "validations" do
     subject { build(:user) }
 
     it { is_expected.to validate_presence_of(:email) }
@@ -15,15 +17,15 @@ RSpec.describe User, type: :model do
     it { is_expected.to validate_inclusion_of(:locale).in_array(%w[ru en]) }
     it { is_expected.to validate_presence_of(:role) }
 
-    describe 'player_id uniqueness' do
+    describe "player_id uniqueness" do
       let(:player) { create(:player) }
 
-      it 'allows nil player_id' do
+      it "allows nil player_id" do
         user = build(:user, player_id: nil)
         expect(user).to be_valid
       end
 
-      it 'rejects duplicate player_id' do
+      it "rejects duplicate player_id" do
         create(:user, player: player)
         user = build(:user, player: player)
         expect(user).not_to be_valid
@@ -32,236 +34,268 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe 'role enum' do
-    it 'defines user, judge, editor, and admin roles' do
+  describe "role enum" do
+    it "defines user, judge, editor, and admin roles" do
       expect(described_class.roles).to eq("user" => "user", "judge" => "judge", "editor" => "editor", "admin" => "admin")
     end
 
-    it 'defaults to user role' do
+    it "defaults to user role" do
       user = build(:user)
       expect(user.role).to eq("user")
     end
   end
 
-  describe '#admin?' do
-    context 'when role is admin' do
+  describe "#has_grant?" do
+    let(:user) { create(:user) }
+    let(:admin_grant) { Grant.find_or_create_by!(code: "admin") }
+    let(:judge_grant) { Grant.find_or_create_by!(code: "judge") }
+
+    context "when user has the grant" do
+      before { create(:user_grant, user: user, grant: admin_grant) }
+
+      it "returns true" do
+        expect(user.has_grant?("admin")).to be true
+      end
+    end
+
+    context "when user does not have the grant" do
+      it "returns false" do
+        expect(user.has_grant?("admin")).to be false
+      end
+    end
+
+    context "when user has a different grant" do
+      before { create(:user_grant, user: user, grant: judge_grant) }
+
+      it "returns false for unassigned grant" do
+        expect(user.has_grant?("admin")).to be false
+      end
+
+      it "returns true for assigned grant" do
+        expect(user.has_grant?("judge")).to be true
+      end
+    end
+  end
+
+  describe "#admin?" do
+    context "when role is admin" do
       let(:user) { build(:user, :admin) }
 
-      it 'returns true' do
+      it "returns true" do
         expect(user.admin?).to be true
       end
     end
 
-    context 'when role is user' do
+    context "when role is user" do
       let(:user) { build(:user) }
 
-      it 'returns false' do
+      it "returns false" do
         expect(user.admin?).to be false
       end
     end
 
-    context 'when role is judge' do
+    context "when role is judge" do
       let(:user) { build(:user, :judge) }
 
-      it 'returns false' do
+      it "returns false" do
         expect(user.admin?).to be false
       end
     end
   end
 
-  describe '#judge?' do
-    context 'when role is judge' do
+  describe "#judge?" do
+    context "when role is judge" do
       let(:user) { build(:user, :judge) }
 
-      it 'returns true' do
+      it "returns true" do
         expect(user.judge?).to be true
       end
     end
 
-    context 'when role is user' do
+    context "when role is user" do
       let(:user) { build(:user) }
 
-      it 'returns false' do
+      it "returns false" do
         expect(user.judge?).to be false
       end
     end
 
-    context 'when role is admin' do
+    context "when role is admin" do
       let(:user) { build(:user, :admin) }
 
-      it 'returns false' do
+      it "returns false" do
         expect(user.judge?).to be false
       end
     end
   end
 
-  describe '#can_manage_protocols?' do
-    context 'when role is admin' do
+  describe "#can_manage_protocols?" do
+    context "when role is admin" do
       let(:user) { build(:user, :admin) }
 
-      it 'returns true' do
+      it "returns true" do
         expect(user.can_manage_protocols?).to be true
       end
     end
 
-    context 'when role is judge' do
+    context "when role is judge" do
       let(:user) { build(:user, :judge) }
 
-      it 'returns true' do
+      it "returns true" do
         expect(user.can_manage_protocols?).to be true
       end
     end
 
-    context 'when role is user' do
+    context "when role is user" do
       let(:user) { build(:user) }
 
-      it 'returns false' do
+      it "returns false" do
         expect(user.can_manage_protocols?).to be false
       end
     end
 
-    context 'when role is editor' do
+    context "when role is editor" do
       let(:user) { build(:user, :editor) }
 
-      it 'returns false' do
+      it "returns false" do
         expect(user.can_manage_protocols?).to be false
       end
     end
   end
 
-  describe '#can_manage_news?' do
-    context 'when role is admin' do
+  describe "#can_manage_news?" do
+    context "when role is admin" do
       let(:user) { build(:user, :admin) }
 
-      it 'returns true' do
+      it "returns true" do
         expect(user.can_manage_news?).to be true
       end
     end
 
-    context 'when role is editor' do
+    context "when role is editor" do
       let(:user) { build(:user, :editor) }
 
-      it 'returns true' do
+      it "returns true" do
         expect(user.can_manage_news?).to be true
       end
     end
 
-    context 'when role is user' do
+    context "when role is user" do
       let(:user) { build(:user) }
 
-      it 'returns false' do
+      it "returns false" do
         expect(user.can_manage_news?).to be false
       end
     end
 
-    context 'when role is judge' do
+    context "when role is judge" do
       let(:user) { build(:user, :judge) }
 
-      it 'returns false' do
+      it "returns false" do
         expect(user.can_manage_news?).to be false
       end
     end
   end
 
-  describe '#claimed_player?' do
-    context 'when user has a claimed player' do
+  describe "#claimed_player?" do
+    context "when user has a claimed player" do
       let(:player) { create(:player) }
       let(:user) { create(:user, player: player) }
 
-      it 'returns true' do
+      it "returns true" do
         expect(user.claimed_player?).to be true
       end
     end
 
-    context 'when user has no claimed player' do
+    context "when user has no claimed player" do
       let(:user) { build(:user) }
 
-      it 'returns false' do
+      it "returns false" do
         expect(user.claimed_player?).to be false
       end
     end
   end
 
-  describe '#pending_claim?' do
-    context 'when user has a pending claim' do
+  describe "#pending_claim?" do
+    context "when user has a pending claim" do
       let(:user) { create(:user) }
 
       before { create(:player_claim, user: user, status: "pending") }
 
-      it 'returns true' do
+      it "returns true" do
         expect(user.pending_claim?).to be true
       end
     end
 
-    context 'when user has no pending claim' do
+    context "when user has no pending claim" do
       let(:user) { create(:user) }
 
-      it 'returns false' do
+      it "returns false" do
         expect(user.pending_claim?).to be false
       end
     end
 
-    context 'when user has only non-pending claims' do
+    context "when user has only non-pending claims" do
       let(:user) { create(:user) }
 
       before { create(:player_claim, user: user, status: "rejected") }
 
-      it 'returns false' do
+      it "returns false" do
         expect(user.pending_claim?).to be false
       end
     end
   end
 
-  describe '#pending_dispute?' do
+  describe "#pending_dispute?" do
     let(:player) { create(:player) }
     let!(:owner) { create(:user, player: player) }
     let(:user) { create(:user) }
 
-    context 'when user has a pending dispute claim' do
+    context "when user has a pending dispute claim" do
       before { create(:player_claim, :dispute, user: user, player: player) }
 
-      it 'returns true' do
+      it "returns true" do
         expect(user.pending_dispute?).to be true
       end
     end
 
-    context 'when user has no pending dispute' do
-      it 'returns false' do
+    context "when user has no pending dispute" do
+      it "returns false" do
         expect(user.pending_dispute?).to be false
       end
     end
 
-    context 'when user has only non-pending dispute claims' do
+    context "when user has only non-pending dispute claims" do
       before { create(:player_claim, :dispute, user: user, player: player, status: "rejected") }
 
-      it 'returns false' do
+      it "returns false" do
         expect(user.pending_dispute?).to be false
       end
     end
   end
 
-  describe '#pending_claim_for' do
+  describe "#pending_claim_for" do
     let(:user) { create(:user) }
     let(:player) { create(:player) }
 
-    context 'when user has a pending claim for the player' do
+    context "when user has a pending claim for the player" do
       let!(:claim) { create(:player_claim, user: user, player: player, status: "pending") }
 
-      it 'returns the claim' do
+      it "returns the claim" do
         expect(user.pending_claim_for(player)).to eq(claim)
       end
     end
 
-    context 'when user has no pending claim for the player' do
-      it 'returns nil' do
+    context "when user has no pending claim for the player" do
+      it "returns nil" do
         expect(user.pending_claim_for(player)).to be_nil
       end
     end
 
-    context 'when user has a non-pending claim for the player' do
+    context "when user has a non-pending claim for the player" do
       before { create(:player_claim, user: user, player: player, status: "approved") }
 
-      it 'returns nil' do
+      it "returns nil" do
         expect(user.pending_claim_for(player)).to be_nil
       end
     end


### PR DESCRIPTION
## Summary
- Add `has_many :user_grants` and `has_many :grants, through: :user_grants` to User
- Add `has_grant?(code)` method to check if a user has a specific grant
- Existing role enum and predicate methods (`admin?`, `judge?`, etc.) remain unchanged — they will be migrated to use grants in subsequent PRs

## Mutation testing
- Mutant: 100% (12/12 killed on `User#has_grant?`)
- Evilution: 100% (5/5 killed on `User#has_grant?`)

## Test plan
- [x] User has_many user_grants (dependent destroy)
- [x] User has_many grants through user_grants
- [x] has_grant? returns true when user has the grant
- [x] has_grant? returns false when user does not have the grant
- [x] has_grant? returns false for unassigned grant, true for assigned
- [x] All existing User specs still pass (42 examples, 0 failures)

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)