### PR TITLE
234: Rename 'Первый выстрел' to 'ПУ' on protocol form

### DIFF
--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -29,7 +29,7 @@ ru:
         plus: "Плюс"
         minus: "Минус"
         best_move: "Лучший ход"
-        first_shoot: "Первый выстрел"
+        first_shoot: "ПУ"
         total: "Итого"
         seat: "Место"
         notes: "Примечания"

--- a/spec/requests/judge/protocols_spec.rb
+++ b/spec/requests/judge/protocols_spec.rb
@@ -42,6 +42,11 @@ RSpec.describe "Judge::Protocols" do
         expect(response.body).to include('id="game_judge" value=""')
       end
 
+      it "shows abbreviated label 'ПУ' for first_shoot column" do
+        expect(response.body).to include("<th", "ПУ")
+        expect(response.body).not_to include("Первый выстрел")
+      end
+
       it "excludes season competitions from the dropdown" do
         season_comp = create(:competition, :season, name: "Season Parent")
         get new_judge_protocol_path


### PR DESCRIPTION
Closes #491

## Summary
- Renames the `first_shoot` column header from "Первый выстрел" to "ПУ" (standard abbreviation) on the protocol form
- Locale-only change — no Ruby code modified, mutation testing not applicable

## Test plan
- [x] New spec: verifies "ПУ" label appears and "Первый выстрел" does not
- [x] All 35 protocol request specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)