### PR TITLE
202: Rewrite outdated competition table title

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -260,7 +260,7 @@ en:
       view_all: "View all"
   competitions:
     show:
-      by_children: "By series and games"
+      by_children: "Competitions"
       by_players: "By players"
       rank: "Rank"
       player: "Player"
@@ -274,7 +274,6 @@ en:
       date: "Date"
       season: "Season"
       series: "Series"
-      by_series: "By series and games"
       by_players: "By players"
       rank: "Rank"
       player: "Player"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -103,7 +103,7 @@ ru:
       view_all: "Подробнее"
   competitions:
     show:
-      by_children: "По сериям и играм"
+      by_children: "Соревнования"
       by_players: "По игрокам"
       rank: "Место"
       player: "Игрок"
@@ -117,7 +117,6 @@ ru:
       date: "Дата"
       season: "Сезон"
       series: "Серия"
-      by_series: "По сериям и играм"
       by_players: "По игрокам"
       rank: "Место"
       player: "Игрок"


### PR DESCRIPTION
## Summary
- Replaced outdated "By series and games" / "По сериям и играм" table title with "Competitions" / "Соревнования" on the competition parent page
- Removed unused `by_series` locale keys from `seasons.show`

Closes #454

## Test plan
- [x] `spec/requests/competitions_spec.rb` — 15 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)