### PR TITLE
660: Use absolute URL for podcast cover image in RSS feed

### DIFF
--- a/app/views/podcast/feed/show.rss.builder
+++ b/app/views/podcast/feed/show.rss.builder
@@ -15,7 +15,7 @@ xml.rss version: "2.0",
     end
 
     if @podcast.cover.attached?
-      xml.tag! "itunes:image", href: url_for(@podcast.cover)
+      xml.tag! "itunes:image", href: rails_blob_url(@podcast.cover)
     end
 
     @episodes.each do |episode|

--- a/spec/requests/podcast/feed_spec.rb
+++ b/spec/requests/podcast/feed_spec.rb
@@ -81,6 +81,22 @@ RSpec.describe "Podcast::Feed" do
         expect(first_pos).to be < second_pos
       end
 
+      context "when podcast has a cover image" do
+        before do
+          podcast = Podcast.instance
+          podcast.cover.attach(
+            io: StringIO.new("fake-image"),
+            filename: "cover.jpg",
+            content_type: "image/jpeg"
+          )
+        end
+
+        it "includes absolute URL in itunes:image href" do
+          get "/podcast/feed.rss?token=#{token.token}"
+          expect(response.body).to match(%r{<itunes:image href="https?://})
+        end
+      end
+
       it "includes episode pub dates" do
         get "/podcast/feed.rss?token=#{token.token}"
         expect(response.body).to include("<pubDate>")


### PR DESCRIPTION
## Summary
- Replace `url_for` with `rails_blob_url` for podcast cover image in RSS feed
- `url_for` generates relative paths (`/rails/active_storage/blobs/...`) which external podcast apps cannot resolve
- `rails_blob_url` generates absolute URLs with host, fixing compatibility with external RSS readers

Closes #660

## Test plan
- [x] Added spec verifying `itunes:image` href contains absolute URL (`https?://`)
- [x] All 17 feed specs pass
- [x] RuboCop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)