### PR TITLE
167: Update authorization checks to use grant-based predicates

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,18 @@ class User < ApplicationRecord
     grants.exists?(code: code)
   end
 
+  def admin?
+    has_grant?("admin")
+  end
+
+  def judge?
+    has_grant?("judge")
+  end
+
+  def editor?
+    has_grant?("editor")
+  end
+
   def can_manage_protocols?
     admin? || judge?
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,4 +35,7 @@ if ENV["ADMIN_EMAIL"].present? && ENV["ADMIN_PASSWORD"].present?
   user.role = "admin"
   user.password = ENV["ADMIN_PASSWORD"] if user.new_record?
   user.save!
+
+  admin_grant = Grant.find_or_create_by!(code: "admin")
+  UserGrant.find_or_create_by!(user: user, grant: admin_grant)
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,14 +6,29 @@ FactoryBot.define do
 
     trait :admin do
       role { "admin" }
+
+      after(:create) do |user|
+        grant = Grant.find_or_create_by!(code: "admin")
+        create(:user_grant, user: user, grant: grant)
+      end
     end
 
     trait :judge do
       role { "judge" }
+
+      after(:create) do |user|
+        grant = Grant.find_or_create_by!(code: "judge")
+        create(:user_grant, user: user, grant: grant)
+      end
     end
 
     trait :editor do
       role { "editor" }
+
+      after(:create) do |user|
+        grant = Grant.find_or_create_by!(code: "editor")
+        create(:user_grant, user: user, grant: grant)
+      end
     end
   end
 end

--- a/spec/migrations/seed_grants_and_migrate_user_roles_spec.rb
+++ b/spec/migrations/seed_grants_and_migrate_user_roles_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe SeedGrantsAndMigrateUserRoles do
       let!(:regular_user) { create(:user) }
 
       it "creates user_grants matching each user's current role" do
+        UserGrant.delete_all
+        Grant.delete_all
         described_class.new.up
 
         expect(grant_code_for(admin_user)).to eq("admin")

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -78,24 +78,27 @@ RSpec.describe User, type: :model do
   end
 
   describe "#admin?" do
-    context "when role is admin" do
-      let(:user) { build(:user, :admin) }
+    let(:user) { create(:user) }
+    let(:admin_grant) { Grant.find_or_create_by!(code: "admin") }
+
+    context "when user has admin grant" do
+      before { create(:user_grant, user: user, grant: admin_grant) }
 
       it "returns true" do
         expect(user.admin?).to be true
       end
     end
 
-    context "when role is user" do
-      let(:user) { build(:user) }
-
+    context "when user has no admin grant" do
       it "returns false" do
         expect(user.admin?).to be false
       end
     end
 
-    context "when role is judge" do
-      let(:user) { build(:user, :judge) }
+    context "when user has a different grant" do
+      let(:judge_grant) { Grant.find_or_create_by!(code: "judge") }
+
+      before { create(:user_grant, user: user, grant: judge_grant) }
 
       it "returns false" do
         expect(user.admin?).to be false
@@ -104,24 +107,27 @@ RSpec.describe User, type: :model do
   end
 
   describe "#judge?" do
-    context "when role is judge" do
-      let(:user) { build(:user, :judge) }
+    let(:user) { create(:user) }
+    let(:judge_grant) { Grant.find_or_create_by!(code: "judge") }
+
+    context "when user has judge grant" do
+      before { create(:user_grant, user: user, grant: judge_grant) }
 
       it "returns true" do
         expect(user.judge?).to be true
       end
     end
 
-    context "when role is user" do
-      let(:user) { build(:user) }
-
+    context "when user has no judge grant" do
       it "returns false" do
         expect(user.judge?).to be false
       end
     end
 
-    context "when role is admin" do
-      let(:user) { build(:user, :admin) }
+    context "when user has a different grant" do
+      let(:admin_grant) { Grant.find_or_create_by!(code: "admin") }
+
+      before { create(:user_grant, user: user, grant: admin_grant) }
 
       it "returns false" do
         expect(user.judge?).to be false
