### PR TITLE
247: Add running tournaments block to main page

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,16 @@
 class HomeController < ApplicationController
+  MINI_STANDINGS_LIMIT = 5
+
   def index
+    @running_competitions = Competition.roots.running.ordered
+    @mini_standings = load_mini_standings(@running_competitions)
+  end
+
+  private
+
+  def load_mini_standings(competitions)
+    competitions.index_with do |competition|
+      Player.with_stats_for_competition(competition).ranked.limit(MINI_STANDINGS_LIMIT)
+    end
   end
 end

--- a/app/models/competition.rb
+++ b/app/models/competition.rb
@@ -18,6 +18,7 @@ class Competition < ApplicationRecord
   scope :featured, -> { where(featured: true) }
   scope :ordered, -> { order(position: :asc, id: :asc) }
   scope :roots, -> { where(parent_id: nil) }
+  scope :running, -> { where(ended_on: nil) }
 
   before_validation :generate_slug, if: -> { slug.blank? && name.present? }
 

--- a/app/views/home/_running_tournaments.html.erb
+++ b/app/views/home/_running_tournaments.html.erb
@@ -1,0 +1,41 @@
+<section>
+  <h2 class="text-2xl font-bold text-maroon mb-6"><%= t(".running_tournaments") %></h2>
+
+  <div class="grid gap-6 md:grid-cols-2">
+    <% running_competitions.each do |competition| %>
+      <div class="border border-gray-200 rounded-lg p-4">
+        <h3 class="text-lg font-semibold mb-3">
+          <%= link_to competition.name, competition_path(slug: competition.slug),
+                class: "text-maroon hover:underline" %>
+        </h3>
+
+        <% players = mini_standings[competition] %>
+        <% if players.any? %>
+          <table class="data-table w-full text-sm">
+            <thead>
+              <tr>
+                <th><%= t(".rank") %></th>
+                <th><%= t(".player") %></th>
+                <th><%= t(".rating") %></th>
+              </tr>
+            </thead>
+            <tbody>
+              <% players.each_with_index do |player, index| %>
+                <tr>
+                  <td><%= index + 1 %></td>
+                  <td><%= link_to player.name, player_path(player) %></td>
+                  <td><%= player.total_rating %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        <% end %>
+
+        <div class="mt-3 text-right">
+          <%= link_to t(".view_all"), competition_path(slug: competition.slug),
+                class: "text-sm text-maroon hover:underline" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</section>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,2 +1,7 @@
 <div class="space-y-12">
+  <% if @running_competitions.any? %>
+    <%= render "home/running_tournaments",
+         running_competitions: @running_competitions,
+         mini_standings: @mini_standings %>
+  <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -200,6 +200,13 @@ en:
       greeting: "A new news draft has been created."
       body: "\"%{title}\" is waiting for editing and publication."
       footer: "This is an automatic notification. You can disable it in your settings."
+  home:
+    running_tournaments:
+      running_tournaments: "Running tournaments"
+      rank: "Rank"
+      player: "Player"
+      rating: "Rating"
+      view_all: "View all"
   competitions:
     show:
       by_children: "By series and games"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -50,6 +50,13 @@ ru:
         title: "Название"
         description: "Описание"
         staff: "Организаторская"
+  home:
+    running_tournaments:
+      running_tournaments: "Текущие турниры"
+      rank: "Место"
+      player: "Игрок"
+      rating: "Рейтинг"
+      view_all: "Подробнее"
   competitions:
     show:
       by_children: "По сериям и играм"

--- a/spec/models/competition_spec.rb
+++ b/spec/models/competition_spec.rb
@@ -60,6 +60,19 @@ RSpec.describe Competition, type: :model do
     end
   end
 
+  describe '.running' do
+    let_it_be(:running) { create(:competition, ended_on: nil) }
+    let_it_be(:finished) { create(:competition, ended_on: Date.new(2025, 12, 31)) }
+
+    it 'returns competitions without an ended_on date' do
+      expect(described_class.running).to include(running)
+    end
+
+    it 'excludes finished competitions' do
+      expect(described_class.running).not_to include(finished)
+    end
+  end
+
   describe '#parent_is_not_self' do
     it 'is invalid when parent_id equals own id' do
       competition = create(:competition)

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -16,4 +16,107 @@ RSpec.describe HomeController do
       expect(response.body).to include("Vanilla Mafia")
     end
   end
