### PR TITLE
NewsScorer: add paragraph structure signal

### DIFF
--- a/app/services/telegram/message_parser.rb
+++ b/app/services/telegram/message_parser.rb
@@ -1,6 +1,6 @@
 module Telegram
   class MessageParser
-    Result = Data.define(:text, :html_content, :from_id, :from_username, :from_first_name, :chat_id, :photo_file_id, :raw_text_length, :entities)
+    Result = Data.define(:text, :html_content, :from_id, :from_username, :from_first_name, :chat_id, :photo_file_id, :raw_text_length, :entities, :raw_text)
 
     def self.call(payload)
       new(payload).call
@@ -30,7 +30,8 @@ module Telegram
         chat_id: @message.dig("chat", "id"),
         photo_file_id: extract_largest_photo_id,
         raw_text_length: raw_text.strip.length,
-        entities: raw_entities
+        entities: raw_entities,
+        raw_text: raw_text
       )
     end
 

--- a/app/services/telegram/news_scorer.rb
+++ b/app/services/telegram/news_scorer.rb
@@ -4,6 +4,9 @@ module Telegram
     FORMATTING_POINTS = 2
     FORMATTING_CAP = 20
 
+    PARAGRAPH_POINTS = 3
+    PARAGRAPH_CAP = 15
+
     def self.call(parsed_result)
       new(parsed_result).call
     end
@@ -13,7 +16,7 @@ module Telegram
     end
 
     def call
-      formatting_score
+      formatting_score + paragraph_score
     end
 
     private
@@ -21,6 +24,11 @@ module Telegram
     def formatting_score
       count = @parsed_result.entities.count { |e| FORMATTING_TYPES.include?(e["type"]) }
       [ count * FORMATTING_POINTS, FORMATTING_CAP ].min
+    end
+
+    def paragraph_score
+      count = @parsed_result.raw_text.scan("\n\n").size
+      [ count * PARAGRAPH_POINTS, PARAGRAPH_CAP ].min
     end
   end
 end

--- a/spec/services/telegram/message_parser_spec.rb
+++ b/spec/services/telegram/message_parser_spec.rb
@@ -268,6 +268,11 @@ RSpec.describe Telegram::MessageParser do
         result = described_class.call(payload)
         expect(result.raw_text_length).to eq("Line one\nLine two".length)
       end
+
+      it "exposes raw_text with newlines preserved" do
+        result = described_class.call(payload)
+        expect(result.raw_text).to eq("Line one\nLine two")
+      end
     end
 
     context "with leading and trailing whitespace" do

--- a/spec/services/telegram/news_scorer_spec.rb
+++ b/spec/services/telegram/news_scorer_spec.rb
@@ -13,12 +13,14 @@ RSpec.describe Telegram::NewsScorer do
         from_first_name: "Denis",
         chat_id: 42,
         photo_file_id: nil,
-        raw_text_length: text.length,
-        entities: entities
+        raw_text_length: raw_text.length,
+        entities: entities,
+        raw_text: raw_text
       )
     end
 
     let(:text) { "Some news article text" }
+    let(:raw_text) { text }
     let(:entities) { [] }
 
     context "with no entities" do
@@ -89,6 +91,42 @@ RSpec.describe Telegram::NewsScorer do
 
       it "counts all formatting types" do
         expect(score).to eq(5 * described_class::FORMATTING_POINTS)
+      end
+    end
+
+    context "with paragraph breaks" do
+      let(:raw_text) { "First paragraph.\n\nSecond paragraph.\n\nThird paragraph." }
+
+      it "adds points per paragraph break" do
+        expect(score).to eq(2 * described_class::PARAGRAPH_POINTS)
+      end
+    end
+
+    context "with single newlines only" do
+      let(:raw_text) { "Line one.\nLine two.\nLine three." }
+
+      it "does not score single newlines" do
+        expect(score).to eq(0)
+      end
+    end
+
+    context "with paragraph breaks exceeding the cap" do
+      let(:raw_text) { ([ "Paragraph" ] * 15).join("\n\n") }
+
+      it "caps the paragraph score" do
+        expect(score).to eq(described_class::PARAGRAPH_CAP)
+      end
+    end
+
+    context "with formatting entities and paragraph breaks" do
+      let(:raw_text) { "Bold heading\n\nSome body text." }
+      let(:entities) do
+        [ { "type" => "bold", "offset" => 0, "length" => 12 } ]
+      end
+
+      it "sums both signals" do
+        expected = described_class::FORMATTING_POINTS + described_class::PARAGRAPH_POINTS
+        expect(score).to eq(expected)
       end
     end
   end


### PR DESCRIPTION
## Summary
- Add paragraph break signal to `Telegram::NewsScorer` — counts `\n\n` in raw text, 3 points per break, capped at 15
- Expose `raw_text` field in `MessageParser::Result` (needed by paragraph signal and future signals: keywords, pronouns, questions)

## Mutation testing
- Evilution: 100% (51/52, 1 equivalent)
- Mutant: 99.04% (104/105, 1 equivalent — `[]` → `.fetch()`)

## Test plan
- [x] 4 new scorer specs: paragraph breaks, single newlines only, cap, combined with formatting
- [x] 1 new parser spec: raw_text with newlines preserved
- [x] All 35 specs pass
- [x] RuboCop clean

Closes #730
Beads: vm-67

🤖 Generated with [Claude Code](https://claude.com/claude-code)