### PR TITLE
264.11: Add seed data for sample announcements

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -49,6 +49,17 @@ end
 missing_keys = FeatureToggle::KEYS - FeatureToggle.pluck(:key)
 raise "Missing feature toggle seeds: #{missing_keys.join(', ')}" if missing_keys.any?
 
+# Sample announcements
+[
+  { version: "1.0.0", grant_code: nil, message: "Добро пожаловать на обновлённый сайт Vanilla Mafia!" },
+  { version: "1.0.0", grant_code: nil, message: "Теперь доступен Зал славы и архив игр." },
+  { version: "1.1.0", grant_code: "judge", message: "Судьи: добавлены протоколы игр с автосохранением." },
+  { version: "1.1.0", grant_code: "editor", message: "Редакторы: добавлено управление новостями." },
+  { version: "1.2.0", grant_code: nil, message: "Добавлена лента новостей клуба." }
+].each do |attrs|
+  Announcement.find_or_create_by!(attrs)
+end
+
 # Admin user (set ADMIN_EMAIL and ADMIN_PASSWORD env vars)
 if ENV["ADMIN_EMAIL"].present? && ENV["ADMIN_PASSWORD"].present?
   user = User.find_or_initialize_by(email: ENV["ADMIN_EMAIL"])

--- a/spec/db/seeds_spec.rb
+++ b/spec/db/seeds_spec.rb
@@ -9,6 +9,26 @@ RSpec.describe "Seeds" do
     expect(FeatureToggle.pluck(:key)).to match_array(FeatureToggle::KEYS)
   end
 
+  it "seeds sample announcements" do
+    expect(Announcement.count).to be >= 3
+  end
+
+  it "seeds announcements with different grant codes" do
+    grant_codes = Announcement.pluck(:grant_code).uniq
+    expect(grant_codes).to include(nil)
+    expect(grant_codes.compact).not_to be_empty
+  end
+
+  it "is idempotent for announcements" do
+    initial_count = Announcement.count
+
+    expect {
+      load Rails.root.join("db/seeds.rb")
+    }.not_to change(Announcement, :count)
+
+    expect(Announcement.count).to eq(initial_count)
+  end
+
   it "is idempotent for feature toggles" do
     initial_count = FeatureToggle.count
     initial_keys  = FeatureToggle.pluck(:key)


### PR DESCRIPTION
## Summary
- Adds 5 sample announcements in `db/seeds.rb` across versions 1.0.0, 1.1.0, 1.2.0
- Includes announcements with `nil` grant_code (visible to all), plus `judge` and `editor` scoped ones
- Uses `find_or_create_by!` for idempotent seeding
- Adds specs verifying seed count, grant code diversity, and idempotency

Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)