### PR TITLE
Display created_at on admin news show/edit

### DIFF
--- a/app/views/admin/news/edit.html.erb
+++ b/app/views/admin/news/edit.html.erb
@@ -1,4 +1,5 @@
-<h1 class="text-2xl font-bold mb-6"><%= t("admin_news.edit.title") %></h1>
+<h1 class="text-2xl font-bold mb-2"><%= t("admin_news.edit.title") %></h1>
+<p class="text-sm text-gray-500 mb-6"><%= t("admin_news.show.created_at", date: l(@news.created_at.to_date)) %></p>
 
 <%= form_with model: @news, url: admin_news_path(@news), method: :patch do |f| %>
   <%= render "form", f: f %>

--- a/app/views/admin/news/show.html.erb
+++ b/app/views/admin/news/show.html.erb
@@ -16,6 +16,7 @@
     <% if @news.game %>
       · <%= t("admin_news.show.linked_game", game: @news.game.full_name) %>
     <% end %>
+    · <%= t("admin_news.show.created_at", date: l(@news.created_at.to_date)) %>
     <% if @news.published_at %>
       · <%= l(@news.published_at, format: :short) %>
     <% end %>

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -310,6 +310,7 @@ ru:
       title: "Редактирование новости"
     show:
       back: "← К списку новостей"
+      created_at: "Создано: %{date}"
       by_author: "Автор: %{author}"
       linked_game: "Игра: %{game}"
       edit: "Редактировать"


### PR DESCRIPTION
## Summary
- Add read-only `created_at` date to the admin news show page (in the metadata line alongside author and published_at)
- Add `created_at` date below the heading on the edit page
- Uses default date format (`dd.mm.YYYY`) consistent with the index page (#683)

Closes #684

## Test plan
- [x] Admin news specs pass (71 examples, 0 failures)
- [x] Visit `/admin/news/:id` — verify "Создано: dd.mm.YYYY" appears in metadata
- [x] Visit `/admin/news/:id/edit` — verify created_at appears below heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)