### PR TITLE
264.4: Add feature toggles for announcement block and toast

### DIFF
--- a/app/models/feature_toggle.rb
+++ b/app/models/feature_toggle.rb
@@ -9,6 +9,8 @@ class FeatureToggle < ApplicationRecord
     home_hall_of_fame
     home_stats
     home_documents
+    home_whats_new
+    toast_whats_new
   ].freeze
   CACHE_TTL = 5.minutes
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,7 +33,9 @@ toggle.save!
   { key: "home_latest_news", description: "Show latest news on main page" },
   { key: "home_hall_of_fame", description: "Show hall of fame teaser on main page" },
   { key: "home_stats", description: "Show stats block on main page" },
-  { key: "home_documents", description: "Show documents section on main page" }
+  { key: "home_documents", description: "Show documents section on main page" },
+  { key: "home_whats_new", description: "Show What's New block on main page" },
+  { key: "toast_whats_new", description: "Show What's New toast notification" }
 ].each do |attrs|
   block_toggle = FeatureToggle.find_or_initialize_by(key: attrs[:key])
   if block_toggle.new_record?

--- a/spec/models/feature_toggle_spec.rb
+++ b/spec/models/feature_toggle_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe FeatureToggle, type: :model do
     it { is_expected.to validate_inclusion_of(:key).in_array(described_class::KEYS) }
   end
 
+  describe "KEYS" do
+    it "includes announcement toggle keys" do
+      expect(described_class::KEYS).to include("home_whats_new", "toast_whats_new")
+    end
+  end
+
   describe ".enabled?" do
     context "when toggle exists and is enabled" do
       let!(:toggle) { create(:feature_toggle, key: "require_approval", enabled: true) }


### PR DESCRIPTION
## Summary
- Add `home_whats_new` and `toast_whats_new` to `FeatureToggle::KEYS`
- Seed data for both toggles (disabled by default)

Part of the What's New announcements epic (#535). Closes #539

## Test plan
- [ ] `bundle exec rspec spec/models/feature_toggle_spec.rb` — 14 examples, 0 failures
- [ ] `bundle exec rails db:seed` runs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)