### PR TITLE
217: Link player nicknames to profiles on Hall of Fame

### DIFF
--- a/app/views/hall_of_fame/_player_card.html.erb
+++ b/app/views/hall_of_fame/_player_card.html.erb
@@ -8,7 +8,7 @@
         <%= image_tag Player::DEFAULT_PHOTO_PATH, alt: player.name %>
       <% end %>
     </div>
-    <p class="font-medium"><%= player.name %></p>
+    <p class="font-medium"><%= link_to player.name, player_path(player), class: "text-maroon hover:underline" %></p>
     <div class="flex flex-wrap gap-2">
       <% awards.each do |pa| %>
         <%= render partial: "hall_of_fame/award", locals: { player_award: pa } %>

--- a/app/views/home/_hall_of_fame.html.erb
+++ b/app/views/home/_hall_of_fame.html.erb
@@ -13,7 +13,7 @@
                         alt: player.name,
                         class: "w-16 h-16 rounded-full object-cover mb-2" %>
         <% end %>
-        <p class="text-sm font-medium truncate w-full"><%= player.name %></p>
+        <p class="text-sm font-medium truncate w-full"><%= link_to player.name, player_path(player), class: "text-maroon hover:underline" %></p>
       </div>
     <% end %>
   </div>

--- a/spec/requests/hall_of_fame_spec.rb
+++ b/spec/requests/hall_of_fame_spec.rb
@@ -30,6 +30,10 @@ RSpec.describe HallOfFameController do
         expect(response.body).to include("Лучший игрок")
       end
 
+      it "links player name to player profile" do
+        assert_select "a[href=?]", player_path(player), text: "Алексей"
+      end
+
       it "renders default photo for players without uploaded pictures" do
         expect(response.body).to include(Player::DEFAULT_PHOTO_PATH)
       end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -437,6 +437,10 @@ RSpec.describe HomeController do
       it "renders the player photo placeholder" do
         expect(response.body).to include(Player::DEFAULT_PHOTO_PATH)
       end
+
+      it "links player name to player profile" do
+        assert_select "a[href=?]", player_path(player), text: "Star Player"
+      end
     end
 
     context "when more than 6 awarded players exist" do


### PR DESCRIPTION
## Summary
- Player names on the Hall of Fame page (`_player_card` partial) are now links to their profile pages
- Player names in the home page Hall of Fame teaser are also linked to profiles
- Added request specs verifying the links in both locations

Closes #469

## Test plan
- [ ] Visit `/hall` — player names should be clickable links to `/players/:id`
- [ ] Visit home page — Hall of Fame teaser player names should be clickable links
- [ ] Verify link styling (maroon color, underline on hover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)