### PR TITLE
632: Add image attachment to podcast episodes

### DIFF
--- a/app/avo/resources/episode.rb
+++ b/app/avo/resources/episode.rb
@@ -15,6 +15,7 @@ class Avo::Resources::Episode < Avo::BaseResource
     field :status, as: :select, enum: ::Episode.statuses
     field :published_at, as: :date_time, sortable: true
     field :duration_seconds, as: :number
+    field :image, as: :file
     field :audio, as: :file
   end
 end

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -1,5 +1,6 @@
 class Episode < ApplicationRecord
   has_one_attached :audio
+  has_one_attached :image
 
   enum :status, { draft: "draft", published: "published" }
 

--- a/spec/avo/resources/episode_spec.rb
+++ b/spec/avo/resources/episode_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Avo::Resources::Episode do
+  subject(:resource) { described_class.new(record: episode, view: :edit) }
+
+  let_it_be(:episode) { create(:episode) }
+
+  before { resource.detect_fields }
+
+  let(:items) { resource.items }
+
+  describe "fields" do
+    it "includes the image field" do
+      field = items.find { |f| f.id == :image }
+
+      expect(field).to be_a(Avo::Fields::FileField)
+    end
+  end
+end

--- a/spec/models/episode_spec.rb
+++ b/spec/models/episode_spec.rb
@@ -31,6 +31,18 @@ RSpec.describe Episode, type: :model do
     end
   end
 
+  describe "image attachment" do
+    it "can attach an image" do
+      episode = create(:episode)
+      episode.image.attach(
+        io: StringIO.new("fake image"),
+        filename: "cover.jpg",
+        content_type: "image/jpeg"
+      )
+      expect(episode.image).to be_attached
+    end
+  end
+
   describe "scopes" do
     describe ".published" do
       let!(:draft_episode) { create(:episode, status: "draft") }


### PR DESCRIPTION
## Summary
- Add `has_one_attached :image` to Episode model for per-episode cover images
- Add `image` file field to Avo Episode admin resource
- Add model and Avo resource specs

Closes #632

## Mutation testing
- Mutant: 92.39% (158/171) — all 13 survivors are in pre-existing code (`enqueue_duration_extraction`), not in new changes
- Evilution: `has_one_attached` is a Rails DSL declaration — no mutations generated for the model change; Avo resource: 98.68% (75/76, 1 survivor on pre-existing `navigation_label`)

## Test plan
- [x] Episode model spec: image attachment works
- [x] Avo resource spec: image field present as FileField
- [x] Full suite: 1587 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)