### PR TITLE
190: Add Russian translations for Avo admin UI

### DIFF
--- a/config/locales/avo.ru.yml
+++ b/config/locales/avo.ru.yml
@@ -1,0 +1,142 @@
+---
+ru:
+  avo:
+    action_ran_successfully: Действие успешно выполнено!
+    actions: Действия
+    add_filter: Добавить фильтр
+    and_x_other_resources: и %{count} других ресурсов
+    applied: применено
+    are_you_sure: Вы уверены?
+    are_you_sure_detach_item: Вы уверены, что хотите отсоединить этот %{item}?
+    are_you_sure_you_want_to_run_this_option: Вы уверены, что хотите выполнить это действие?
+    attach: Прикрепить
+    attach_and_attach_another: Прикрепить и прикрепить ещё один
+    attach_item: Прикрепить %{item}
+    attachment_class_attached: "%{attachment_class} прикреплено."
+    attachment_class_detached: "%{attachment_class} отсоединено."
+    attachment_destroyed: Вложение удалено
+    attachment_failed: Не удалось прикрепить %{attachment_class}
+    cancel: Отмена
+    choose_a_country: Выберите страну
+    choose_an_option: Выберите опцию
+    choose_item: Выбрать %{item}
+    clear_value: Очистить значение
+    click_to_reveal_filters: Нажмите, чтобы открыть фильтры
+    close: Закрыть
+    close_modal: Закрыть модальное окно
+    confirm: Подтвердить
+    copy: Копировать
+    create_new_item: Создать новый %{item}
+    created_at_timestamp: Создано в %{created_at}
+    dashboard: Панель управления
+    dashboards: Панели управления
+    default_scope: Все
+    delete: удалить
+    delete_file: Удалить файл
+    delete_item: Удалить %{item}
+    detach_item: Отсоединить %{item}
+    details: Детали
+    download: Скачать
+    download_file: Скачать файл
+    download_item: Скачать %{item}
+    edit: редактировать
+    edit_item: редактировать %{item}
+    empty_dashboard_message: Добавьте карточки на эту панель управления
+    failed: Ошибка
+    failed_to_find_attachment: Вложение не найдено
+    failed_to_load: Загрузка не удалась
+    'false': Ложь
+    file:
+      few: файла
+      many: файлов
+      one: файл
+      other: файлов
+    filter_by: Фильтровать по
+    filters: Фильтры
+    go_back: Назад
+    grid_view: Сетка
+    hide_content: Скрыть содержимое
+    home: Главная
+    key_value_field:
+      add_row: Добавить строку
+      delete_row: Удалить строку
+      key: Ключ
+      reorder_row: Перенести строку
+      value: Значение
+    less_content: Меньше контента
+    list_is_empty: Список пуст
+    loading: Загрузка...
+    media_library:
+      title: Медиатека
+    more: Ещё
+    more_content: Больше контента
+    more_records_available: Доступно больше записей.
+    nested:
+      add_new_item: Добавить новый %{item}
+    new: новый
+    next_page: Следующая страница
+    no_cancel: Нет, отмена
+    no_cards_present: Нет карточек
+    no_item_found: Запись не найдена
+    no_options_available: Опции недоступны
+    no_related_item_found: Связанная запись не найдена
+    not_authorized: У вас нет прав для выполнения этого действия.
+    number_of_items:
+      one: один %{item}
+      other: "%{count} %{item}"
+      zero: нет %{item}
+    oops_nothing_found: Ой! Ничего не найдено...
+    order:
+      higher: Переместить запись вверх
+      lower: Переместить запись вниз
+      reorder_record: Переупорядочить запись
+      to_bottom: Переместить запись в конец
+      to_top: Переместить запись в начало
+    per_page: На странице
+    prev_page: Предыдущая страница
+    records_selected_from_all_pages_html: Все записи выбраны со всех страниц
+    remove_selection: Убрать выбор
+    reset: сбросить
+    reset_filters: Сбросить фильтры
+    resource_created: Запись создана
+    resource_destroyed: Запись удалена
+    resource_updated: Запись обновлена
+    resources: Ресурсы
+    run: Запустить
+    save: Сохранить
+    search:
+      cancel_button: Отмена
+      placeholder: Поиск
+    select_all: Выбрать все
+    select_all_matching: Выбрать все совпадающие
+    select_item: Выбрать элемент
+    show_content: Показать содержимое
+    sign_out: Выйти
+    sort_asc: Сортировать по возрастанию
+    sort_desc: Сортировать по убыванию
+    sort_reset: Сбросить сортировку
+    switch_to_view: Переключиться на вид %{view_type}
+    table_view: Таблица
+    this_field_has_attachments_disabled: Для этого поля прикрепления отключены.
+    tools: Инструменты
+    'true': Истина
+    type_to_search: Поиск...
+    unauthorized: Не авторизован
+    undo: Отменить
+    updated_at_timestamp: Обновлено в %{updated_at}
+    view: Просмотр
+    view_item: Просмотр %{item}
+    visit_record_on_external_path: Перейти к записи через внешнюю ссылку
+    was_successfully_created: успешно создана
+    was_successfully_updated: успешно обновлена
+    x_items_more:
+      one: ещё один элемент
+      other: "%{count} других элементов"
+      zero: нет других элементов
+    x_records_selected_from_a_total_of_x_html: Выбрано <span class="font-bold text-gray-700">%{selected}</span> записей на этой странице из общего количества <span class="font-bold text-gray-700">%{count}</span>
+    x_records_selected_from_all_pages_html: Выбрано <span class="font-bold text-gray-700">%{count}</span> записей со всех страниц
+    x_records_selected_from_page_html: Выбрано <span class="font-bold text-gray-700">%{selected}</span> записей на этой странице
+    yes_confirm: Да, уверен
+    you_cant_upload_new_resource: Вы не можете загружать файлы в редактор Trix, пока не сохраните ресурс.
+    you_havent_set_attachment_key: Вы не установили `attachment_key` для этого поля Trix.
+    you_missed_something_check_form: Возможно, вы что-то упустили. Пожалуйста, проверьте форму.

