### PR TITLE
206: Link game names to game details on competition child page

### DIFF
--- a/app/views/competitions/show.html.erb
+++ b/app/views/competitions/show.html.erb
@@ -66,7 +66,7 @@
         <tr>
           <th><%= t(".player") %></th>
           <% @games.each do |game| %>
-            <th><%= t("common.game") %> <%= game.game_number %></th>
+            <th><%= link_to "#{t('common.game')} #{game.game_number}", game_path(game), class: "text-maroon hover:underline" %></th>
           <% end %>
           <th><%= t(".total") %></th>
         </tr>


### PR DESCRIPTION
## Summary
- Made game column headers ("Game 1", "Game 2", etc.) in the leaf competition table clickable links to the game detail page

Closes #462

## Test plan
- [x] `spec/requests/competitions_spec.rb` — 15 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)