### PR TITLE
Add Telegram::NewsScorer with formatting entity signal

### DIFF
--- a/app/services/telegram/news_scorer.rb
+++ b/app/services/telegram/news_scorer.rb
@@ -1,0 +1,26 @@
+module Telegram
+  class NewsScorer
+    FORMATTING_TYPES = %w[bold italic code pre strikethrough].freeze
+    FORMATTING_POINTS = 2
+    FORMATTING_CAP = 20
+
+    def self.call(parsed_result)
+      new(parsed_result).call
+    end
+
+    def initialize(parsed_result)
+      @parsed_result = parsed_result
+    end
+
+    def call
+      formatting_score
+    end
+
+    private
+
+    def formatting_score
+      count = @parsed_result.entities.count { |e| FORMATTING_TYPES.include?(e["type"]) }
+      [ count * FORMATTING_POINTS, FORMATTING_CAP ].min
+    end
+  end
+end

--- a/spec/services/telegram/news_scorer_spec.rb
+++ b/spec/services/telegram/news_scorer_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.describe Telegram::NewsScorer do
+  describe ".call" do
+    subject(:score) { described_class.call(parsed_result) }
+
+    let(:parsed_result) do
+      Telegram::MessageParser::Result.new(
+        text: text,
+        html_content: "",
+        from_id: 42,
+        from_username: "testuser",
+        from_first_name: "Denis",
+        chat_id: 42,
+        photo_file_id: nil,
+        raw_text_length: text.length,
+        entities: entities
+      )
+    end
+
+    let(:text) { "Some news article text" }
+    let(:entities) { [] }
+
+    context "with no entities" do
+      it "returns zero" do
+        expect(score).to eq(0)
+      end
+    end
+
+    context "with formatting entities" do
+      let(:entities) do
+        [
+          { "type" => "bold", "offset" => 0, "length" => 4 },
+          { "type" => "italic", "offset" => 5, "length" => 3 }
+        ]
+      end
+
+      it "adds points per formatting entity" do
+        expect(score).to eq(2 * described_class::FORMATTING_POINTS)
+      end
+    end
+
+    context "with non-formatting entities" do
+      let(:entities) do
+        [
+          { "type" => "mention", "offset" => 0, "length" => 5 },
+          { "type" => "hashtag", "offset" => 6, "length" => 4 },
+          { "type" => "url", "offset" => 11, "length" => 20 }
+        ]
+      end
+
+      it "does not score non-formatting entities" do
+        expect(score).to eq(0)
+      end
+    end
+
+    context "with mixed entity types" do
+      let(:entities) do
+        [
+          { "type" => "bold", "offset" => 0, "length" => 4 },
+          { "type" => "mention", "offset" => 5, "length" => 5 },
+          { "type" => "pre", "offset" => 11, "length" => 10 }
+        ]
+      end
+
+      it "scores only formatting entities" do
+        expect(score).to eq(2 * described_class::FORMATTING_POINTS)
+      end
+    end
+
+    context "with formatting entities exceeding the cap" do
+      let(:entities) do
+        20.times.map do |i|
+          { "type" => "bold", "offset" => i * 5, "length" => 4 }
+        end
+      end
+
+      it "caps the formatting score" do
+        expect(score).to eq(described_class::FORMATTING_CAP)
+      end
+    end
+
+    context "with all formatting entity types" do
+      let(:entities) do
+        %w[bold italic code pre strikethrough].map.with_index do |type, i|
+          { "type" => type, "offset" => i * 5, "length" => 4 }
+        end
+      end
+
+      it "counts all formatting types" do
+        expect(score).to eq(5 * described_class::FORMATTING_POINTS)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- New `Telegram::NewsScorer` service — accepts `MessageParser::Result`, returns integer score
- First signal: formatting entities (bold, italic, code, pre, strikethrough) — 2 points each, capped at 20
- Skeleton designed for adding more signals (paragraph structure, links, photo, keywords, penalties)

## Mutation testing
- Evilution: 100% (30/31 killed, 1 equivalent)
- Mutant: 98.52% (67/68 killed, 1 equivalent — `[]` → `.fetch()`)

## Test plan
- [x] 6 specs covering: no entities, formatting entities, non-formatting entities, mixed types, cap, all formatting types
- [x] RuboCop clean

Closes #729
Beads: vm-66

🤖 Generated with [Claude Code](https://claude.com/claude-code)