### PR TITLE
266: Add content length validation to News model

### DIFF
--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -11,8 +11,11 @@ class News < ApplicationRecord
 
   enum :status, { draft: "draft", published: "published" }
 
+  MAX_CONTENT_LENGTH = 50_000
+
   validates :title, presence: true
   validates :status, presence: true
+  validate :content_length_within_limit
 
   scope :recent, -> { order(Arel.sql("published_at IS NULL, published_at DESC, id DESC")) }
   scope :drafts_first, -> { order(Arel.sql("published_at IS NOT NULL, published_at DESC, id DESC")) }
@@ -33,5 +36,16 @@ class News < ApplicationRecord
 
   def unpublish!
     update!(status: :draft, published_at: nil)
+  end
+
+  private
+
+  def content_length_within_limit
+    return if content.blank?
+
+    plain_text_length = content.body.to_plain_text.length
+    if plain_text_length > MAX_CONTENT_LENGTH
+      errors.add(:content, :too_long, count: MAX_CONTENT_LENGTH)
+    end
   end
 end

--- a/spec/models/news_spec.rb
+++ b/spec/models/news_spec.rb
@@ -14,6 +14,26 @@ RSpec.describe News, type: :model do
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:status) }
     it { is_expected.to define_enum_for(:status).with_values(draft: "draft", published: "published").backed_by_column_of_type(:string) }
+
+    describe "content length" do
+      let(:author) { create(:user) }
+
+      it "allows content within the limit" do
+        news = build(:news, author: author, content: "a" * 50_000)
+        expect(news).to be_valid
+      end
+
+      it "rejects content exceeding the limit" do
+        news = build(:news, author: author, content: "a" * 50_001)
+        expect(news).not_to be_valid
+        expect(news.errors.where(:content, :too_long)).to be_present
+      end
+
+      it "allows blank content" do
+        news = build(:news, author: author)
+        expect(news).to be_valid
+      end
+    end
   end
 
   describe '.recent' do


### PR DESCRIPTION
## Summary
- Add `MAX_CONTENT_LENGTH = 50_000` constant and custom validation on News model
- Validates plain text length of rich text content, preventing content-size abuse at write time
- Allows blank content (no minimum required)

## Mutation Testing
- Mutant: 100% (45/45 killed, 1 neutral from test ordering)
- Evilution: 100% (30/30 killed, 2 equivalent)

## Test plan
- [x] Content within 50,000 chars is valid
- [x] Content exceeding 50,000 chars is rejected with `:too_long` error on `:content`
- [x] Blank content is valid

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)