@@ -129,33 +135,58 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "#editor?" do
+    let(:user) { create(:user) }
+    let(:editor_grant) { Grant.find_or_create_by!(code: "editor") }
+
+    context "when user has editor grant" do
+      before { create(:user_grant, user: user, grant: editor_grant) }
+
+      it "returns true" do
+        expect(user.editor?).to be true
+      end
+    end
+
+    context "when user has no editor grant" do
+      it "returns false" do
+        expect(user.editor?).to be false
+      end
+    end
+  end
+
   describe "#can_manage_protocols?" do
-    context "when role is admin" do
-      let(:user) { build(:user, :admin) }
+    let(:user) { create(:user) }
+
+    context "when user has admin grant" do
+      let(:admin_grant) { Grant.find_or_create_by!(code: "admin") }
+
+      before { create(:user_grant, user: user, grant: admin_grant) }
 
       it "returns true" do
         expect(user.can_manage_protocols?).to be true
       end
     end
 
-    context "when role is judge" do
-      let(:user) { build(:user, :judge) }
+    context "when user has judge grant" do
+      let(:judge_grant) { Grant.find_or_create_by!(code: "judge") }
+
+      before { create(:user_grant, user: user, grant: judge_grant) }
 
       it "returns true" do
         expect(user.can_manage_protocols?).to be true
       end
     end
 
-    context "when role is user" do
-      let(:user) { build(:user) }
-
+    context "when user has no grants" do
       it "returns false" do
         expect(user.can_manage_protocols?).to be false
       end
     end
 
-    context "when role is editor" do
-      let(:user) { build(:user, :editor) }
+    context "when user has editor grant" do
+      let(:editor_grant) { Grant.find_or_create_by!(code: "editor") }
+
+      before { create(:user_grant, user: user, grant: editor_grant) }
 
       it "returns false" do
         expect(user.can_manage_protocols?).to be false
@@ -164,32 +195,38 @@ RSpec.describe User, type: :model do
   end
 
   describe "#can_manage_news?" do
-    context "when role is admin" do
-      let(:user) { build(:user, :admin) }
+    let(:user) { create(:user) }
+
+    context "when user has admin grant" do
+      let(:admin_grant) { Grant.find_or_create_by!(code: "admin") }
+
+      before { create(:user_grant, user: user, grant: admin_grant) }
 
       it "returns true" do
         expect(user.can_manage_news?).to be true
       end
     end
 
-    context "when role is editor" do
-      let(:user) { build(:user, :editor) }
+    context "when user has editor grant" do
+      let(:editor_grant) { Grant.find_or_create_by!(code: "editor") }
+
+      before { create(:user_grant, user: user, grant: editor_grant) }
 
       it "returns true" do
         expect(user.can_manage_news?).to be true
       end
     end
 
-    context "when role is user" do
-      let(:user) { build(:user) }
-
+    context "when user has no grants" do
       it "returns false" do
         expect(user.can_manage_news?).to be false
       end
     end
 
-    context "when role is judge" do
-      let(:user) { build(:user, :judge) }
+    context "when user has judge grant" do
+      let(:judge_grant) { Grant.find_or_create_by!(code: "judge") }
+
+      before { create(:user_grant, user: user, grant: judge_grant) }
 
       it "returns false" do
         expect(user.can_manage_news?).to be false


### PR DESCRIPTION
## Summary
- Override enum-generated `admin?`, `judge?`, `editor?` methods on User to delegate to `has_grant?`, so all authorization checks (controllers, policies, views, routes) use the multi-grant system
- Update factory traits to create corresponding grants via `after(:create)` callbacks
- Update seeds to assign admin grant alongside the role
- Fix migration spec to handle factory-created grants before re-running migration

## Mutation testing
- Mutant: 100% (33/33 killed on `User#admin?`, `User#judge?`, `User#editor?`)
- Evilution: 100% (20/20 killed on `app/models/user.rb:16-30`)

## Test plan
- [x] `admin?` returns true only when user has admin grant
- [x] `judge?` returns true only when user has judge grant
- [x] `editor?` returns true only when user has editor grant
- [x] `can_manage_protocols?` works with grant-based admin/judge checks
- [x] `can_manage_news?` works with grant-based admin/editor checks
- [x] Full test suite passes (1040 examples, 0 failures)
- [x] Factory traits create grants so all existing controller/policy specs pass

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)