### PR TITLE
191: Prefill position with MAX+1 on new records

### DIFF
--- a/app/avo/resources/award.rb
+++ b/app/avo/resources/award.rb
@@ -15,7 +15,7 @@ class Avo::Resources::Award < Avo::BaseResource
     field :title, as: :text, required: true, sortable: true
     field :description, as: :textarea
     field :staff, as: :boolean, sortable: true
-    field :position, as: :number, sortable: true
+    field :position, as: :number, sortable: true, default: -> { Award.maximum(:position).to_i + 1 }
     field :icon, as: :file, is_image: true
     field :player_awards, as: :has_many
   end

--- a/app/avo/resources/competition.rb
+++ b/app/avo/resources/competition.rb
@@ -19,7 +19,7 @@ class Avo::Resources::Competition < Avo::BaseResource
     }
     field :slug, as: :text, help: I18n.t("avo.competition.slug_hint")
     field :kind, as: :select, options: ::Competition::KINDS.values.to_h { |k| [ I18n.t("activerecord.attributes.competition.kinds.#{k}"), k ] }
-    field :position, as: :number
+    field :position, as: :number, default: -> { Competition.maximum(:position).to_i + 1 }
     field :parent, as: :belongs_to, required: false
     field :started_on, as: :date
     field :ended_on, as: :date

--- a/app/avo/resources/player_award.rb
+++ b/app/avo/resources/player_award.rb
@@ -8,6 +8,6 @@ class Avo::Resources::PlayerAward < Avo::BaseResource
     field :player, as: :belongs_to, searchable: true, sortable: true
     field :award, as: :belongs_to, searchable: true, sortable: true
     field :competition, as: :belongs_to
-    field :position, as: :number, sortable: true
+    field :position, as: :number, sortable: true, default: -> { PlayerAward.maximum(:position).to_i + 1 }
   end
 end

--- a/app/avo/resources/playlist_episode.rb
+++ b/app/avo/resources/playlist_episode.rb
@@ -5,6 +5,6 @@ class Avo::Resources::PlaylistEpisode < Avo::BaseResource
     field :id, as: :id
     field :playlist, as: :belongs_to
     field :episode, as: :belongs_to
-    field :position, as: :number, required: true, sortable: true
+    field :position, as: :number, required: true, sortable: true, default: -> { PlaylistEpisode.maximum(:position).to_i + 1 }
   end
 end

--- a/spec/avo/resources/position_prefill_spec.rb
+++ b/spec/avo/resources/position_prefill_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Position field prefill" do
+  def position_field_for(resource_class, record)
+    resource = resource_class.new(record: record, view: :new)
+    resource.detect_fields
+    resource.items.find { |f| f.id == :position }
+  end
+
+  describe "Award" do
+    let(:field) { position_field_for(Avo::Resources::Award, Award.new) }
+
+    it "defaults to 1 when no records exist" do
+      expect(field.default).to be_a(Proc)
+      expect(field.default.call).to eq(1)
+    end
+
+    it "defaults to MAX+1 when records exist" do
+      create(:award, position: 5)
+
+      expect(field.default.call).to eq(6)
+    end
+  end
+
+  describe "Competition" do
+    let(:field) { position_field_for(Avo::Resources::Competition, Competition.new) }
+
+    it "defaults to MAX+1" do
+      create(:competition, :season, position: 3)
+
+      expect(field.default).to be_a(Proc)
+      expect(field.default.call).to eq(4)
+    end
+  end
+
+  describe "PlayerAward" do
+    let(:field) { position_field_for(Avo::Resources::PlayerAward, PlayerAward.new) }
+
+    it "defaults to MAX+1" do
+      player = create(:player)
+      award = create(:award, position: 1)
+      create(:player_award, player: player, award: award, position: 7)
+
+      expect(field.default).to be_a(Proc)
+      expect(field.default.call).to eq(8)
+    end
+  end
+
+  describe "PlaylistEpisode" do
+    let(:field) { position_field_for(Avo::Resources::PlaylistEpisode, PlaylistEpisode.new) }
+
+    it "defaults to MAX+1" do
+      playlist = create(:playlist)
+      episode = create(:episode)
+      create(:playlist_episode, playlist: playlist, episode: episode, position: 4)
+
+      expect(field.default).to be_a(Proc)
+      expect(field.default.call).to eq(5)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Award, Competition, PlayerAward, and PlaylistEpisode position fields now default to `MAX(position) + 1`
- Saves admins from manually looking up the next available position

Closes #443

## Test plan
- [x] Create a new Award in Avo — position should be prefilled
- [x] Create a new Competition — position should be prefilled
- [ ] `bundle exec rspec spec/avo/resources/position_prefill_spec.rb` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)