### PR TITLE
203: Fix first column name on competition parent page

### DIFF
--- a/app/views/competitions/show.html.erb
+++ b/app/views/competitions/show.html.erb
@@ -8,7 +8,7 @@
       <table class="data-table">
         <thead>
           <tr>
-            <th><%= t(".player") %></th>
+            <th><%= t(".name") %></th>
             <th><%= t(".games") %></th>
             <th></th>
           </tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -261,6 +261,7 @@ en:
   competitions:
     show:
       by_children: "Competitions"
+      name: "Name"
       by_players: "By players"
       rank: "Rank"
       player: "Player"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -104,6 +104,7 @@ ru:
   competitions:
     show:
       by_children: "Соревнования"
+      name: "Название"
       by_players: "По игрокам"
       rank: "Место"
       player: "Игрок"


### PR DESCRIPTION
## Summary
- Changed first table column header from "Player"/"Игрок" to "Name"/"Название" since it displays child competition names, not players
- Added new `name` locale key for `competitions.show`

Closes #456

## Test plan
- [x] `spec/requests/competitions_spec.rb` — 15 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)