### PR TITLE
168: Avo Episode resource with audio upload and search

### DIFF
--- a/app/avo/resources/episode.rb
+++ b/app/avo/resources/episode.rb
@@ -1,15 +1,17 @@
 class Avo::Resources::Episode < Avo::BaseResource
-  # self.includes = []
-  # self.attachments = []
-  # self.search = {
-  #   query: -> { query.ransack(id_eq: q, m: "or").result(distinct: false) }
-  # }
+  self.title = :title
+  self.default_view_type = :table
+
+  self.search = {
+    query: -> { query.where("title ILIKE ?", "%#{params[:q]}%") }
+  }
 
   def fields
     field :id, as: :id
-    field :title, as: :text
+    field :title, as: :text, required: true, sortable: true
     field :description, as: :textarea
     field :status, as: :select, enum: ::Episode.statuses
-    field :published_at, as: :date_time
+    field :published_at, as: :date_time, sortable: true
+    field :audio, as: :file
   end
 end

--- a/spec/requests/avo_resources_spec.rb
+++ b/spec/requests/avo_resources_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Avo admin resources" do
   let_it_be(:game_participation) { create(:game_participation, game: game, player: player) }
   let_it_be(:player_award) { create(:player_award, player: player, award: award) }
   let_it_be(:feature_toggle) { create(:feature_toggle) }
+  let_it_be(:episode) { create(:episode) }
   let_it_be(:player_claim) { create(:player_claim, user: non_admin, player: player) }
   let_it_be(:claimed_player) { create(:player, user: create(:user)) }
   let_it_be(:dispute_claim) { create(:player_claim, :dispute, user: admin, player: claimed_player) }
@@ -53,7 +54,8 @@ RSpec.describe "Avo admin resources" do
     "player_awards" => :player_award,
     "users" => :admin,
     "feature_toggles" => :feature_toggle,
-    "player_claims" => :player_claim
+    "player_claims" => :player_claim,
+    "episodes" => :episode
   }.each do |resource_name, record_method|
     describe resource_name do
       describe "GET /avo/resources/#{resource_name}" do


### PR DESCRIPTION
## Summary
- Update Avo Episode resource: title search, audio file upload field, sortable title/published_at
- Status field uses enum select (draft/published)
- Add episodes to shared Avo resources access spec

## Test plan
- [x] Avo episodes index/show requires admin (tested via shared examples)
- [x] Non-admin gets 404, unauthenticated redirects to sign in
- [x] Full test suite passes (1070 examples, 0 failures)

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)