### PR TITLE
264.10: Add toast_title i18n key for announcement toast

### DIFF
--- a/app/views/layouts/_announcement_toast.html.erb
+++ b/app/views/layouts/_announcement_toast.html.erb
@@ -3,7 +3,7 @@
      data-announcement-dismiss-url-value="<%= announcement_dismissals_path %>">
   <div class="bg-white border border-gray-200 rounded-lg shadow-lg p-4">
     <div class="flex items-start justify-between mb-2">
-      <h4 class="font-semibold text-maroon"><%= t("home.whats_new.title") %></h4>
+      <h4 class="font-semibold text-maroon"><%= t("home.whats_new.toast_title") %></h4>
       <button type="button"
               class="text-neutral-400 hover:text-neutral-600 ml-4"
               data-action="announcement-dismiss#dismiss"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -226,6 +226,7 @@ en:
       cta: "Current tournament"
     whats_new:
       title: "What's New"
+      toast_title: "What's New"
       version: "Version %{version}"
       dismiss: "Dismiss"
     recently_finished:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -69,6 +69,7 @@ ru:
       cta: "Текущий турнир"
     whats_new:
       title: "Что нового"
+      toast_title: "Что нового"
       version: "Версия %{version}"
       dismiss: "Скрыть"
     recently_finished:

--- a/spec/requests/announcement_toast_spec.rb
+++ b/spec/requests/announcement_toast_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe "Announcement toast notification" do
     it "includes announcement IDs in dismiss button data" do
       expect(response.body).to include("data-announcement-ids=\"#{announcement.id}\"")
     end
+
+    it "renders the toast-specific title" do
+      expect(response.body).to include(I18n.t("home.whats_new.toast_title"))
+    end
   end
 
   context "when toast_whats_new toggle is disabled" do


### PR DESCRIPTION
## Summary
- Adds `toast_title` i18n key (en + ru) so the toast notification can have a distinct title from the What's New block
- Updates toast partial to use `home.whats_new.toast_title` instead of `home.whats_new.title`
- Adds spec verifying the toast renders the toast-specific title

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)