### PR TITLE
205: Link player nicknames to profiles on competition child page

### DIFF
--- a/app/views/competitions/show.html.erb
+++ b/app/views/competitions/show.html.erb
@@ -76,7 +76,7 @@
           <% participations = @participations_by_player[player] %>
           <% participations_by_game = participations.index_by(&:game_id) %>
           <tr>
-            <td><%= player.name %></td>
+            <td><%= link_to player.name, player_path(player) %></td>
             <% @games.each do |game| %>
               <td><%= participations_by_game[game.id]&.total %></td>
             <% end %>


### PR DESCRIPTION
## Summary
- Wrapped player names in the leaf competition table with `link_to player_path`, making them clickable links to player profiles

Closes #460

## Test plan
- [x] `spec/requests/competitions_spec.rb` — 15 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)