### PR TITLE
Fix value field not showing in Avo FeatureToggle resource

### DIFF
--- a/app/avo/resources/feature_toggle.rb
+++ b/app/avo/resources/feature_toggle.rb
@@ -15,7 +15,7 @@ class Avo::Resources::FeatureToggle < Avo::BaseResource
     field :id, as: :id
     field :key, as: :select, options: -> { ::FeatureToggle::KEYS.map { |k| [ k, k ] } }
     field :enabled, as: :boolean
-    field :value, as: :string
+    field :toggle_value, as: :text, for_attribute: :value, name: "Value"
     field :description, as: :textarea
     field :updated_at, as: :date_time, sortable: true
   end

--- a/spec/avo/resources/feature_toggle_spec.rb
+++ b/spec/avo/resources/feature_toggle_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Avo::Resources::FeatureToggle do
+  subject(:resource) { described_class.new(record: toggle, view: view) }
+
+  let_it_be(:toggle) { create(:feature_toggle, key: "home_hero", value: "banner.jpg") }
+
+  before { resource.detect_fields }
+
+  describe "value field" do
+    context "on index view" do
+      let(:view) { :index }
+
+      it "is present" do
+        field = resource.get_field(:toggle_value)
+        expect(field).to be_present
+      end
+
+      it "reads from the value attribute" do
+        field = resource.get_field(:toggle_value)
+        expect(field.value).to eq("banner.jpg")
+      end
+    end
+
+    context "on edit view" do
+      let(:view) { :edit }
+
+      it "is present" do
+        field = resource.get_field(:toggle_value)
+        expect(field).to be_present
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- The `:value` field ID collides with `Avo::Fields::BaseField#value` method, causing the field to be invisible in all Avo views (index, show, edit)
- Renamed field to `:toggle_value` with `for_attribute: :value` to map to the correct DB column while avoiding the name collision
- Added specs verifying the field is present and reads the correct attribute

Closes #719

## Test plan
- [x] Spec verifies field is present on index and edit views
- [x] Spec verifies field reads from the `value` attribute
- [x] RuboCop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)