### PR TITLE
188: Add Sign in with Google button to sign-in and registration pages

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -32,5 +32,25 @@
     </div>
   <% end %>
 
+  <div class="relative my-6">
+    <div class="absolute inset-0 flex items-center">
+      <div class="w-full border-t border-neutral-300"></div>
+    </div>
+    <div class="relative flex justify-center text-sm">
+      <span class="bg-white px-2 text-neutral-500"><%= t("devise.shared.links.or") %></span>
+    </div>
+  </div>
+
+  <%= button_to user_google_oauth2_omniauth_authorize_path, method: :post, data: { turbo: false },
+        class: "w-full rounded-md border border-neutral-300 px-6 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50 transition-colors flex items-center justify-center gap-2 cursor-pointer" do %>
+    <svg class="w-5 h-5" viewBox="0 0 24 24">
+      <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"/>
+      <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+      <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+      <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+    </svg>
+    <%= t("devise.shared.links.sign_in_with_google") %>
+  <% end %>
+
   <%= render "devise/shared/links" %>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -31,5 +31,25 @@
     </div>
   <% end %>
 
+  <div class="relative my-6">
+    <div class="absolute inset-0 flex items-center">
+      <div class="w-full border-t border-neutral-300"></div>
+    </div>
+    <div class="relative flex justify-center text-sm">
+      <span class="bg-white px-2 text-neutral-500"><%= t("devise.shared.links.or") %></span>
+    </div>
+  </div>
+
+  <%= button_to user_google_oauth2_omniauth_authorize_path, method: :post, data: { turbo: false },
+        class: "w-full rounded-md border border-neutral-300 px-6 py-2 text-sm font-medium text-neutral-700 hover:bg-neutral-50 transition-colors flex items-center justify-center gap-2 cursor-pointer" do %>
+    <svg class="w-5 h-5" viewBox="0 0 24 24">
+      <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"/>
+      <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+      <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+      <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+    </svg>
+    <%= t("devise.shared.links.sign_in_with_google") %>
+  <% end %>
+
   <%= render "devise/shared/links" %>
 </div>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -97,6 +97,8 @@ en:
         sign_up: "Sign up"
         forgot_password: "Forgot your password?"
         back: "Back"
+        or: "or"
+        sign_in_with_google: "Sign in with Google"
     unlocks:
       send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
       send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."

--- a/config/locales/devise.ru.yml
+++ b/config/locales/devise.ru.yml
@@ -70,6 +70,8 @@ ru:
         sign_up: "Зарегистрироваться"
         forgot_password: "Забыли пароль?"
         back: "Назад"
+        or: "или"
+        sign_in_with_google: "Войти через Google"
     mailer:
       reset_password_instructions:
         subject: "Инструкции по сбросу пароля"

--- a/spec/requests/devise/sessions_spec.rb
+++ b/spec/requests/devise/sessions_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Devise::Sessions" do
+  describe "GET /users/sign_in" do
+    it "displays the Google sign-in button" do
+      get new_user_session_path
+      expect(response.body).to include("google_oauth2")
+    end
+
+    it "includes sign in with Google text" do
+      get new_user_session_path
+      expect(response.body).to include(I18n.t("devise.shared.links.sign_in_with_google"))
+    end
+  end
+
+  describe "GET /users/sign_up" do
+    it "displays the Google sign-in button" do
+      get new_user_registration_path
+      expect(response.body).to include("google_oauth2")
+    end
+
+    it "includes sign in with Google text" do
+      get new_user_registration_path
+      expect(response.body).to include(I18n.t("devise.shared.links.sign_in_with_google"))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add "Sign in with Google" button with Google logo SVG to sign-in page
- Add same button to registration page
- Include "or" divider between the email/password form and OAuth button
- Uses `button_to` with POST method and `turbo: false` for OmniAuth compatibility
- Add i18n keys (`sign_in_with_google`, `or`) in both en and ru

Closes #430

**Beads issue:** vanilla-mafia-188

## Test plan

- [x] 4 request specs: both pages show Google button and i18n text
- [x] Specs pass (4 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)