### PR TITLE
224: Fix dispute form title to show player nickname

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -352,7 +352,7 @@ en:
     award: {}
   player_disputes:
     new:
-      title: "Dispute profile %{player_name}"
+      title: "Player %{player_name} is actually me"
       evidence_label: "Evidence"
       evidence_placeholder: "Describe why this profile belongs to you"
       submit: "Submit"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -196,7 +196,7 @@ ru:
         claim_already_exists: "Заявка на этого игрока уже существует."
   player_disputes:
     new:
-      title: "Оспаривание профиля %{player_name}"
+      title: "На самом деле игрок %{player_name} — это я"
       evidence_label: "Обоснование"
       evidence_placeholder: "Опишите, почему этот профиль принадлежит вам"
       submit: "Отправить"

--- a/spec/requests/player_disputes_spec.rb
+++ b/spec/requests/player_disputes_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe PlayerDisputesController do
       it "returns success" do
         expect(response).to have_http_status(:ok)
       end
+
+      it "renders the title with the player nickname" do
+        expect(response.body).to include(I18n.t("player_disputes.new.title", player_name: player.name))
+      end
     end
   end
 


### PR DESCRIPTION
## Summary
- Updated dispute form title to include the player's nickname dynamically
- RU: "На самом деле игрок {name} — это я"
- EN: "Player {name} is actually me"
- Added test verifying the title renders with the player's name

Closes #476

## Test plan
- [ ] Visit `/players/:id/dispute/new` — title should show the player's nickname

🤖 Generated with [Claude Code](https://claude.com/claude-code)