### PR TITLE
238: Fix alignment in Result section of protocol form

### DIFF
--- a/app/views/judge/protocols/_form.html.erb
+++ b/app/views/judge/protocols/_form.html.erb
@@ -24,8 +24,8 @@
       <label class="w-40 font-semibold text-sm text-right" for="game_name"><%= Game.human_attribute_name(:name) %></label>
       <input type="text" name="game[name]" id="game_name" value="<%= @game.name %>" class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm" />
     </div>
-    <fieldset class="flex flex-col sm:flex-row items-center px-4 py-3 gap-2">
-      <legend class="w-40 font-semibold text-sm text-right"><%= Game.human_attribute_name(:result) %></legend>
+    <div class="flex flex-col sm:flex-row items-center px-4 py-3 gap-2">
+      <span class="w-40 font-semibold text-sm text-right"><%= Game.human_attribute_name(:result) %></span>
       <div class="w-full flex items-center gap-6">
         <% Game.results.each_key do |key| %>
           <label class="inline-flex items-center gap-2 cursor-pointer text-sm">
@@ -34,7 +34,7 @@
           </label>
         <% end %>
       </div>
-    </fieldset>
+    </div>
     <div class="flex flex-col sm:flex-row items-center px-4 py-3 gap-2">
       <label class="w-40 font-semibold text-sm text-right" for="game_judge"><%= t("game_protocols.form.judge") %></label>
       <input type="text" name="game[judge]" id="game_judge" value="<%= @game.judge %>" class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm" />

--- a/spec/requests/judge/protocols_spec.rb
+++ b/spec/requests/judge/protocols_spec.rb
@@ -51,6 +51,11 @@ RSpec.describe "Judge::Protocols" do
         expect(response.body).not_to include('name="participations[1][win]"')
       end
 
+      it "renders result section with same layout as other form rows" do
+        expect(response.body).not_to include("<fieldset")
+        expect(response.body).not_to include("<legend")
+      end
+
       it "excludes season competitions from the dropdown" do
         season_comp = create(:competition, :season, name: "Season Parent")
         get new_judge_protocol_path


### PR DESCRIPTION
Closes #493

## Summary
- Replaces `<fieldset>`/`<legend>` with `<div>`/`<span>` in the Result radio button row
- `<legend>` has special browser rendering that breaks flex alignment with the label/input rows above and below it
- Now uses the same `<div>` + `<span class="w-40 ...">` pattern as all other form rows

## Test plan
- [x] New spec: verifies no `<fieldset>` or `<legend>` in form output
- [x] All 37 protocol request specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)