### PR TITLE
213: Refactor player profile with stats and awards

### DIFF
--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -6,5 +6,6 @@ class PlayersController < ApplicationController
     @games_by_competition = games.group_by { |g| g.competition.root }
     @player_awards = result.player_awards
     @news_articles = result.news_articles
+    @stats = result.stats
   end
 end

--- a/app/services/player_profile_service.rb
+++ b/app/services/player_profile_service.rb
@@ -1,5 +1,7 @@
 class PlayerProfileService
-  Result = Data.define(:player, :games, :player_awards, :news_articles)
+  Result = Data.define(:player, :games, :player_awards, :news_articles, :stats)
+  Stats = Data.define(:total_games, :total_wins, :win_rate, :first_game_date, :role_stats)
+  RoleStat = Data.define(:role_code, :role_name, :games, :wins, :win_rate)
 
   def self.call(player_id:)
     new(player_id).call
@@ -11,11 +13,48 @@ class PlayerProfileService
 
   def call
     player = Player.find(@player_id)
+    participations = player.game_participations.includes(:role, :game)
+
     Result.new(
       player: player,
       games: player.games.includes(competition: :parent).ordered,
       player_awards: player.player_awards.ordered.includes(:award).load,
-      news_articles: News.mentioning_player(player).includes({ author: :player }, :tags, :rich_text_content)
+      news_articles: News.mentioning_player(player).includes({ author: :player }, :tags, :rich_text_content),
+      stats: build_stats(participations)
     )
+  end
+
+  private
+
+  def build_stats(participations)
+    loaded = participations.to_a
+    total_games = loaded.size
+    total_wins = loaded.count(&:win)
+
+    Stats.new(
+      total_games: total_games,
+      total_wins: total_wins,
+      win_rate: total_games.zero? ? 0.0 : (total_wins * 100.0 / total_games).round(1),
+      first_game_date: loaded.filter_map { |p| p.game.played_on }.min,
+      role_stats: build_role_stats(loaded)
+    )
+  end
+
+  def build_role_stats(participations)
+    participations
+      .select { |p| p.role_code.present? }
+      .group_by(&:role_code)
+      .map do |role_code, role_participations|
+        games = role_participations.size
+        wins = role_participations.count(&:win)
+        RoleStat.new(
+          role_code: role_code,
+          role_name: role_participations.first.role.name,
+          games: games,
+          wins: wins,
+          win_rate: (wins * 100.0 / games).round(1)
+        )
+      end
+      .sort_by { |rs| [ -rs.games, rs.role_code ] }
   end
 end

--- a/app/views/players/show.html.erb
+++ b/app/views/players/show.html.erb
@@ -1,7 +1,7 @@
 <h1 class="text-3xl font-bold text-maroon mb-6"><%= @player.name %></h1>
 
-<div class="rounded border border-maroon/20 p-4">
-  <div class="flex items-start gap-4">
+<div class="rounded border border-maroon/20 p-4 mb-6">
+  <div class="flex flex-col md:flex-row gap-6">
     <div id="player-photo" class="shrink-0">
       <% if @player.photo.attached? %>
         <%= image_tag @player.photo.variant(resize_to_limit: [300, 300]), alt: @player.name %>
@@ -9,13 +9,51 @@
         <%= image_tag Player::DEFAULT_PHOTO_PATH, alt: @player.name %>
       <% end %>
     </div>
-    <% if @player_awards.any? %>
-      <div id="player-awards" class="ml-auto flex w-full flex-wrap justify-end gap-2">
-        <% @player_awards.each do |pa| %>
-          <%= render partial: "hall_of_fame/award", locals: { player_award: pa } %>
+
+    <div class="flex-1 space-y-4">
+      <div class="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
+        <div>
+          <span class="text-gray-500"><%= t(".total_games") %></span>
+          <p class="text-lg font-semibold"><%= @stats.total_games %></p>
+        </div>
+        <div>
+          <span class="text-gray-500"><%= t(".win_rate") %></span>
+          <p class="text-lg font-semibold"><%= @stats.win_rate %>%</p>
+        </div>
+        <% if @stats.first_game_date %>
+          <div>
+            <span class="text-gray-500"><%= t(".playing_since") %></span>
+            <p class="text-lg font-semibold"><%= l(@stats.first_game_date, format: :short) %></p>
+          </div>
         <% end %>
       </div>
-    <% end %>
+
+      <% if @stats.role_stats.any? %>
+        <div>
+          <h3 class="text-sm text-gray-500 mb-2"><%= t(".role_stats") %></h3>
+          <div class="flex flex-wrap gap-3">
+            <% @stats.role_stats.each do |rs| %>
+              <div class="flex items-center gap-2 rounded bg-gray-50 px-3 py-1.5 text-sm">
+                <span class="font-medium"><%= rs.role_name %></span>
+                <span><%= rs.games %></span>
+                <span class="text-gray-400">|</span>
+                <span><%= rs.win_rate %>%</span>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+
+      <% if @player_awards.any? %>
+        <div id="player-awards">
+          <div class="flex flex-wrap gap-2">
+            <% @player_awards.each do |pa| %>
+              <%= render partial: "hall_of_fame/award", locals: { player_award: pa } %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
   </div>
 </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -373,6 +373,10 @@ en:
       dispute_player: "Dispute profile"
       dispute_pending: "Dispute pending"
       edit_profile: "Edit profile"
