### PR TITLE
264.2: Create AnnouncementDismissal model and migration

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,4 +1,6 @@
 class Announcement < ApplicationRecord
+  has_many :announcement_dismissals, dependent: :destroy
+
   validates :version, presence: true
   validates :message, presence: true
 end

--- a/app/models/announcement_dismissal.rb
+++ b/app/models/announcement_dismissal.rb
@@ -1,0 +1,6 @@
+class AnnouncementDismissal < ApplicationRecord
+  belongs_to :user
+  belongs_to :announcement
+
+  validates :user_id, uniqueness: { scope: :announcement_id }
+end

--- a/db/migrate/20260328170652_create_announcement_dismissals.rb
+++ b/db/migrate/20260328170652_create_announcement_dismissals.rb
@@ -1,0 +1,12 @@
+class CreateAnnouncementDismissals < ActiveRecord::Migration[8.1]
+  def change
+    create_table :announcement_dismissals do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :announcement, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :announcement_dismissals, [ :user_id, :announcement_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_28_170240) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_28_170652) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -47,6 +47,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_28_170240) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "announcement_dismissals", force: :cascade do |t|
+    t.integer "announcement_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["announcement_id"], name: "index_announcement_dismissals_on_announcement_id"
+    t.index ["user_id", "announcement_id"], name: "index_announcement_dismissals_on_user_id_and_announcement_id", unique: true
+    t.index ["user_id"], name: "index_announcement_dismissals_on_user_id"
   end
 
   create_table "announcements", force: :cascade do |t|
@@ -295,6 +305,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_28_170240) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "announcement_dismissals", "announcements"
+  add_foreign_key "announcement_dismissals", "users"
   add_foreign_key "competitions", "competitions", column: "parent_id"
   add_foreign_key "game_participations", "games"
   add_foreign_key "game_participations", "players"

--- a/spec/factories/announcement_dismissals.rb
+++ b/spec/factories/announcement_dismissals.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :announcement_dismissal do
+    user
+    announcement
+  end
+end

--- a/spec/models/announcement_dismissal_spec.rb
+++ b/spec/models/announcement_dismissal_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AnnouncementDismissal do
+  describe "validations" do
+    subject { build(:announcement_dismissal) }
+
+    it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(:announcement_id) }
+  end
+
+  describe "associations" do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:announcement) }
+  end
+
+  describe "indexes" do
+    it "has a unique index on [user_id, announcement_id]" do
+      index = ActiveRecord::Base.connection.indexes(:announcement_dismissals).find do |i|
+        i.columns == %w[user_id announcement_id]
+      end
+
+      expect(index).to be_present
+      expect(index.unique).to be(true)
+    end
+  end
+end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe Announcement do
     it { is_expected.to validate_presence_of(:message) }
   end
 
+  describe "associations" do
+    it { is_expected.to have_many(:announcement_dismissals).dependent(:destroy) }
+  end
+
   describe "indexes" do
     it "has an index on grant_code" do
       index = ActiveRecord::Base.connection.indexes(:announcements).find { |i| i.columns == [ "grant_code" ] }


### PR DESCRIPTION
## Summary
- Create `announcement_dismissals` table with `user_id` and `announcement_id` FKs (both not null)
- Unique index on `[user_id, announcement_id]` to prevent duplicate dismissals
- AnnouncementDismissal model with belongs_to associations and uniqueness validation
- Add `has_many :announcement_dismissals` to Announcement model

Part of the What's New announcements epic (#535). Closes #537

## Mutation testing
- Mutant: 100% (0/0 — pure DSL)
- Evilution: 0/0 mutations

## Test plan
- [ ] `bundle exec rspec spec/models/announcement_dismissal_spec.rb spec/models/announcement_spec.rb` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)