### PR TITLE
264.1: Create Announcement model and migration

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,0 +1,4 @@
+class Announcement < ApplicationRecord
+  validates :version, presence: true
+  validates :message, presence: true
+end

--- a/db/migrate/20260328170240_create_announcements.rb
+++ b/db/migrate/20260328170240_create_announcements.rb
@@ -1,0 +1,13 @@
+class CreateAnnouncements < ActiveRecord::Migration[8.1]
+  def change
+    create_table :announcements do |t|
+      t.string :version, null: false
+      t.string :grant_code
+      t.text :message, null: false
+
+      t.timestamps
+    end
+
+    add_index :announcements, :grant_code
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_27_163411) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_28_170240) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -47,6 +47,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_27_163411) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "announcements", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "grant_code"
+    t.text "message", null: false
+    t.datetime "updated_at", null: false
+    t.string "version", null: false
+    t.index ["grant_code"], name: "index_announcements_on_grant_code"
   end
 
   create_table "awards", force: :cascade do |t|

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :announcement do
+    sequence(:version) { |n| "1.0.#{n}" }
+    message { "New feature available" }
+  end
+end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Announcement do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:version) }
+    it { is_expected.to validate_presence_of(:message) }
+  end
+
+  describe "indexes" do
+    it "has an index on grant_code" do
+      index = ActiveRecord::Base.connection.indexes(:announcements).find { |i| i.columns == [ "grant_code" ] }
+
+      expect(index).to be_present
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Create `announcements` table: `version` (string, not null), `grant_code` (string, nullable, indexed), `message` (text, not null)
- Announcement model with presence validations on version and message
- Factory and specs

Part of the What's New announcements epic (#535). Closes #536

## Mutation testing
- Mutant: 100% (0/0 — pure DSL, no method bodies to mutate)
- Evilution: 0/0 mutations

## Test plan
- [ ] `bundle exec rspec spec/models/announcement_spec.rb` passes
- [ ] `bundle exec rails db:migrate` runs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)