### PR TITLE
Show edit link on news pages for editors

### DIFF
--- a/app/views/competitions/show.html.erb
+++ b/app/views/competitions/show.html.erb
@@ -105,6 +105,12 @@
             <div class="prose max-w-none text-neutral-700">
               <%= article.content %>
             </div>
+            <% if user_signed_in? && current_user.can_manage_news? %>
+              <div class="mt-2">
+                <%= link_to t("news.index.edit"), edit_admin_news_path(article),
+                      class: "text-sm text-blue-600 hover:underline" %>
+              </div>
+            <% end %>
           </article>
         <% end %>
       </div>

--- a/app/views/news/index.html.erb
+++ b/app/views/news/index.html.erb
@@ -23,6 +23,12 @@
         <div class="prose max-w-none text-neutral-700">
           <%= article.content %>
         </div>
+        <% if user_signed_in? && current_user.can_manage_news? %>
+          <div class="mt-2">
+            <%= link_to t("news.index.edit"), edit_admin_news_path(article),
+                  class: "text-sm text-blue-600 hover:underline" %>
+          </div>
+        <% end %>
       </article>
     <% end %>
   </div>

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -286,6 +286,7 @@ ru:
     index:
       title: "Новости"
       empty: "Новостей пока нет."
+      edit: "Редактировать"
     show:
       back: "← К новостям"
       linked_game: "Игра %{game}"

--- a/spec/requests/news_spec.rb
+++ b/spec/requests/news_spec.rb
@@ -37,6 +37,35 @@ RSpec.describe NewsController do
       assert_select "a[href=?]", "/news/#{published_article.id}", count: 0
     end
 
+    context "when user is an editor" do
+      let_it_be(:editor) { create(:user, :editor) }
+
+      before { sign_in editor }
+
+      it "shows edit link" do
+        get news_index_path
+        expect(response.body).to include(edit_admin_news_path(published_article))
+      end
+    end
+
+    context "when user is not signed in" do
+      it "does not show edit link" do
+        get news_index_path
+        expect(response.body).not_to include(edit_admin_news_path(published_article))
+      end
+    end
+
+    context "when user has no editor grant" do
+      let_it_be(:regular_user) { create(:user) }
+
+      before { sign_in regular_user }
+
+      it "does not show edit link" do
+        get news_index_path
+        expect(response.body).not_to include(edit_admin_news_path(published_article))
+      end
+    end
+
     context "when there are no published articles" do
       before { News.update_all(status: :draft, published_at: nil) }
 


### PR DESCRIPTION
## Summary
- Display "Редактировать" link next to news articles on `/news` and `/competitions/:slug` for users with the editor (or admin) grant
- Uses `current_user.can_manage_news?` to gate visibility
- Also added to the competition show page for consistency

Closes #685

## Test plan
- [x] News specs pass (10 examples, 0 failures) — covers editor sees link, guest doesn't, regular user doesn't
- [x] Competitions specs pass (15 examples, 0 failures)
- [x] Visit `/news` as editor — verify edit links appear
- [x] Visit `/news` as guest — verify no edit links

🤖 Generated with [Claude Code](https://claude.com/claude-code)