### PR TITLE
256.1: Revoke podcast feed token on unsubscribe

### DIFF
--- a/app/models/user_grant.rb
+++ b/app/models/user_grant.rb
@@ -3,4 +3,17 @@ class UserGrant < ApplicationRecord
   belongs_to :grant
 
   validates :grant_id, uniqueness: { scope: :user_id }
+
+  after_destroy :revoke_podcast_feed_token, if: :subscriber_grant?
+
+  private
+
+  def subscriber_grant?
+    grant.code == "subscriber"
+  end
+
+  def revoke_podcast_feed_token
+    token = user.podcast_feed_token
+    token.revoke! if token
+  end
 end

--- a/spec/models/user_grant_spec.rb
+++ b/spec/models/user_grant_spec.rb
@@ -25,4 +25,40 @@ RSpec.describe UserGrant, type: :model do
       expect(user_grant).to be_valid
     end
   end
+
+  describe "after_destroy callback" do
+    context "when subscriber grant is removed" do
+      let(:user) { create(:user) }
+      let(:subscriber_grant) { Grant.find_or_create_by!(code: "subscriber") }
+      let!(:user_grant) { create(:user_grant, user: user, grant: subscriber_grant) }
+      let!(:feed_token) { create(:podcast_feed_token, user: user) }
+
+      it "revokes the user's podcast feed token" do
+        user_grant.destroy!
+        expect(feed_token.reload.revoked?).to be true
+      end
+    end
+
+    context "when subscriber grant is removed and user has no feed token" do
+      let(:user) { create(:user) }
+      let(:subscriber_grant) { Grant.find_or_create_by!(code: "subscriber") }
+      let!(:user_grant) { create(:user_grant, user: user, grant: subscriber_grant) }
+
+      it "does not raise an error" do
+        expect { user_grant.destroy! }.not_to raise_error
+      end
+    end
+
+    context "when non-subscriber grant is removed" do
+      let(:user) { create(:user) }
+      let(:judge_grant) { Grant.find_or_create_by!(code: "judge") }
+      let!(:user_grant) { create(:user_grant, user: user, grant: judge_grant) }
+      let!(:feed_token) { create(:podcast_feed_token, user: user) }
+
+      it "does not revoke the user's podcast feed token" do
+        user_grant.destroy!
+        expect(feed_token.reload.revoked?).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Add `after_destroy` callback on `UserGrant` that revokes the user's `PodcastFeedToken` when the subscriber grant is removed
- Only triggers for subscriber grants — other grant removals don't affect the feed token
- Handles case where user has no feed token without errors

## Mutation Testing
- Mutant: 100% (26/26 killed, 2 neutral from environment)
- Evilution: 100% (11/11 killed)

## Test plan
- [x] Removing subscriber grant revokes the user's podcast feed token
- [x] Removing subscriber grant when user has no feed token doesn't raise
- [x] Removing non-subscriber grant doesn't revoke the feed token

Closes #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)