### PR TITLE
267: Show help section link in sidebar for judges and admins

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,6 +48,10 @@ class User < ApplicationRecord
     admin? || editor?
   end
 
+  def can_view_help?
+    admin? || judge?
+  end
+
   def claimed_player?
     player_id.present?
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -69,6 +69,12 @@
                     class: "block text-gray-300 hover:text-white transition-colors" %>
             </li>
           <% end %>
+          <% if current_user.can_view_help? %>
+            <li>
+              <%= link_to t("nav.help"), help_index_path,
+                    class: "block text-gray-300 hover:text-white transition-colors" %>
+            </li>
+          <% end %>
           <% if current_user.can_manage_news? %>
             <li>
               <%= link_to t("nav.manage_news"), admin_news_index_path,
@@ -143,6 +149,12 @@
                 <% if current_user.can_manage_protocols? %>
                   <li>
                     <%= link_to t("nav.protocols"), judge_protocols_path,
+                          class: "block hover:text-white transition-colors" %>
+                  </li>
+                <% end %>
+                <% if current_user.can_view_help? %>
+                  <li>
+                    <%= link_to t("nav.help"), help_index_path,
                           class: "block hover:text-white transition-colors" %>
                   </li>
                 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -214,6 +214,7 @@ en:
     notification_settings: "Notifications"
     sign_in: "Sign in"
     sign_out: "Sign out"
+    help: "Help"
     admin: "Admin"
   notification_settings:
     edit:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -372,6 +372,7 @@ ru:
     notification_settings: "Уведомления"
     sign_in: "Войти"
     sign_out: "Выйти"
+    help: "Справка"
     admin: "Админка"
   notification_settings:
     edit:

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -277,6 +277,56 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "#can_view_help?" do
+    let(:user) { create(:user) }
+
+    context "when user has admin grant" do
+      let(:admin_grant) { Grant.find_or_create_by!(code: "admin") }
+
+      before { create(:user_grant, user: user, grant: admin_grant) }
+
+      it "returns true" do
+        expect(user.can_view_help?).to be true
+      end
+    end
+
+    context "when user has judge grant" do
+      let(:judge_grant) { Grant.find_or_create_by!(code: "judge") }
+
+      before { create(:user_grant, user: user, grant: judge_grant) }
+
+      it "returns true" do
+        expect(user.can_view_help?).to be true
+      end
+    end
+
+    context "when user has no grants" do
+      it "returns false" do
+        expect(user.can_view_help?).to be false
+      end
+    end
+
+    context "when user has editor grant" do
+      let(:editor_grant) { Grant.find_or_create_by!(code: "editor") }
+
+      before { create(:user_grant, user: user, grant: editor_grant) }
+
+      it "returns false" do
+        expect(user.can_view_help?).to be false
+      end
+    end
+
+    context "when user has subscriber grant" do
+      let(:subscriber_grant) { Grant.find_or_create_by!(code: "subscriber") }
+
+      before { create(:user_grant, user: user, grant: subscriber_grant) }
+
+      it "returns false" do
+        expect(user.can_view_help?).to be false
+      end
+    end
+  end
+
   describe "#claimed_player?" do
     context "when user has a claimed player" do
       let(:player) { create(:player) }

--- a/spec/requests/navigation_spec.rb
+++ b/spec/requests/navigation_spec.rb
@@ -5,6 +5,44 @@ RSpec.describe "Navigation" do
   let_it_be(:admin) { create(:user, :admin) }
   let_it_be(:user) { create(:user) }
 
+  describe "help link" do
+    let_it_be(:judge) { create(:user, :judge) }
+
+    context "when signed in as judge" do
+      before { sign_in judge }
+
+      it "displays the help link" do
+        get "/news"
+        expect(response.body).to include(help_index_path)
+      end
+    end
+
+    context "when signed in as admin" do
+      before { sign_in admin }
+
+      it "displays the help link" do
+        get "/news"
+        expect(response.body).to include(help_index_path)
+      end
+    end
+
+    context "when signed in as regular user" do
+      before { sign_in user }
+
+      it "does not display the help link" do
+        get "/news"
+        expect(response.body).not_to include(help_index_path)
+      end
+    end
+
+    context "when not signed in" do
+      it "does not display the help link" do
+        get "/news"
+        expect(response.body).not_to include(help_index_path)
+      end
+    end
+  end
+
   describe "podcast link" do
     context "when signed in as subscriber" do
       before { sign_in subscriber }


### PR DESCRIPTION
## Summary
- Add `User#can_view_help?` method (returns true for judges and admins)
- Show help link in both mobile and desktop sidebar navigation for users with relevant grants
- Add `nav.help` i18n key in both Russian and English locales

## Mutation Testing
- Mutant: 100% (14/14 mutants killed)
- Evilution: 100% (4/4 mutants killed)

## Test plan
- [x] User model: `can_view_help?` returns true for admin, true for judge, false for editor, false for subscriber, false for no grants
- [x] Navigation: help link shown for judge and admin, hidden for regular user and unauthenticated

Closes #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)