### PR TITLE
204: Remove pagination from competition parent players table

### DIFF
--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -6,7 +6,7 @@ class CompetitionsController < ApplicationController
 
     if @parent_view
       @games_by_child = result.games_by_child
-      @pagy, @players = pagy(result.players, limit: 25, count: result.player_count)
+      @players = result.players
     else
       @games = result.games
       @participations_by_player = result.participations_by_player

--- a/app/services/competition_overview_service.rb
+++ b/app/services/competition_overview_service.rb
@@ -1,5 +1,5 @@
 class CompetitionOverviewService
-  Result = Data.define(:parent_view, :games_by_child, :players, :player_count, :games, :participations_by_player, :players_sorted)
+  Result = Data.define(:parent_view, :games_by_child, :players, :games, :participations_by_player, :players_sorted)
 
   def self.call(competition:)
     new(competition).call
@@ -29,7 +29,6 @@ class CompetitionOverviewService
       parent_view: true,
       games_by_child: games_by_child,
       players: Player.with_aggregated_stats.where(games: { competition_id: subtree_ids }).ranked,
-      player_count: Player.joins(game_participations: :game).where(games: { competition_id: subtree_ids }).distinct.count,
       games: Game.none,
       participations_by_player: {},
       players_sorted: []
@@ -45,7 +44,6 @@ class CompetitionOverviewService
       parent_view: false,
       games_by_child: {},
       players: [],
-      player_count: participations_by_player.size,
       games: games,
       participations_by_player: participations_by_player,
       players_sorted: players_sorted

--- a/app/views/competitions/show.html.erb
+++ b/app/views/competitions/show.html.erb
@@ -48,7 +48,7 @@
         <tbody>
           <% @players.each_with_index do |player, index| %>
             <tr>
-              <td><%= @pagy.from + index %></td>
+              <td><%= index + 1 %></td>
               <td><%= link_to player.name, player_path(player) %></td>
               <td><%= player.total_rating %></td>
               <td><%= player.games_count %></td>
@@ -58,8 +58,6 @@
         </tbody>
       </table>
     </div>
-
-    <%= render "shared/pagy_nav", pagy: @pagy %>
   </section>
 <% else %>
   <div class="scroll-wrapper">

--- a/spec/services/competition_overview_service_spec.rb
+++ b/spec/services/competition_overview_service_spec.rb
@@ -63,10 +63,6 @@ RSpec.describe CompetitionOverviewService do
         expect(player.total_rating).to eq(2.5)
       end
 
-      it "returns the player count" do
-        expect(result.player_count).to eq(2)
-      end
-
       it "reports as parent" do
         expect(result.parent_view).to be true
       end
@@ -98,10 +94,6 @@ RSpec.describe CompetitionOverviewService do
         expect(result.participations_by_player[player2]).to contain_exactly(participation2, participation4)
       end
 
-      it "returns the player count" do
-        expect(result.player_count).to eq(2)
-      end
-
       it "sorts players by total rating descending" do
         expect(result.players_sorted).to eq([ player2, player1 ])
       end
@@ -129,7 +121,6 @@ RSpec.describe CompetitionOverviewService do
 
         expect(result.games_by_child.values.flatten).to be_empty
         expect(result.players).to be_empty
-        expect(result.player_count).to eq(0)
       end
 
       it "returns empty data for leaf" do
@@ -139,7 +130,6 @@ RSpec.describe CompetitionOverviewService do
         expect(result.games).to be_empty
         expect(result.participations_by_player).to be_empty
         expect(result.players_sorted).to be_empty
-        expect(result.player_count).to eq(0)
       end
     end
   end


### PR DESCRIPTION
## Summary
- Removed pagy pagination from the players table on competition parent pages — all players are now shown
- Removed `player_count` from `CompetitionOverviewService` (only needed for pagy)
- Rank column now uses simple `index + 1` instead of `@pagy.from + index`

Closes #458

## Test plan
- [x] `spec/requests/competitions_spec.rb` — 15 examples, 0 failures
- [x] `spec/services/competition_overview_service_spec.rb` — 18 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)