### PR TITLE
211: Add subtitle with game result on game page

### DIFF
--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -13,6 +13,8 @@
   <% end %>
 </div>
 
+<p class="text-lg text-gray-600 mb-6"><%= t(".result.#{@game.result}") %></p>
+
 <div class="scroll-wrapper">
   <table class="data-table">
     <thead>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -330,6 +330,10 @@ en:
       additional_score: "Bonus"
       best_move: "Best move"
       total: "Total"
+      result:
+        in_progress: "In progress"
+        peace_victory: "City wins"
+        mafia_victory: "Mafia wins"
     overlay:
       seat: "Seat"
       player: "Player"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -173,6 +173,10 @@ ru:
       additional_score: "Доп. балл"
       best_move: "Лучший ход"
       total: "Итого"
+      result:
+        in_progress: "Игра в процессе"
+        peace_victory: "Победа мирных"
+        mafia_victory: "Победа мафии"
     overlay:
       seat: "Место"
       player: "Игрок"


### PR DESCRIPTION
## Summary
- Added a subtitle below the game title showing the result: "City wins" / "Mafia wins" / "In progress"
- Added `games.show.result` locale keys for both EN and RU

Closes #461

## Test plan
- [x] `spec/requests/games_spec.rb` — 10 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)