--- a/spec/avo/russian_translations_spec.rb
+++ b/spec/avo/russian_translations_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Avo Russian translations" do
+  around do |example|
+    I18n.with_locale(:ru) { example.run }
+  end
+
+  it "translates core UI strings" do
+    expect(I18n.t("avo.save")).to eq("Сохранить")
+    expect(I18n.t("avo.edit")).to eq("редактировать")
+    expect(I18n.t("avo.delete")).to eq("удалить")
+    expect(I18n.t("avo.cancel")).to eq("Отмена")
+  end
+
+  it "translates search placeholder" do
+    expect(I18n.t("avo.search.placeholder")).to eq("Поиск")
+  end
+
+  it "translates resource CRUD messages" do
+    expect(I18n.t("avo.resource_created")).to eq("Запись создана")
+    expect(I18n.t("avo.resource_updated")).to eq("Запись обновлена")
+    expect(I18n.t("avo.resource_destroyed")).to eq("Запись удалена")
+  end
+
+  it "translates pagination" do
+    expect(I18n.t("avo.per_page")).to eq("На странице")
+    expect(I18n.t("avo.next_page")).to eq("Следующая страница")
+    expect(I18n.t("avo.prev_page")).to eq("Предыдущая страница")
+  end
+
+  it "translates boolean values" do
+    expect(I18n.t("avo.true")).to eq("Истина")
+    expect(I18n.t("avo.false")).to eq("Ложь")
+  end
+
+  it "does not fall back to English for any avo key" do
+    en_keys = I18n.t("avo", locale: :en).keys
+    ru_keys = I18n.t("avo", locale: :ru).keys
+
+    missing = en_keys - ru_keys
+
+    expect(missing).to be_empty, "Missing Russian translations for avo keys: #{missing.join(', ')}"
+  end
+end


### PR DESCRIPTION
## Summary
- Install official `avo.ru.yml` locale from the Avo gem
- App default locale is `:ru`, so all Avo admin pages now render in Russian (buttons, messages, labels, pagination)

Closes #442

## Test plan
- [ ] Open any Avo admin page — UI should be in Russian
- [ ] `bundle exec rspec spec/avo/russian_translations_spec.rb` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)