### PR TITLE
201: Fix password reset emails not being sent

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,6 +53,7 @@ Rails.application.configure do
   config.active_job.queue_adapter = :solid_queue
   config.solid_queue.connects_to = { database: { writing: :queue } }
 
+  config.action_mailer.delivery_method = :smtp
   config.action_mailer.raise_delivery_errors = false
   config.action_mailer.default_url_options = { host: "cnxmafia.org", protocol: "https" }
   config.action_mailer.smtp_settings = {

--- a/spec/config/production_mailer_spec.rb
+++ b/spec/config/production_mailer_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "Production mailer configuration" do
+  let(:config) { Rails.application.config_for(:production_mailer) }
+  let(:production_config_path) { Rails.root.join("config/environments/production.rb") }
+  let(:production_config) { File.read(production_config_path) }
+
+  it "sets delivery_method to :smtp" do
+    expect(production_config).to match(/config\.action_mailer\.delivery_method\s*=\s*:smtp/)
+  end
+
+  it "configures smtp_settings with Resend" do
+    expect(production_config).to include('address: "smtp.resend.com"')
+  end
+end


### PR DESCRIPTION
## Summary
- Production mailer config had `smtp_settings` for Resend but was missing `delivery_method = :smtp`, causing Rails to default to `:sendmail`
- All emails (password reset, disputes, news drafts) were silently dropped because `raise_delivery_errors = false`
- Added the missing `delivery_method` line and a config spec to prevent regression

Closes #453

## Test plan
- [x] Config spec verifies `delivery_method = :smtp` is present in production.rb
- [x] Config spec verifies Resend SMTP address is configured
- [x] RuboCop clean
- [ ] Deploy and verify password reset email arrives via Resend dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)