### PR TITLE
163: Add RequireSubscriber concern for subscriber-only sections

### DIFF
--- a/app/controllers/concerns/require_subscriber.rb
+++ b/app/controllers/concerns/require_subscriber.rb
@@ -1,0 +1,14 @@
+module RequireSubscriber
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :authenticate_user!
+    before_action :require_subscriber_grant
+  end
+
+  private
+
+  def require_subscriber_grant
+    head :not_found unless current_user.subscriber? || current_user.admin?
+  end
+end

--- a/spec/controllers/concerns/require_subscriber_spec.rb
+++ b/spec/controllers/concerns/require_subscriber_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe RequireSubscriber do
+  let(:controller_class) do
+    Class.new(ApplicationController) do
+      include RequireSubscriber
+
+      def index
+        head :ok
+      end
+    end
+  end
+
+  let(:controller) { controller_class.new }
+
+  describe "#require_subscriber_grant" do
+    before do
+      allow(controller).to receive(:head)
+    end
+
+    context "when user has subscriber grant" do
+      let(:user) { create(:user, :subscriber) }
+
+      before { allow(controller).to receive(:current_user).and_return(user) }
+
+      it "does not block access" do
+        controller.send(:require_subscriber_grant)
+        expect(controller).not_to have_received(:head)
+      end
+    end
+
+    context "when user has admin grant" do
+      let(:user) { create(:user, :admin) }
+
+      before { allow(controller).to receive(:current_user).and_return(user) }
+
+      it "does not block access" do
+        controller.send(:require_subscriber_grant)
+        expect(controller).not_to have_received(:head)
+      end
+    end
+
+    context "when user has no subscriber or admin grant" do
+      let(:user) { create(:user) }
+
+      before { allow(controller).to receive(:current_user).and_return(user) }
+
+      it "returns not found" do
+        controller.send(:require_subscriber_grant)
+        expect(controller).to have_received(:head).with(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `RequireSubscriber` controller concern with `before_action` gate
- Requires `subscriber` or `admin` grant; returns 404 otherwise
- Authenticates user via Devise before checking grants

## Mutation testing
- Mutant: 100% (28/28 killed)
- Evilution: 100%

## Test plan
- [x] Subscriber grant holders can access
- [x] Admin grant holders can access
- [x] Users without subscriber/admin grant get 404
- [x] Full test suite passes (1055 examples, 0 failures)

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)