### PR TITLE
Display linked competition on admin news show page

### DIFF
--- a/app/views/admin/news/show.html.erb
+++ b/app/views/admin/news/show.html.erb
@@ -13,6 +13,9 @@
 
   <div class="text-sm text-gray-500 mb-4">
     <%= t("admin_news.show.by_author", author: @news.author.email) %>
+    <% if @news.competition %>
+      · <%= t("admin_news.show.linked_competition", competition: @news.competition.name) %>
+    <% end %>
     <% if @news.game %>
       · <%= t("admin_news.show.linked_game", game: @news.game.full_name) %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -129,6 +129,7 @@ en:
       back: "← Back to news"
       by_author: "Author: %{author}"
       linked_series: "Season %{season}, Series %{series}"
+      linked_competition: "Competition: %{competition}"
       linked_game: "Game: %{game}"
       edit: "Edit"
       publish: "Publish"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -315,6 +315,7 @@ ru:
       back: "← К списку новостей"
       created_at: "Создано: %{date}"
       by_author: "Автор: %{author}"
+      linked_competition: "Турнир: %{competition}"
       linked_game: "Игра: %{game}"
       edit: "Редактировать"
       publish: "Опубликовать"

--- a/spec/requests/admin/news_spec.rb
+++ b/spec/requests/admin/news_spec.rb
@@ -294,6 +294,35 @@ RSpec.describe "Admin::News" do
       end
     end
 
+    context "when article has a competition (stage)" do
+      let_it_be(:season) { create(:competition, :season, name: "Сезон 5") }
+      let_it_be(:stage) { create(:competition, :series, parent: season, name: "Серия 2") }
+      let(:article_with_stage) { create(:news, :published, competition: stage) }
+
+      before do
+        sign_in editor
+        get admin_news_path(article_with_stage)
+      end
+
+      it "displays the competition name" do
+        expect(response.body).to include("Серия 2")
+      end
+    end
+
+    context "when article has a root competition (season)" do
+      let_it_be(:season) { create(:competition, :season, name: "Сезон 9") }
+      let(:article_with_season) { create(:news, :published, competition: season) }
+
+      before do
+        sign_in editor
+        get admin_news_path(article_with_season)
+      end
+
+      it "displays the competition name" do
+        expect(response.body).to include("Сезон 9")
+      end
+    end
+
     context "when article has photos" do
       let(:article_with_photo) { create(:news, :with_photo) }
 


### PR DESCRIPTION
## Summary
- Show the linked competition name in the admin news show page metadata section
- Displays between author and game info, with i18n support (ru: "Турнир", en: "Competition")
- Works for both root competitions (seasons) and child stages

Closes #698

## Test plan
- [x] New spec: article with a stage competition displays stage name
- [x] New spec: article with a root competition (season) displays season name
- [x] All 87 admin news specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)