### PR TITLE
Add Save & Publish button to admin news edit form

### DIFF
--- a/app/controllers/admin/news_controller.rb
+++ b/app/controllers/admin/news_controller.rb
@@ -46,6 +46,7 @@ class Admin::NewsController < ApplicationController
     authorize @news
 
     if @news.update(news_params)
+      @news.publish! if params[:publish].present? && @news.draft?
       redirect_to admin_news_path(@news), notice: t("admin_news.update.success")
     else
       load_form_data

--- a/app/views/admin/news/_form.html.erb
+++ b/app/views/admin/news/_form.html.erb
@@ -64,7 +64,13 @@
   </div>
 </div>
 
-<div class="flex justify-end mt-4">
+<div class="flex justify-end gap-2 mt-4">
   <%= f.submit local_assigns[:submit_label] || (f.object.new_record? ? t("admin_news.form.submit_create") : t("admin_news.form.submit_update")),
         class: "bg-blue-500 hover:bg-blue-600 text-white font-medium py-2 px-4 rounded-md text-sm cursor-pointer" %>
+  <% if f.object.persisted? && f.object.draft? %>
+    <button type="submit" name="publish" value="1"
+            class="bg-green-500 hover:bg-green-600 text-white font-medium py-2 px-4 rounded-md text-sm cursor-pointer">
+      <%= t("admin_news.form.submit_save_and_publish") %>
+    </button>
+  <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,6 +143,7 @@ en:
       game: "Game"
       submit_create: "Create"
       submit_update: "Save"
+      submit_save_and_publish: "Save & Publish"
     status:
       draft: "Draft"
       published: "Published"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -330,6 +330,7 @@ ru:
       series: "Серия"
       submit_create: "Создать"
       submit_update: "Сохранить"
+      submit_save_and_publish: "Сохранить и опубликовать"
     status:
       draft: "Черновик"
       published: "Опубликовано"

--- a/spec/requests/admin/news_spec.rb
+++ b/spec/requests/admin/news_spec.rb
@@ -389,6 +389,23 @@ RSpec.describe "Admin::News" do
       it "renders the photo upload field" do
         assert_select "input[type='file'][name='news[photos][]']"
       end
+
+      it "renders the Save & Publish button for draft articles" do
+        assert_select "button[type='submit'][name='publish']", text: I18n.t("admin_news.form.submit_save_and_publish")
+      end
+    end
+
+    context "when article is published" do
+      let_it_be(:published_article) { create(:news, :published) }
+
+      before do
+        sign_in editor
+        get edit_admin_news_path(published_article)
+      end
+
+      it "does not render the Save & Publish button" do
+        assert_select "button[name='publish']", count: 0
+      end
     end
 
     context "when article has photos" do
@@ -526,6 +543,38 @@ RSpec.describe "Admin::News" do
           end
           patch admin_news_path(article), params: { news: { title: "Updated Title", photos: [ "" ] } }
           expect(article.reload.photos).to be_attached
+        end
+      end
+
+      context "with publish param" do
+        it "saves changes and publishes the article" do
+          patch admin_news_path(article), params: { news: { title: "Published Title" }, publish: "1" }
+          article.reload
+          expect(article.title).to eq("Published Title")
+          expect(article).to be_published
+          expect(article.published_at).to be_present
+        end
+
+        it "redirects to show" do
+          patch admin_news_path(article), params: { news: { title: "Published Title" }, publish: "1" }
+          expect(response).to redirect_to(admin_news_path(article))
+        end
+      end
+
+      context "with publish param on already published article" do
+        let!(:published_article) { create(:news, :published, author: editor) }
+
+        it "updates without error" do
+          patch admin_news_path(published_article), params: { news: { title: "Updated" }, publish: "1" }
+          expect(published_article.reload.title).to eq("Updated")
+          expect(published_article).to be_published
+        end
+      end
+
+      context "with publish param and invalid params" do
+        it "does not publish the article" do
+          patch admin_news_path(article), params: { news: { title: "" }, publish: "1" }
+          expect(article.reload).to be_draft
         end
       end
 


### PR DESCRIPTION
## Summary
- Add "Save & Publish" button to the edit form for draft news articles
- Saves changes and publishes in one action (submits `publish=1` param)
- Button only appears for drafts, not for already-published articles
- Gracefully handles: already published articles, invalid params (no publish on validation failure)

Closes #699

## Mutation testing
- Mutant: 98.76% (80/81 killed) — the 1 "survivor" is a neutral failure (mutant infra), not a real gap
- Evilution: N/A (changes in ERB template and controller one-liner)

## Test plan
- [x] Edit form renders "Save & Publish" button for draft articles
- [x] Edit form does NOT render button for published articles
- [x] PATCH with `publish` param saves changes and publishes
- [x] PATCH with `publish` param redirects to show
- [x] PATCH with `publish` on already-published article updates without error
- [x] PATCH with `publish` and invalid params does not publish
- [x] All 93 admin news specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)