### PR TITLE
175: Register subscriber grant

### DIFF
--- a/app/models/grant.rb
+++ b/app/models/grant.rb
@@ -1,5 +1,5 @@
 class Grant < ApplicationRecord
-  CODES = %w[user judge editor admin].freeze
+  CODES = %w[user judge editor admin subscriber].freeze
 
   has_many :user_grants, dependent: :destroy
   has_many :users, through: :user_grants

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,10 @@ class User < ApplicationRecord
     has_grant?("editor")
   end
 
+  def subscriber?
+    has_grant?("subscriber")
+  end
+
   def can_manage_protocols?
     admin? || judge?
   end

--- a/db/migrate/20260324111830_seed_subscriber_grant.rb
+++ b/db/migrate/20260324111830_seed_subscriber_grant.rb
@@ -1,0 +1,9 @@
+class SeedSubscriberGrant < ActiveRecord::Migration[8.1]
+  def up
+    Grant.find_or_create_by!(code: "subscriber")
+  end
+
+  def down
+    Grant.find_by(code: "subscriber")&.destroy!
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_24_105438) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_24_111830) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -24,5 +24,12 @@ FactoryBot.define do
         create(:user_grant, user: user, grant: grant)
       end
     end
+
+    trait :subscriber do
+      after(:create) do |user|
+        grant = Grant.find_or_create_by!(code: "subscriber")
+        create(:user_grant, user: user, grant: grant)
+      end
+    end
   end
 end

--- a/spec/models/grant_spec.rb
+++ b/spec/models/grant_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Grant, type: :model do
 
   describe "CODES" do
     it "includes all expected grant codes" do
-      expect(Grant::CODES).to contain_exactly("user", "judge", "editor", "admin")
+      expect(Grant::CODES).to contain_exactly("user", "judge", "editor", "admin", "subscriber")
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -143,6 +143,25 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "#subscriber?" do
+    let(:user) { create(:user) }
+    let(:subscriber_grant) { Grant.find_or_create_by!(code: "subscriber") }
+
+    context "when user has subscriber grant" do
+      before { create(:user_grant, user: user, grant: subscriber_grant) }
+
+      it "returns true" do
+        expect(user.subscriber?).to be true
+      end
+    end
+
+    context "when user has no subscriber grant" do
+      it "returns false" do
+        expect(user.subscriber?).to be false
+      end
+    end
+  end
+
   describe "#can_manage_protocols?" do
     let(:user) { create(:user) }
 


### PR DESCRIPTION
## Summary
- Add `subscriber` to `Grant::CODES`
- Add `User#subscriber?` predicate delegating to `has_grant?`
- Seed subscriber grant via migration
- Add `:subscriber` factory trait for tests

## Mutation testing
- Mutant: 100% (11/11 killed on `User#subscriber?`)
- Evilution: 100% on `User#subscriber?`

## Test plan
- [x] Grant::CODES includes "subscriber"
- [x] `subscriber?` returns true/false based on grant
- [x] Full test suite passes (1052 examples, 0 failures)
- [x] Rubocop clean

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)