+
+  describe "running tournaments block" do
+    context "when running competitions with players exist" do
+      let_it_be(:competition) { create(:competition, :season, name: "Season 6", ended_on: nil) }
+      let_it_be(:child) { create(:competition, :series, parent: competition, name: "Series 1") }
+      let_it_be(:role) { create(:role) }
+      let_it_be(:players) do
+        (1..6).map { |i| create(:player, name: "Player #{i}") }
+      end
+      let_it_be(:game) { create(:game, competition: child) }
+
+      before_all do
+        players.each_with_index do |player, i|
+          create(:game_participation, game: game, player: player, role: role, plus: 10 - i)
+        end
+      end
+
+      before { get root_path }
+
+      it "renders the section title" do
+        expect(response.body).to include(I18n.t("home.running_tournaments.running_tournaments"))
+      end
+
+      it "renders the competition name" do
+        expect(response.body).to include("Season 6")
+      end
+
+      it "renders a link to the competition page" do
+        expect(response.body).to include(competition_path(slug: competition.slug))
+      end
+
+      it "renders top 5 players" do
+        (1..5).each do |i|
+          expect(response.body).to include("Player #{i}")
+        end
+      end
+
+      it "does not render the 6th player" do
+        expect(response.body).not_to include("Player 6")
+      end
+
+      it "renders player ratings" do
+        expect(response.body).to include("10.0")
+      end
+
+      it "ranks players by rating descending" do
+        body = response.body
+        pos_player1 = body.index("Player 1")
+        pos_player5 = body.index("Player 5")
+        expect(pos_player1).to be < pos_player5
+      end
+    end
+
+    context "when only child competitions are running" do
+      let_it_be(:parent) { create(:competition, :season, name: "Parent Season", ended_on: nil) }
+      let_it_be(:child_running) { create(:competition, :series, parent: parent, name: "Child Series", ended_on: nil) }
+
+      before { get root_path }
+
+      it "shows root competitions only" do
+        expect(response.body).to include("Parent Season")
+        expect(response.body).not_to include("Child Series")
+      end
+    end
+
+    context "when multiple running competitions exist" do
+      let_it_be(:second) { create(:competition, :season, name: "Second Comp", ended_on: nil, position: 2) }
+      let_it_be(:first) { create(:competition, :season, name: "First Comp", ended_on: nil, position: 1) }
+
+      before { get root_path }
+
+      it "orders competitions by position" do
+        body = response.body
+        pos_first = body.index("First Comp")
+        pos_second = body.index("Second Comp")
+        expect(pos_first).to be < pos_second
+      end
+    end
+
+    context "when no running competitions exist" do
+      let_it_be(:finished) { create(:competition, :season, name: "Season 5", ended_on: Date.new(2025, 12, 31)) }
+
+      before { get root_path }
+
+      it "does not render the running tournaments section" do
+        expect(response.body).not_to include(I18n.t("home.running_tournaments.running_tournaments"))
+      end
+    end
+
+    context "when a running competition has no games yet" do
+      let_it_be(:empty_competition) { create(:competition, :season, name: "Empty Season", ended_on: nil) }
+
+      before { get root_path }
+
+      it "renders the competition name" do
+        expect(response.body).to include("Empty Season")
+      end
+
+      it "does not render a standings table for it" do
+        expect(response.body).not_to include("<table")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Add `Competition.running` scope — filters by `ended_on IS NULL`
- Load running root competitions with top 5 players in `HomeController#index`
- New partial `_running_tournaments.html.erb` renders competition cards with mini-standings (rank, player name, rating) and links to full pages
- Section hidden when no running competitions exist
- i18n keys for EN and RU

## Mutation Testing
- Mutant: 95% (38/40 killed, 2 neutral — `allow_browser` 403 in killfork)
- Evilution: 100% (14/15 killed, 1 equivalent)

Closes #499

## Test plan
- [x] `GET /` shows running competitions with top 5 players
- [x] Finished competitions (with `ended_on`) are not shown
- [ ] Competitions are ordered by position
- [x] Only root competitions are shown (not children)
- [x] Empty competitions render without a table
- [ ] Section is hidden when no running competitions exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)