### PR TITLE
212: Add subtitle with judge name on game page

### DIFF
--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -13,7 +13,10 @@
   <% end %>
 </div>
 
-<p class="text-lg text-gray-600 mb-6"><%= t(".result.#{@game.result}") %></p>
+<p class="text-lg text-gray-600 mb-2"><%= t(".result.#{@game.result}") %></p>
+<% if @game.judge.present? %>
+  <p class="text-sm text-gray-500 mb-6"><%= t(".judge", name: @game.judge) %></p>
+<% end %>
 
 <div class="scroll-wrapper">
   <table class="data-table">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -330,6 +330,7 @@ en:
       additional_score: "Bonus"
       best_move: "Best move"
       total: "Total"
+      judge: "Judge: %{name}"
       result:
         in_progress: "In progress"
         peace_victory: "City wins"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -173,6 +173,7 @@ ru:
       additional_score: "Доп. балл"
       best_move: "Лучший ход"
       total: "Итого"
+      judge: "Ведущий: %{name}"
       result:
         in_progress: "Игра в процессе"
         peace_victory: "Победа мирных"


### PR DESCRIPTION
## Summary
- Added judge name subtitle below the game result line ("Judge: Name" / "Ведущий: Name")
- Only shown when `game.judge` is present

Closes #463

## Test plan
- [x] `spec/requests/games_spec.rb` — 10 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)