### PR TITLE
669: Adjust publish/unpublish for scheduled publishing

### DIFF
--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -36,11 +36,13 @@ class News < ApplicationRecord
   end
 
   def publish!
-    update!(status: :published, published_at: Time.current)
+    attrs = { status: :published }
+    attrs[:published_at] = Time.current if published_at.blank?
+    update!(attrs)
   end
 
   def unpublish!
-    update!(status: :draft, published_at: nil)
+    update!(status: :draft)
   end
 
   private

--- a/spec/models/news_spec.rb
+++ b/spec/models/news_spec.rb
@@ -195,13 +195,38 @@ RSpec.describe News, type: :model do
 
   describe '#publish!' do
     let(:author) { create(:user) }
-    let(:news) { create(:news, author:) }
 
-    it 'sets status to published and published_at' do
-      news.publish!
+    context "when published_at is nil" do
+      let(:news) { create(:news, author:) }
 
-      expect(news.status).to eq("published")
-      expect(news.published_at).to be_within(1.second).of(Time.current)
+      it "sets status to published" do
+        news.publish!
+
+        expect(news.status).to eq("published")
+      end
+
+      it "sets published_at to current time" do
+        news.publish!
+
+        expect(news.published_at).to be_within(1.second).of(Time.current)
+      end
+    end
+
+    context "when published_at is already set" do
+      let(:scheduled_time) { 2.days.from_now }
+      let(:news) { create(:news, author:, published_at: scheduled_time) }
+
+      it "sets status to published" do
+        news.publish!
+
+        expect(news.status).to eq("published")
+      end
+
+      it "does not change published_at" do
+        news.publish!
+
+        expect(news.published_at).to be_within(1.second).of(scheduled_time)
+      end
     end
   end
 
@@ -209,11 +234,17 @@ RSpec.describe News, type: :model do
     let(:author) { create(:user) }
     let(:news) { create(:news, :published, author:) }
 
-    it 'sets status to draft and clears published_at' do
+    it "sets status to draft" do
       news.unpublish!
 
       expect(news.status).to eq("draft")
-      expect(news.published_at).to be_nil
+    end
+
+    it "does not change published_at" do
+      original_published_at = news.published_at
+      news.unpublish!
+
+      expect(news.published_at).to eq(original_published_at)
     end
   end
 end

--- a/spec/requests/admin/news_spec.rb
+++ b/spec/requests/admin/news_spec.rb
@@ -475,6 +475,21 @@ RSpec.describe "Admin::News" do
         end
       end
 
+      context "when article has a scheduled published_at" do
+        let(:scheduled_time) { 2.days.from_now }
+        let(:article) { create(:news, author: editor, published_at: scheduled_time) }
+
+        it "publishes the article" do
+          patch publish_admin_news_path(article)
+          expect(article.reload).to be_published
+        end
+
+        it "preserves the scheduled published_at" do
+          patch publish_admin_news_path(article)
+          expect(article.reload.published_at).to be_within(1.second).of(scheduled_time)
+        end
+      end
+
       context "when article is already published" do
         let_it_be(:article) { create(:news, :published) }
 
@@ -518,9 +533,10 @@ RSpec.describe "Admin::News" do
           expect(article.reload).to be_draft
         end
 
-        it "clears published_at" do
+        it "preserves published_at" do
+          original_published_at = article.published_at
           patch unpublish_admin_news_path(article)
-          expect(article.reload.published_at).to be_nil
+          expect(article.reload.published_at).to eq(original_published_at)
         end
 
         it "redirects to index" do


### PR DESCRIPTION
## Summary
- **publish!** now only sets `published_at` if it's blank — preserves existing future dates for scheduled publishing
- **unpublish!** now only toggles status to `draft` without clearing `published_at`, so re-publishing restores the original schedule

This enables the workflow: set `published_at` to a future date → publish → article becomes visible at that time. Unpublishing and re-publishing preserves the schedule.

Closes #669

## Mutation Testing
- Mutant: 97.77% (44/45) — 1 survivor is a neutral/timeout

## Test plan
- [x] `publish!` with nil `published_at`: sets it to now
- [x] `publish!` with existing `published_at`: preserves the scheduled time
- [x] `unpublish!`: sets status to draft, preserves `published_at`
- [x] Request spec: scheduled publish preserves `published_at`
- [x] Request spec: unpublish preserves `published_at`
- [x] All existing specs pass (109 examples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)