### PR TITLE
231: Pre-fill Judge field with current user's player nickname

### DIFF
--- a/app/controllers/judge/protocols_controller.rb
+++ b/app/controllers/judge/protocols_controller.rb
@@ -5,6 +5,7 @@ class Judge::ProtocolsController < ApplicationController
 
   def new
     @game = Game.new(played_on: Date.current)
+    @game.judge = current_user.player.name if current_user.claimed_player?
     @participations = 10.times.map { |i| GameParticipation.new(seat: i + 1, role_code: "peace") }
     load_form_data
   end

--- a/spec/requests/judge/protocols_spec.rb
+++ b/spec/requests/judge/protocols_spec.rb
@@ -29,6 +29,19 @@ RSpec.describe "Judge::Protocols" do
         expect(response.body).to include(I18n.t("game_protocols.new.title"))
       end
 
+      it "pre-fills judge with current user's player nickname" do
+        claimed_player = create(:player, name: "AdminNick")
+        admin.update!(player: claimed_player)
+        get new_judge_protocol_path
+        expect(response.body).to include('id="game_judge" value="AdminNick"')
+      end
+
+      it "leaves judge blank when user has no claimed player" do
+        admin.update!(player: nil)
+        get new_judge_protocol_path
+        expect(response.body).to include('id="game_judge" value=""')
+      end
+
       it "excludes season competitions from the dropdown" do
         season_comp = create(:competition, :season, name: "Season Parent")
         get new_judge_protocol_path


### PR DESCRIPTION
Closes #489

## Summary
- Pre-fills the Judge text field on the new protocol form with the current user's claimed player nickname
- Field remains editable — pre-fill is a convenience, not a constraint
- No change to edit form (existing judge value is preserved)

## Mutation testing
- Mutant: 98.46% (64/65 killed, 1 neutral — killfork 403)
- Evilution: 76.9% (30/39 killed, 9 survived — all on pre-existing line, 100% on new code)

## Test plan
- [x] New spec: pre-fills judge when user has claimed player
- [x] New spec: leaves judge blank when user has no claimed player
- [x] All 34 protocol request specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)