+      total_games: "Games played"
+      win_rate: "Win rate"
+      role_stats: "By roles"
+      playing_since: "Playing since"
   profiles:
     edit:
       title: "Edit profile"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -223,6 +223,10 @@ ru:
       dispute_player: "Оспорить профиль"
       dispute_pending: "Запрос на оспаривание на рассмотрении"
       edit_profile: "Редактировать профиль"
+      total_games: "Игр сыграно"
+      win_rate: "Процент побед"
+      role_stats: "По ролям"
+      playing_since: "Играет с"
       news: "Новости"
   profiles:
     edit:

--- a/spec/services/player_profile_service_spec.rb
+++ b/spec/services/player_profile_service_spec.rb
@@ -99,6 +99,72 @@ RSpec.describe PlayerProfileService do
       expect(articles.first.association(:rich_text_content)).to be_loaded
     end
 
+    describe "stats" do
+      let_it_be(:stats_player) { create(:player, name: "Статистик") }
+      let_it_be(:peace_role) { Role.find_or_create_by!(code: "peace") { |r| r.name = "Мирный" } }
+      let_it_be(:mafia_role) { Role.find_or_create_by!(code: "mafia") { |r| r.name = "Мафия" } }
+      let_it_be(:sheriff_role) { Role.find_or_create_by!(code: "sheriff") { |r| r.name = "Шериф" } }
+      let_it_be(:stats_game1) { create(:game, game_number: 1, result: :peace_victory, played_on: Date.new(2024, 6, 15)) }
+      let_it_be(:stats_game2) { create(:game, game_number: 2, result: :mafia_victory, played_on: Date.new(2024, 3, 1)) }
+      let_it_be(:stats_game3) { create(:game, game_number: 3, result: :peace_victory, played_on: Date.new(2025, 1, 10)) }
+
+      before do
+        create(:game_participation, game: stats_game1, player: stats_player, role: peace_role, win: true)
+        create(:game_participation, game: stats_game2, player: stats_player, role: mafia_role, win: true)
+        create(:game_participation, game: stats_game3, player: stats_player, role: peace_role, win: false)
+      end
+
+      let(:stats) { described_class.call(player_id: stats_player.id).stats }
+
+      it "returns total games count" do
+        expect(stats.total_games).to eq(3)
+      end
+
+      it "returns total wins count" do
+        expect(stats.total_wins).to eq(2)
+      end
+
+      it "returns win rate as percentage" do
+        expect(stats.win_rate).to eq(66.7)
+      end
+
+      it "returns earliest game date regardless of order" do
+        expect(stats.first_game_date).to eq(Date.new(2024, 3, 1))
+      end
+
+      it "returns role stats for each role played" do
+        expect(stats.role_stats).to contain_exactly(
+          have_attributes(role_code: "peace", role_name: "Мирный", games: 2, wins: 1, win_rate: 50.0),
+          have_attributes(role_code: "mafia", role_name: "Мафия", games: 1, wins: 1, win_rate: 100.0)
+        )
+      end
+
+      it "orders role stats by games count descending" do
+        expect(stats.role_stats.first.role_code).to eq("peace")
+      end
+
+      context "when player has no games" do
+        let_it_be(:no_games_player) { create(:player, name: "Новичок") }
+        let(:empty_stats) { described_class.call(player_id: no_games_player.id).stats }
+
+        it "returns zero total games" do
+          expect(empty_stats.total_games).to eq(0)
+        end
+
+        it "returns zero win rate" do
+          expect(empty_stats.win_rate).to eq(0.0)
+        end
+
+        it "returns nil first game date" do
+          expect(empty_stats.first_game_date).to be_nil
+        end
+
+        it "returns empty role stats" do
+          expect(empty_stats.role_stats).to be_empty
+        end
+      end
+    end
+
     context "when player has no games or awards" do
       let_it_be(:lonely_player) { create(:player, name: "Одинокий") }
       let(:lonely_result) { described_class.call(player_id: lonely_player.id) }


### PR DESCRIPTION
## Summary
- Added player statistics to the profile page: total games, win rate, per-role breakdown (games + win rate), and "playing since" date
- Restructured the main block layout — photo on left, stats grid + role chips + awards on right (responsive with `flex-col md:flex-row`)
- Added `Stats` and `RoleStat` data structs to `PlayerProfileService`

Closes #465

## Mutation testing
- Mutant: 91.6% (282/308 — survivors are eager loading mutations and `.to_a`/`.to_ary` equivalents)
- Evilution: 100% (173/173, 3 equivalent)

## Test plan
- [x] `spec/services/player_profile_service_spec.rb` — 30 examples, 0 failures
- [x] `spec/requests/players_spec.rb` — 44 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)