### PR TITLE
Expose raw entities in MessageParser::Result

### DIFF
--- a/app/services/telegram/message_parser.rb
+++ b/app/services/telegram/message_parser.rb
@@ -1,6 +1,6 @@
 module Telegram
   class MessageParser
-    Result = Data.define(:text, :html_content, :from_id, :from_username, :from_first_name, :chat_id, :photo_file_id, :raw_text_length)
+    Result = Data.define(:text, :html_content, :from_id, :from_username, :from_first_name, :chat_id, :photo_file_id, :raw_text_length, :entities)
 
     def self.call(payload)
       new(payload).call
@@ -29,7 +29,8 @@ module Telegram
         from_first_name: from&.dig("first_name"),
         chat_id: @message.dig("chat", "id"),
         photo_file_id: extract_largest_photo_id,
-        raw_text_length: raw_text.strip.length
+        raw_text_length: raw_text.strip.length,
+        entities: raw_entities
       )
     end
 

--- a/spec/services/telegram/message_parser_spec.rb
+++ b/spec/services/telegram/message_parser_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe Telegram::MessageParser do
         }
       end
 
+      it "returns empty entities array" do
+        result = described_class.call(payload)
+        expect(result.entities).to eq([])
+      end
+
       it "extracts the message text" do
         result = described_class.call(payload)
         expect(result.text).to eq("Hello world")
@@ -190,6 +195,11 @@ RSpec.describe Telegram::MessageParser do
         }
       end
 
+      it "exposes raw entities array" do
+        result = described_class.call(payload)
+        expect(result.entities).to eq([ { "type" => "bold", "offset" => 0, "length" => 4 } ])
+      end
+
       it "applies entity formatting in html_content" do
         result = described_class.call(payload)
         expect(result.html_content).to eq("<strong>Bold</strong> update here")
@@ -217,6 +227,11 @@ RSpec.describe Telegram::MessageParser do
             ]
           }
         }
+      end
+
+      it "exposes caption entities array" do
+        result = described_class.call(payload)
+        expect(result.entities).to eq([ { "type" => "italic", "offset" => 0, "length" => 5 } ])
       end
 
       it "applies caption entities to html_content" do


### PR DESCRIPTION
## Summary
- Add `entities` field to `Telegram::MessageParser::Result` Data.define
- Downstream consumers (e.g. the upcoming `NewsScorer`) can inspect entity types without re-parsing the payload
- Passes through the raw entities array (from `entities` or `caption_entities`)

## Mutation testing
- Evilution: 100% (159/159 mutants killed)
- Mutant: 95.52% (235/246 mutants killed) — 11 survivors are all equivalent mutants (pre-existing: `[]`→`fetch`, `to_i`→`Integer()`, module-scoped name resolution)

## Test plan
- [x] 3 new specs: empty entities, text entities, caption entities
- [x] All 24 existing specs pass
- [x] RuboCop clean

Closes #728
Beads: vm-65

🤖 Generated with [Claude Code](https://claude.com/claude-code)