### PR TITLE
633: Preserve episode description formatting

### DIFF
--- a/app/views/podcast/episodes/show.html.erb
+++ b/app/views/podcast/episodes/show.html.erb
@@ -79,6 +79,6 @@
 
 <% if @episode.description.present? %>
   <div class="prose max-w-none text-neutral-700">
-    <p><%= @episode.description %></p>
+    <%= simple_format(@episode.description) %>
   </div>
 <% end %>

--- a/spec/requests/podcast/episodes_spec.rb
+++ b/spec/requests/podcast/episodes_spec.rb
@@ -128,6 +128,13 @@ RSpec.describe "Podcast::Episodes" do
         expect(response.body).to include(published_episode.description)
       end
 
+      it "preserves line breaks in episode description" do
+        episode = create(:episode, title: "Multiline", description: "Line one\nLine two",
+                         status: "published", published_at: Time.current)
+        get "/podcast/episodes/#{episode.id}"
+        expect(response.body).to include("<br")
+      end
+
       it "displays published_at date" do
         get "/podcast/episodes/#{published_episode.id}"
         expect(response.body).to include(I18n.l(published_episode.published_at, format: :short))


### PR DESCRIPTION
## Summary
- Replace raw `<p>` tag with `simple_format` in episode show view to preserve line breaks and paragraph formatting in descriptions

Closes #633

## Test plan
- [x] Added request spec verifying `<br` tag appears for multiline descriptions
- [x] All 32 episode request specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)