### PR TITLE
192: Redirect Avo root to games

### DIFF
--- a/config/initializers/avo.rb
+++ b/config/initializers/avo.rb
@@ -7,7 +7,7 @@ Avo.configure do |config|
   # config.prefix_path = "/internal"
 
   # Where should the user be redirected when visiting the `/avo` url
-  # config.home_path = nil
+  config.home_path = "/avo/resources/games"
 
   ## == Licensing ==
   # config.license_key = ENV['AVO_LICENSE_KEY']

--- a/spec/avo/root_redirect_spec.rb
+++ b/spec/avo/root_redirect_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Avo root redirect" do
+  it "sets home_path to games resource" do
+    expect(Avo.configuration.home_path).to eq("/avo/resources/games")
+  end
+end


### PR DESCRIPTION
## Summary
- Change Avo home_path from default (awards) to `/avo/resources/games`
- Games is the most frequently used admin resource

Closes #444

## Test plan
- [ ] Visit `/avo` — should redirect to `/avo/resources/games`
- [ ] `bundle exec rspec spec/avo/root_redirect_spec.rb` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)