### PR TITLE
210: Highlight rows of winning players on game page

### DIFF
--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -28,7 +28,7 @@
     </thead>
     <tbody>
       <% @participations.each do |participation| %>
-        <tr>
+        <tr class="<%= 'bg-green-50' if participation.win %>">
           <td><%= participation.seat %></td>
           <td><%= link_to participation.player.name, player_path(participation.player), class: "text-maroon hover:underline" %></td>
           <td>


### PR DESCRIPTION
## Summary
- Added `bg-green-50` background to game participation table rows where `participation.win` is true
- Subtle green highlight makes it easy to identify winners at a glance

Closes #459

## Test plan
- [x] `spec/requests/games_spec.rb` — 10 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)