### PR TITLE
207: Show linked news on competition child page

### DIFF
--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -11,6 +11,7 @@ class CompetitionsController < ApplicationController
       @games = result.games
       @participations_by_player = result.participations_by_player
       @players_sorted = result.players_sorted
+      @news = result.news
     end
   end
 end

--- a/app/services/competition_overview_service.rb
+++ b/app/services/competition_overview_service.rb
@@ -1,5 +1,5 @@
 class CompetitionOverviewService
-  Result = Data.define(:parent_view, :games_by_child, :players, :games, :participations_by_player, :players_sorted)
+  Result = Data.define(:parent_view, :games_by_child, :players, :games, :participations_by_player, :players_sorted, :news)
 
   def self.call(competition:)
     new(competition).call
@@ -31,7 +31,8 @@ class CompetitionOverviewService
       players: Player.with_aggregated_stats.where(games: { competition_id: subtree_ids }).ranked,
       games: Game.none,
       participations_by_player: {},
-      players_sorted: []
+      players_sorted: [],
+      news: []
     )
   end
 
@@ -46,7 +47,8 @@ class CompetitionOverviewService
       players: [],
       games: games,
       participations_by_player: participations_by_player,
-      players_sorted: players_sorted
+      players_sorted: players_sorted,
+      news: News.published.for_competition(@competition).includes(:author, :tags, content_attachment: :blob).recent
     )
   end
 end

--- a/app/views/competitions/show.html.erb
+++ b/app/views/competitions/show.html.erb
@@ -86,4 +86,28 @@
       </tbody>
     </table>
   </div>
+
+  <% if @news.any? %>
+    <section class="mt-10">
+      <h2 class="text-2xl font-bold text-maroon mb-4"><%= t(".news") %></h2>
+      <div class="space-y-6">
+        <% @news.each do |article| %>
+          <article class="border-b border-neutral-200 pb-4">
+            <h3 class="text-lg font-bold mb-1"><%= article.title %></h3>
+            <div class="text-sm text-neutral-500 mb-2">
+              <% if article.published_at.present? %>
+                <%= l(article.published_at, format: :short) %>
+              <% end %>
+              <% if article.author.claimed_player? %>
+                · <%= article.author.player.name %>
+              <% end %>
+            </div>
+            <div class="prose max-w-none text-neutral-700">
+              <%= article.content %>
+            </div>
+          </article>
+        <% end %>
+      </div>
+    </section>
+  <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -270,6 +270,7 @@ en:
       win_rate: "Win rate"
       view: "Result"
       total: "Total"
+      news: "News"
   seasons:
     show:
       date: "Date"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -113,6 +113,7 @@ ru:
       win_rate: "Процент побед"
       view: "Итог"
       total: "Итого"
+      news: "Новости"
   seasons:
     show:
       date: "Дата"


### PR DESCRIPTION
## Summary
- Added a news section below the scores table on leaf competition pages
- Loads published news linked to the competition via `News.for_competition`
- Displays title, date, author, and rich text content (matching the news index style)
- Added `news` field to `CompetitionOverviewService::Result`

Closes #464

## Test plan
- [x] `spec/requests/competitions_spec.rb` — 15 examples, 0 failures
- [x] `spec/services/competition_overview_service_spec.rb` — 18 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)