### PR TITLE
264.9: Add Stimulus controller for announcement dismiss

### DIFF
--- a/app/javascript/controllers/announcement_dismiss_controller.js
+++ b/app/javascript/controllers/announcement_dismiss_controller.js
@@ -1,0 +1,28 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { url: String }
+
+  async dismiss(event) {
+    const ids = event.currentTarget.dataset.announcementIds
+    if (!ids) return
+
+    const response = await fetch(this.urlValue, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": this.csrfToken
+      },
+      body: JSON.stringify({ announcement_ids: ids.split(",") })
+    })
+
+    if (response.ok) {
+      this.element.remove()
+    }
+  }
+
+  get csrfToken() {
+    const meta = document.querySelector('meta[name="csrf-token"]')
+    return meta ? meta.content : ""
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `announcement_dismiss_controller.js` Stimulus controller
- On dismiss click: POSTs announcement IDs to `/announcements/dismiss`, removes the element on success
- Works for both the What's New block and toast notification partials
- Uses the same CSRF token pattern as existing controllers

Closes #544

🤖 Generated with [Claude Code](https://claude.com/claude-code)