### PR TITLE
172: Drop legacy role column from users table

### DIFF
--- a/app/avo/resources/user.rb
+++ b/app/avo/resources/user.rb
@@ -8,7 +8,6 @@ class Avo::Resources::User < Avo::BaseResource
   def fields
     field :id, as: :id
     field :email, as: :text
-    field :role, as: :select, enum: ::User.roles, readonly: true, help: "Legacy field — use grants below"
     field :player, as: :belongs_to
     field :user_grants, as: :has_many
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,11 +7,8 @@ class User < ApplicationRecord
   has_many :user_grants, dependent: :destroy
   has_many :grants, through: :user_grants
 
-  enum :role, { user: "user", judge: "judge", editor: "editor", admin: "admin" }
-
   validates :locale, inclusion: { in: I18n.available_locales.map(&:to_s) }
   validates :player_id, uniqueness: true, allow_nil: true
-  validates :role, presence: true
 
   def has_grant?(code)
     grants.exists?(code: code)

--- a/app/services/notify_editors_about_draft_service.rb
+++ b/app/services/notify_editors_about_draft_service.rb
@@ -19,7 +19,7 @@ class NotifyEditorsAboutDraftService
 
   def recipients
     User
-      .where(role: %w[editor admin])
+      .joins(:grants).where(grants: { code: %w[editor admin] })
       .where(notify_on_news_draft: true)
       .where.not(id: @news.author_id)
   end

--- a/db/migrate/20260324105438_drop_role_from_users.rb
+++ b/db/migrate/20260324105438_drop_role_from_users.rb
@@ -1,0 +1,9 @@
+class DropRoleFromUsers < ActiveRecord::Migration[8.1]
+  def up
+    remove_column :users, :role
+  end
+
+  def down
+    add_column :users, :role, :string, null: false, default: "user"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_24_065136) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_24_105438) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -235,7 +235,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_24_065136) do
     t.datetime "remember_created_at"
     t.datetime "reset_password_sent_at"
     t.string "reset_password_token"
-    t.string "role", default: "user", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["player_id"], name: "index_users_on_player_id", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,7 +32,6 @@ raise "Missing feature toggle seeds: #{missing_keys.join(', ')}" if missing_keys
 # Admin user (set ADMIN_EMAIL and ADMIN_PASSWORD env vars)
 if ENV["ADMIN_EMAIL"].present? && ENV["ADMIN_PASSWORD"].present?
   user = User.find_or_initialize_by(email: ENV["ADMIN_EMAIL"])
-  user.role = "admin"
   user.password = ENV["ADMIN_PASSWORD"] if user.new_record?
   user.save!
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,8 +5,6 @@ FactoryBot.define do
     locale { "ru" }
 
     trait :admin do
-      role { "admin" }
-
       after(:create) do |user|
         grant = Grant.find_or_create_by!(code: "admin")
         create(:user_grant, user: user, grant: grant)
@@ -14,8 +12,6 @@ FactoryBot.define do
     end
 
     trait :judge do
-      role { "judge" }
-
       after(:create) do |user|
         grant = Grant.find_or_create_by!(code: "judge")
         create(:user_grant, user: user, grant: grant)
@@ -23,8 +19,6 @@ FactoryBot.define do
     end
 
     trait :editor do
-      role { "editor" }
-
       after(:create) do |user|
         grant = Grant.find_or_create_by!(code: "editor")
         create(:user_grant, user: user, grant: grant)

--- a/spec/migrations/seed_grants_and_migrate_user_roles_spec.rb
+++ b/spec/migrations/seed_grants_and_migrate_user_roles_spec.rb
@@ -10,26 +10,6 @@ RSpec.describe SeedGrantsAndMigrateUserRoles do
         expect(Grant.pluck(:code)).to contain_exactly("user", "judge", "editor", "admin")
       end
     end
-
-    context "when users have roles" do
-      let!(:admin_user) { create(:user, :admin) }
-      let!(:judge_user) { create(:user, :judge) }
-      let!(:regular_user) { create(:user) }
-
-      it "creates user_grants matching each user's current role" do
-        UserGrant.delete_all
-        Grant.delete_all
-        described_class.new.up
-
-        expect(grant_code_for(admin_user)).to eq("admin")
-        expect(grant_code_for(judge_user)).to eq("judge")
-        expect(grant_code_for(regular_user)).to eq("user")
-      end
-
-      def grant_code_for(user)
-        UserGrant.joins(:grant).where(user: user).pick("grants.code")
-      end
-    end
   end
 
   describe "#down" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe User, type: :model do
     it { is_expected.to validate_uniqueness_of(:email).case_insensitive }
     it { is_expected.to validate_presence_of(:password) }
     it { is_expected.to validate_inclusion_of(:locale).in_array(%w[ru en]) }
-    it { is_expected.to validate_presence_of(:role) }
+
 
     describe "player_id uniqueness" do
       let(:player) { create(:player) }
@@ -31,17 +31,6 @@ RSpec.describe User, type: :model do
         expect(user).not_to be_valid
         expect(user.errors.where(:player_id, :taken)).to be_present
       end
-    end
-  end
-
-  describe "role enum" do
-    it "defines user, judge, editor, and admin roles" do
-      expect(described_class.roles).to eq("user" => "user", "judge" => "judge", "editor" => "editor", "admin" => "admin")
-    end
-
-    it "defaults to user role" do
-      user = build(:user)
-      expect(user.role).to eq("user")
     end
   end
 


### PR DESCRIPTION
## Summary
- Drop `role` column from `users` table via migration
- Remove `enum :role` declaration and `validates :role` from User model
- Update `NotifyEditorsAboutDraftService` to query via `grants` join instead of `role` column
- Remove role field from Avo User resource, seeds, factory traits
- Remove role enum specs and untestable migration spec (migration depends on removed column)

## Mutation testing
- Mutant: 100% real coverage (82/82 killed, 4 neutral due to pre-existing test infra issue)
- Evilution: 100% (on `NotifyEditorsAboutDraftService#recipients`)

## Test plan
- [x] Full test suite passes (1050 examples, 0 failures)
- [x] Rubocop clean
- [x] `NotifyEditorsAboutDraftService` correctly queries editors/admins via grants join
- [x] User model works without role column

Closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)