### PR TITLE
173: Avo Playlist resource with episode ordering

### DIFF
--- a/app/avo/resources/playlist.rb
+++ b/app/avo/resources/playlist.rb
@@ -1,12 +1,14 @@
 class Avo::Resources::Playlist < Avo::BaseResource
-  # self.includes = []
-  # self.attachments = []
-  # self.search = {
-  #   query: -> { query.ransack(id_eq: q, m: "or").result(distinct: false) }
-  # }
+  self.title = :title
+  self.default_view_type = :table
+
+  self.search = {
+    query: -> { query.where("title ILIKE ?", "%#{params[:q]}%") }
+  }
 
   def fields
     field :id, as: :id
-    field :title, as: :text
+    field :title, as: :text, required: true, sortable: true
+    field :playlist_episodes, as: :has_many
   end
 end

--- a/app/avo/resources/playlist_episode.rb
+++ b/app/avo/resources/playlist_episode.rb
@@ -1,14 +1,8 @@
 class Avo::Resources::PlaylistEpisode < Avo::BaseResource
-  # self.includes = []
-  # self.attachments = []
-  # self.search = {
-  #   query: -> { query.ransack(id_eq: q, m: "or").result(distinct: false) }
-  # }
-
   def fields
     field :id, as: :id
     field :playlist, as: :belongs_to
     field :episode, as: :belongs_to
-    field :position, as: :number
+    field :position, as: :number, required: true, sortable: true
   end
 end

--- a/spec/requests/avo_resources_spec.rb
+++ b/spec/requests/avo_resources_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe "Avo admin resources" do
   let_it_be(:player_award) { create(:player_award, player: player, award: award) }
   let_it_be(:feature_toggle) { create(:feature_toggle) }
   let_it_be(:episode) { create(:episode) }
+  let_it_be(:playlist) { create(:playlist) }
+  let_it_be(:playlist_episode) { create(:playlist_episode, playlist: playlist, episode: episode) }
   let_it_be(:player_claim) { create(:player_claim, user: non_admin, player: player) }
   let_it_be(:claimed_player) { create(:player, user: create(:user)) }
   let_it_be(:dispute_claim) { create(:player_claim, :dispute, user: admin, player: claimed_player) }
@@ -55,7 +57,9 @@ RSpec.describe "Avo admin resources" do
     "users" => :admin,
     "feature_toggles" => :feature_toggle,
     "player_claims" => :player_claim,
-    "episodes" => :episode
+    "episodes" => :episode,
+    "playlists" => :playlist,
+    "playlist_episodes" => :playlist_episode
   }.each do |resource_name, record_method|
     describe resource_name do
       describe "GET /avo/resources/#{resource_name}" do


### PR DESCRIPTION
## Summary
- Update Avo Playlist resource: title search, sortable title, `playlist_episodes` has_many for managing episodes
- Update Avo PlaylistEpisode resource: sortable position field, required marker
- Add playlists and playlist_episodes to shared Avo resources access spec

## Test plan
- [x] Avo playlists index/show requires admin
- [x] Avo playlist_episodes index/show requires admin
- [x] Full test suite passes (1093 examples, 0 failures)

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)