### PR TITLE
264.7: Add What's New block partial on main page

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -27,7 +27,7 @@ class HomeController < ApplicationController
 
   private
 
-  BLOCK_KEYS = %i[hero running_tournaments recently_finished recent_games latest_news hall_of_fame stats documents].freeze
+  BLOCK_KEYS = %i[hero whats_new running_tournaments recently_finished recent_games latest_news hall_of_fame stats documents].freeze
 
   def load_block_visibility
     BLOCK_KEYS.index_with { |key| !FeatureToggle.disabled?("home_#{key}") }

--- a/app/views/home/_whats_new.html.erb
+++ b/app/views/home/_whats_new.html.erb
@@ -1,0 +1,25 @@
+<section data-controller="announcement-dismiss"
+         data-announcement-dismiss-url-value="<%= announcement_dismissals_path %>">
+  <h2 class="text-2xl font-bold text-maroon mb-6"><%= t(".title") %></h2>
+
+  <% announcements.group_by(&:version).each do |version, items| %>
+    <div class="border border-gray-200 rounded-lg p-4 mb-4">
+      <div class="flex items-center justify-between mb-2">
+        <h3 class="font-semibold text-lg"><%= t(".version", version: version) %></h3>
+        <button type="button"
+                class="text-neutral-400 hover:text-neutral-600"
+                data-action="announcement-dismiss#dismiss"
+                data-announcement-ids="<%= items.map(&:id).join(',') %>"
+                aria-label="<%= t(".dismiss") %>">
+          &times;
+        </button>
+      </div>
+
+      <ul class="space-y-1">
+        <% items.each do |announcement| %>
+          <li class="text-sm text-neutral-700"><%= announcement.message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+</section>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,6 +3,10 @@
     <%= render "home/hero" %>
   <% end %>
 
+  <% if @block_visible[:whats_new] && @announcements&.any? %>
+    <%= render "home/whats_new", announcements: @announcements %>
+  <% end %>
+
   <% if @block_visible[:running_tournaments] && @running_competitions.any? %>
     <%= render "home/running_tournaments",
          running_competitions: @running_competitions,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -224,6 +224,10 @@ en:
       title: "Vanilla Mafia"
       tagline: "Competitive Mafia club"
       cta: "Current tournament"
+    whats_new:
+      title: "What's New"
+      version: "Version %{version}"
+      dismiss: "Dismiss"
     recently_finished:
       title: "Recently finished tournaments"
       winner: "Winner"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -67,6 +67,10 @@ ru:
       title: "Vanilla Mafia"
       tagline: "Клуб спортивной мафии"
       cta: "Текущий турнир"
+    whats_new:
+      title: "Что нового"
+      version: "Версия %{version}"
+      dismiss: "Скрыть"
     recently_finished:
       title: "Недавно завершённые турниры"
       winner: "Победитель"

--- a/spec/requests/home_whats_new_spec.rb
+++ b/spec/requests/home_whats_new_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Home What's New block" do
+  let_it_be(:user) { create(:user) }
+  let_it_be(:announcement) { create(:announcement, version: "2.0.0", message: "New feature released") }
+
+  context "when signed in with home_whats_new enabled" do
+    let!(:toggle) { create(:feature_toggle, key: "home_whats_new", enabled: true) }
+
+    before do
+      sign_in user
+      get root_path
+    end
+
+    it "renders the What's New section title" do
+      expect(response.body).to include(I18n.t("home.whats_new.title"))
+    end
+
+    it "renders the version heading" do
+      expect(response.body).to include(I18n.t("home.whats_new.version", version: "2.0.0"))
+    end
+
+    it "renders the announcement message" do
+      expect(response.body).to include("New feature released")
+    end
+
+    it "renders the dismiss button" do
+      expect(response.body).to include(I18n.t("home.whats_new.dismiss"))
+    end
+
+    it "includes announcement IDs in dismiss button data" do
+      expect(response.body).to include("data-announcement-ids=\"#{announcement.id}\"")
+    end
+  end
+
+  context "when home_whats_new toggle is disabled" do
+    let!(:toggle) { create(:feature_toggle, key: "home_whats_new", enabled: false) }
+
+    before do
+      sign_in user
+      get root_path
+    end
+
+    it "does not render the What's New section" do
+      expect(response.body).not_to include(I18n.t("home.whats_new.title"))
+    end
+  end
+
+  context "when user is not signed in" do
+    let!(:toggle) { create(:feature_toggle, key: "home_whats_new", enabled: true) }
+
+    before { get root_path }
+
+    it "does not render the What's New section" do
+      expect(response.body).not_to include(I18n.t("home.whats_new.title"))
+    end
+  end
+
+  context "when all announcements are dismissed" do
+    let!(:toggle) { create(:feature_toggle, key: "home_whats_new", enabled: true) }
+    let!(:dismissal) { create(:announcement_dismissal, user: user, announcement: announcement) }
+
+    before do
+      sign_in user
+      get root_path
+    end
+
+    it "does not render the What's New section" do
+      expect(response.body).not_to include(I18n.t("home.whats_new.title"))
+    end
+  end
+
+  context "with multiple versions" do
+    let!(:toggle) { create(:feature_toggle, key: "home_whats_new", enabled: true) }
+    let!(:announcement2) { create(:announcement, version: "2.1.0", message: "Another update") }
+
+    before do
+      sign_in user
+      get root_path
+    end
+
+    it "renders both version headings" do
+      expect(response.body).to include(I18n.t("home.whats_new.version", version: "2.0.0"))
+      expect(response.body).to include(I18n.t("home.whats_new.version", version: "2.1.0"))
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Create `_whats_new.html.erb` partial: groups announcements by version with dismiss buttons
- Add `whats_new` to `BLOCK_KEYS` for toggle visibility
- Render between hero and running tournaments when `home_whats_new` toggle is enabled
- Add i18n keys for title, version heading, and dismiss button (en + ru)
- Also covers vanilla-mafia-264.10 (i18n keys for announcements)

Part of the What's New announcements epic (#535). Closes #542

## Mutation testing
- Mutant: 97.91% (from 264.5 — controller method unchanged)
- Evilution: 88.89% (surviving mutant is in shared `load_block_visibility` — covered by existing home_spec)

## Test plan
- [ ] `bundle exec rspec spec/requests/home_whats_new_spec.rb` — 9 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)