### PR TITLE
185: Add provider and uid columns to users table

### DIFF
--- a/db/migrate/20260325042809_add_omniauth_to_users.rb
+++ b/db/migrate/20260325042809_add_omniauth_to_users.rb
@@ -1,0 +1,7 @@
+class AddOmniauthToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+    add_index :users, [ :provider, :uid ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_24_154808) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_25_042809) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -270,12 +270,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_24_154808) do
     t.string "locale", default: "ru", null: false
     t.boolean "notify_on_news_draft", default: true, null: false
     t.integer "player_id"
+    t.string "provider"
     t.datetime "remember_created_at"
     t.datetime "reset_password_sent_at"
     t.string "reset_password_token"
+    t.string "uid"
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["player_id"], name: "index_users_on_player_id", unique: true
+    t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_many(:grants).through(:user_grants) }
   end
 
+  describe "database columns" do
+    it { is_expected.to have_db_column(:provider).of_type(:string) }
+    it { is_expected.to have_db_column(:uid).of_type(:string) }
+    it { is_expected.to have_db_index(%i[provider uid]).unique }
+  end
+
   describe "validations" do
     subject { build(:user) }
 


### PR DESCRIPTION
## Summary

- Add `provider` and `uid` string columns to users table
- Add unique composite index on `[provider, uid]` to prevent duplicate OAuth identities

Closes #427

**Beads issue:** vanilla-mafia-185

## Test plan

- [x] Migration runs successfully
- [x] Database column and index specs pass (3 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)