### PR TITLE
216: Show Edit profile link to admins on player profile

### DIFF
--- a/app/views/players/show.html.erb
+++ b/app/views/players/show.html.erb
@@ -62,6 +62,10 @@
     <div class="mb-6">
       <%= link_to t(".edit_profile"), edit_profile_path, class: "text-maroon hover:underline font-medium" %>
     </div>
+  <% elsif current_user.admin? %>
+    <div class="mb-6">
+      <%= link_to t(".edit_profile"), avo.edit_resources_player_path(@player), class: "text-maroon hover:underline font-medium" %>
+    </div>
   <% elsif (existing_claim = current_user.player_claims.find_by(player: @player)) %>
     <% if existing_claim.pending? %>
       <p class="text-gray-600 italic mb-6">

--- a/spec/requests/players_spec.rb
+++ b/spec/requests/players_spec.rb
@@ -92,6 +92,26 @@ RSpec.describe PlayersController do
       end
     end
 
+    context "when user is an admin viewing another player" do
+      let_it_be(:player) { create(:player, name: "Чужой") }
+      let_it_be(:game) { create(:game, game_number: 10) }
+      let_it_be(:participation) { create(:game_participation, game: game, player: player) }
+      let(:admin) { create(:user, :admin) }
+
+      before do
+        sign_in admin
+        get player_path(player)
+      end
+
+      it "renders the edit profile link" do
+        expect(response.body).to include(I18n.t("players.show.edit_profile"))
+      end
+
+      it "links to the Avo edit page" do
+        expect(response.body).to include(avo.edit_resources_player_path(player))
+      end
+    end
+
     context "when player is unclaimed and user can claim" do
       let_it_be(:player) { create(:player, name: "Свободный") }
       let_it_be(:game) { create(:game, game_number: 3) }


### PR DESCRIPTION
## Summary
- Profile owner sees "Edit profile" linking to their profile editor (`edit_profile_path`)
- Admin users now also see "Edit profile", linking to the Avo player edit page (`avo.edit_resources_player_path`)

Closes #467

## Test plan
- [x] `spec/requests/players_spec.rb` — 39 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)