### PR TITLE
264.5: Load announcements in HomeController for current user

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -22,6 +22,7 @@ class HomeController < ApplicationController
     @latest_news = News.published.recent.limit(LATEST_NEWS_LIMIT) if @block_visible[:latest_news]
     @hall_of_fame_players = load_hall_of_fame_players if @block_visible[:hall_of_fame]
     @stats = load_stats if @block_visible[:stats]
+    @announcements = load_announcements
   end
 
   private
@@ -50,6 +51,13 @@ class HomeController < ApplicationController
       games: Game.finished.count,
       competitions: Competition.roots.finished.count
     }
+  end
+
+  def load_announcements
+    return unless user_signed_in?
+    return unless FeatureToggle.enabled?("home_whats_new") || FeatureToggle.enabled?("toast_whats_new")
+
+    Announcement.for_user(current_user)
   end
 
   def load_hall_of_fame_players

--- a/spec/requests/home_announcements_spec.rb
+++ b/spec/requests/home_announcements_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Home announcements" do
+  let_it_be(:user) { create(:user) }
+  let_it_be(:announcement) { create(:announcement, version: "1.0.0", message: "Welcome update") }
+
+  context "when user is signed in" do
+    before { sign_in user }
+
+    context "when home_whats_new toggle is enabled" do
+      let!(:toggle) { create(:feature_toggle, key: "home_whats_new", enabled: true) }
+
+      it "loads announcements for the user" do
+        get root_path
+
+        expect(controller.instance_variable_get(:@announcements)).to include(announcement)
+      end
+    end
+
+    context "when toast_whats_new toggle is enabled" do
+      let!(:toggle) { create(:feature_toggle, key: "toast_whats_new", enabled: true) }
+
+      it "loads announcements for the user" do
+        get root_path
+
+        expect(controller.instance_variable_get(:@announcements)).to include(announcement)
+      end
+    end
+
+    context "when both toggles are disabled" do
+      let!(:block_toggle) { create(:feature_toggle, key: "home_whats_new", enabled: false) }
+      let!(:toast_toggle) { create(:feature_toggle, key: "toast_whats_new", enabled: false) }
+
+      it "does not load announcements" do
+        get root_path
+
+        expect(controller.instance_variable_get(:@announcements)).to be_nil
+      end
+    end
+
+    context "when user has dismissed an announcement" do
+      let!(:toggle) { create(:feature_toggle, key: "home_whats_new", enabled: true) }
+      let!(:dismissal) { create(:announcement_dismissal, user: user, announcement: announcement) }
+
+      it "excludes dismissed announcements" do
+        get root_path
+
+        expect(controller.instance_variable_get(:@announcements)).not_to include(announcement)
+      end
+    end
+  end
+
+  context "when user is not signed in" do
+    context "when toggle is enabled" do
+      let!(:toggle) { create(:feature_toggle, key: "home_whats_new", enabled: true) }
+
+      it "does not load announcements" do
+        get root_path
+
+        expect(controller.instance_variable_get(:@announcements)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Load `Announcement.for_user(current_user)` into `@announcements` in `HomeController#index`
- Only loads when user is signed in AND at least one toggle (`home_whats_new` or `toast_whats_new`) is enabled
- Respects grant-based visibility and dismissals via `for_user` scope

Part of the What's New announcements epic (#535). Closes #540

## Mutation testing
- Mutant: 97.91% (47/48 killed) — surviving mutant is a neutral mutation causing 403 on auth guard
- Evilution: 100% (9/9 killed)

## Test plan
- [ ] `bundle exec rspec spec/requests/home_announcements_spec.rb` — 5 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)