### PR TITLE
661: Add episode cover image to RSS feed metadata

### DIFF
--- a/app/controllers/podcast/feed_controller.rb
+++ b/app/controllers/podcast/feed_controller.rb
@@ -4,7 +4,7 @@ class Podcast::FeedController < ApplicationController
 
   def show
     @podcast = Podcast.instance
-    @episodes = Episode.published.recent.includes(:audio_attachment)
+    @episodes = Episode.published.recent.includes(:audio_attachment, :image_attachment)
     @token = params[:token]
     render formats: :rss
   end

--- a/app/views/podcast/feed/show.rss.builder
+++ b/app/views/podcast/feed/show.rss.builder
@@ -31,6 +31,10 @@ xml.rss version: "2.0",
                         type: episode.audio.content_type
         end
 
+        if episode.image.attached?
+          xml.tag! "itunes:image", href: rails_blob_url(episode.image)
+        end
+
         if episode.formatted_duration
           xml.tag! "itunes:duration", episode.formatted_duration
         end

--- a/spec/requests/podcast/feed_spec.rb
+++ b/spec/requests/podcast/feed_spec.rb
@@ -111,6 +111,34 @@ RSpec.describe "Podcast::Feed" do
         end
       end
 
+      context "when episode has a cover image" do
+        let_it_be(:episode_with_image) do
+          episode = create(:episode, title: "Image Episode", status: "published", published_at: Time.current)
+          episode.image.attach(
+            io: StringIO.new("fake-image"),
+            filename: "cover.jpg",
+            content_type: "image/jpeg"
+          )
+          episode
+        end
+
+        it "includes itunes:image tag with absolute URL" do
+          get "/podcast/feed.rss?token=#{token.token}"
+          expect(response.body).to match(%r{<itunes:image href="https?://[^"]*cover\.jpg[^"]*"/>})
+        end
+      end
+
+      context "when episode has no cover image" do
+        it "does not include itunes:image tag in episode item" do
+          get "/podcast/feed.rss?token=#{token.token}"
+          # Extract just the item blocks (between <item> and </item>)
+          items = response.body.scan(%r{<item>.*?</item>}m)
+          items.each do |item|
+            expect(item).not_to include("itunes:image")
+          end
+        end
+      end
+
       context "when episode has audio" do
         let_it_be(:episode_with_audio) do
           episode = create(:episode, title: "Audio Episode", status: "published", published_at: Time.current)


### PR DESCRIPTION
## Summary
- Add `<itunes:image>` tag per episode in RSS feed when the episode has an attached image
- Use `rails_blob_url` for absolute URLs (consistent with podcast-level cover fix in #662)
- Eager-load `image_attachment` in feed controller to prevent N+1 queries

Closes #661

## Test plan
- [x] Added spec verifying `itunes:image` tag with absolute URL appears for episodes with images
- [x] Added spec verifying no `itunes:image` in episode items when no image attached
- [x] All 18 feed specs pass
- [x] RuboCop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)