### PR TITLE
186: Configure Devise omniauthable with Google provider

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
-  devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable
+  devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable,
+         :omniauthable, omniauth_providers: [ :google_oauth2 ]
 
   belongs_to :player, optional: true
   has_many :player_claims, dependent: :destroy

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -299,6 +299,12 @@ Devise.setup do |config|
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = '/my_engine/users/auth'
 
+  # ==> OmniAuth configuration
+  config.omniauth :google_oauth2,
+                  ENV["GOOGLE_CLIENT_ID"],
+                  ENV["GOOGLE_CLIENT_SECRET"],
+                  scope: "email,profile"
+
   # ==> Hotwire/Turbo configuration
   # When using Devise with Hotwire/Turbo, the http status for error responses
   # and some redirects must match the following. The default in Devise for existing

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,6 +8,16 @@ RSpec.describe User, type: :model do
     it { is_expected.to have_many(:grants).through(:user_grants) }
   end
 
+  describe "devise modules" do
+    it "includes omniauthable" do
+      expect(User.devise_modules).to include(:omniauthable)
+    end
+
+    it "configures google_oauth2 as omniauth provider" do
+      expect(User.omniauth_providers).to include(:google_oauth2)
+    end
+  end
+
   describe "database columns" do
     it { is_expected.to have_db_column(:provider).of_type(:string) }
     it { is_expected.to have_db_column(:uid).of_type(:string) }


### PR DESCRIPTION
## Summary

- Add `:omniauthable` Devise module to User model with `google_oauth2` provider
- Configure Google OAuth in Devise initializer using `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` env vars
- Scope: `email,profile`

Closes #428

**Beads issue:** vanilla-mafia-186

## Test plan

- [x] User model specs pass (48 examples, 0 failures)
- [x] Devise modules spec verifies omniauthable is included
- [x] Devise modules spec verifies google_oauth2 is a configured provider
- [x] Rubocop passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)