### PR TITLE
673: Truncate news title to 100 chars in admin list

### DIFF
--- a/app/views/admin/news/index.html.erb
+++ b/app/views/admin/news/index.html.erb
@@ -31,7 +31,7 @@
         <% @news.each do |article| %>
           <tr>
             <td class="px-4 py-3">
-              <%= link_to article.title, admin_news_path(article), class: "text-blue-600 hover:underline" %>
+              <%= link_to truncate(article.title, length: 100), admin_news_path(article), class: "text-blue-600 hover:underline" %>
             </td>
             <td class="px-4 py-3">
               <% if article.author.player %>


### PR DESCRIPTION
## Summary
- Truncate title column to 100 characters in `/admin/news` list view using Rails `truncate` helper

Closes #673

## Test plan
- [x] All admin news specs pass (71 examples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)