### PR TITLE
Include year in created_at on admin news list

### DIFF
--- a/app/views/admin/news/index.html.erb
+++ b/app/views/admin/news/index.html.erb
@@ -45,7 +45,7 @@
                 <%= t("admin_news.status.#{article.status}") %>
               </span>
             </td>
-            <td class="px-4 py-3"><%= l(article.created_at, format: :short) %></td>
+            <td class="px-4 py-3"><%= l(article.created_at.to_date) %></td>
             <td class="px-4 py-3"><%= article.published_at && l(article.published_at, format: :short) %></td>
             <td class="px-4 py-3 text-right whitespace-nowrap">
               <%= link_to t("admin_news.index.edit"), edit_admin_news_path(article),


### PR DESCRIPTION
## Summary
- Switch `created_at` column in admin news list from time `:short` format (`"01 апр, 12:00"`) to default date format (`"01.04.2026"`)
- The year was missing, making it unclear when older articles were created

Closes #683

## Test plan
- [x] Admin news specs pass (71 examples, 0 failures)
- [x] Visit `/admin/news` — verify `created_at` column shows dates with year

🤖 Generated with [Claude Code](https://claude.com/claude-code)