### PR TITLE
Show full date with year on news pages

### DIFF
--- a/app/views/news/_article.html.erb
+++ b/app/views/news/_article.html.erb
@@ -4,7 +4,7 @@
   </h2>
   <div class="text-sm text-neutral-500 mb-3">
     <% if article.published_at.present? %>
-      <%= l(article.published_at, format: :short) %>
+      <%= l(article.published_at, format: :full_date) %>
     <% end %>
     <% if article.author.claimed_player? %>
       · <%= article.author.player.name %>

--- a/app/views/news/_preview_list.html.erb
+++ b/app/views/news/_preview_list.html.erb
@@ -6,7 +6,7 @@
       </h3>
       <div class="text-sm text-neutral-500 mb-2">
         <% if article.published_at.present? %>
-          <%= l(article.published_at, format: :short) %>
+          <%= l(article.published_at, format: :full_date) %>
         <% end %>
         <% if article.author.claimed_player? %>
           · <%= article.author.player.name %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,9 @@
 #       enabled: "ON"
 
 en:
+  time:
+    formats:
+      full_date: "%-d %B %Y"
   activerecord:
     attributes:
       user:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,4 +1,7 @@
 ru:
+  time:
+    formats:
+      full_date: "%-d %B %Y"
   activerecord:
     models:
       player: "Игрок"

--- a/spec/requests/news_spec.rb
+++ b/spec/requests/news_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe NewsController do
       expect(response.body).to include(content)
     end
 
+    it "displays published_at with day, month name, and year" do
+      get news_index_path
+      expected_date = I18n.l(published_article.published_at, format: :full_date)
+      expect(response.body).to include(expected_date)
+    end
+
     it "excludes draft articles" do
       get news_index_path
       expect(response.body).not_to include(draft_article.title)


### PR DESCRIPTION
## Summary
- Add `full_date` time format (`%-d %B %Y`) to both ru and en locales
- Update news article partial and preview list partial to use `full_date` instead of `short`
- Dates now display as "3 апреля 2026" (ru) or "3 April 2026" (en)

Closes #700

## Test plan
- [x] New spec: published_at displays with day, month name, and year
- [x] All 19 news specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)