### PR TITLE
183: Add podcast link to main navigation for subscribers

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -57,6 +57,12 @@
                 class: "block text-gray-300 hover:text-white transition-colors" %>
         </li>
         <% if user_signed_in? %>
+          <% if current_user.subscriber? || current_user.admin? %>
+            <li>
+              <%= link_to t("nav.podcast"), podcast_episodes_path,
+                    class: "block text-gray-300 hover:text-white transition-colors" %>
+            </li>
+          <% end %>
           <% if current_user.can_manage_protocols? %>
             <li>
               <%= link_to t("nav.protocols"), new_judge_protocol_path,
@@ -128,6 +134,12 @@
                       class: "block hover:text-white transition-colors" %>
               </li>
               <% if user_signed_in? %>
+                <% if current_user.subscriber? || current_user.admin? %>
+                  <li>
+                    <%= link_to t("nav.podcast"), podcast_episodes_path,
+                          class: "block hover:text-white transition-colors" %>
+                  </li>
+                <% end %>
                 <% if current_user.can_manage_protocols? %>
                   <li>
                     <%= link_to t("nav.protocols"), new_judge_protocol_path,

--- a/spec/requests/navigation_spec.rb
+++ b/spec/requests/navigation_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe "Navigation" do
+  let_it_be(:subscriber) { create(:user, :subscriber) }
+  let_it_be(:admin) { create(:user, :admin) }
+  let_it_be(:user) { create(:user) }
+
+  describe "podcast link" do
+    context "when signed in as subscriber" do
+      before { sign_in subscriber }
+
+      it "displays the podcast link" do
+        get "/news"
+        expect(response.body).to include(podcast_episodes_path)
+      end
+    end
+
+    context "when signed in as admin" do
+      before { sign_in admin }
+
+      it "displays the podcast link" do
+        get "/news"
+        expect(response.body).to include(podcast_episodes_path)
+      end
+    end
+
+    context "when signed in as regular user" do
+      before { sign_in user }
+
+      it "does not display the podcast link" do
+        get "/news"
+        expect(response.body).not_to include(podcast_episodes_path)
+      end
+    end
+
+    context "when not signed in" do
+      it "does not display the podcast link" do
+        get "/news"
+        expect(response.body).not_to include(podcast_episodes_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add podcast link to both mobile and desktop navigation menus
- Visible only to users with subscriber or admin grants
- Placed after News link, before admin-only links
- Uses existing `nav.podcast` i18n key (en: "Podcast", ru: "Подкаст")

Closes #424

**Beads issue:** vanilla-mafia-183

## Test plan

- [x] Navigation specs pass (4 examples: subscriber sees link, admin sees link, regular user doesn't, anonymous doesn't)

🤖 Generated with [Claude Code](https://claude.com/claude-code)