### PR TITLE
264.6: Add POST /announcements/dismiss endpoint

### DIFF
--- a/app/controllers/announcement_dismissals_controller.rb
+++ b/app/controllers/announcement_dismissals_controller.rb
@@ -1,0 +1,15 @@
+class AnnouncementDismissalsController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    announcement_ids = Array(params[:announcement_ids]).map(&:to_i)
+    already_dismissed = current_user.announcement_dismissals.where(announcement_id: announcement_ids).pluck(:announcement_id)
+    new_ids = announcement_ids - already_dismissed
+
+    new_ids.each do |announcement_id|
+      current_user.announcement_dismissals.create!(announcement_id: announcement_id)
+    end
+
+    head :ok
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
   has_many :news, foreign_key: :author_id, inverse_of: :author, dependent: :restrict_with_exception
   has_many :user_grants, dependent: :destroy
   has_many :grants, through: :user_grants
+  has_many :announcement_dismissals, dependent: :destroy
 
   validates :locale, inclusion: { in: I18n.available_locales.map(&:to_s) }
   validates :password, password_strength: true, if: :password_required?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
   resource :locale, only: [ :update ]
   resource :profile, only: [ :edit, :update ]
   resource :notification_settings, only: [ :edit, :update ]
+  resources :announcement_dismissals, only: [ :create ], path: "announcements/dismiss"
 
   namespace :podcast do
     resources :episodes, only: [ :index, :show ] do

--- a/spec/requests/announcement_dismissals_spec.rb
+++ b/spec/requests/announcement_dismissals_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "POST /announcements/dismiss" do
+  let_it_be(:user) { create(:user) }
+  let_it_be(:announcement1) { create(:announcement, version: "1.0.0", message: "First") }
+  let_it_be(:announcement2) { create(:announcement, version: "1.0.1", message: "Second") }
+
+  context "when signed in" do
+    before { sign_in user }
+
+    it "creates dismissals for the given announcement IDs" do
+      expect {
+        post announcement_dismissals_path, params: { announcement_ids: [ announcement1.id, announcement2.id ] }
+      }.to change(AnnouncementDismissal, :count).by(2)
+    end
+
+    it "responds with success" do
+      post announcement_dismissals_path, params: { announcement_ids: [ announcement1.id ] }
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "ignores already-dismissed announcements" do
+      create(:announcement_dismissal, user: user, announcement: announcement1)
+
+      expect {
+        post announcement_dismissals_path, params: { announcement_ids: [ announcement1.id, announcement2.id ] }
+      }.to change(AnnouncementDismissal, :count).by(1)
+    end
+
+    it "handles missing announcement_ids param" do
+      expect {
+        post announcement_dismissals_path, params: {}
+      }.not_to change(AnnouncementDismissal, :count)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context "when not signed in" do
+    it "redirects to sign in" do
+      post announcement_dismissals_path, params: { announcement_ids: [ announcement1.id ] }
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `POST /announcements/dismiss` with `announcement_ids` array
- Creates AnnouncementDismissal records for the current user, skipping duplicates
- Requires authentication (redirects guests to sign-in)
- Adds `has_many :announcement_dismissals` to User model

Part of the What's New announcements epic (#535). Closes #541

## Mutation testing
- Mutant: N/A (can't correlate request specs to controller methods)
- Evilution: 100% (39/39 killed)

## Test plan
- [ ] `bundle exec rspec spec/requests/announcement_dismissals_spec.rb` — 5 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)