### PR TITLE
NewsScorer: add link signal

### DIFF
--- a/app/services/telegram/news_scorer.rb
+++ b/app/services/telegram/news_scorer.rb
@@ -7,6 +7,9 @@ module Telegram
     PARAGRAPH_POINTS = 3
     PARAGRAPH_CAP = 15
 
+    LINK_POINTS = 3
+    LINK_CAP = 15
+
     def self.call(parsed_result)
       new(parsed_result).call
     end
@@ -16,7 +19,7 @@ module Telegram
     end
 
     def call
-      formatting_score + paragraph_score
+      formatting_score + paragraph_score + link_score
     end
 
     private
@@ -29,6 +32,11 @@ module Telegram
     def paragraph_score
       count = @parsed_result.raw_text.scan("\n\n").size
       [ count * PARAGRAPH_POINTS, PARAGRAPH_CAP ].min
+    end
+
+    def link_score
+      count = @parsed_result.entities.count { |e| e["type"] == "text_link" }
+      [ count * LINK_POINTS, LINK_CAP ].min
     end
   end
 end

--- a/spec/services/telegram/news_scorer_spec.rb
+++ b/spec/services/telegram/news_scorer_spec.rb
@@ -129,5 +129,56 @@ RSpec.describe Telegram::NewsScorer do
         expect(score).to eq(expected)
       end
     end
+
+    context "with text_link entities" do
+      let(:entities) do
+        [
+          { "type" => "text_link", "offset" => 0, "length" => 10, "url" => "https://example.com" },
+          { "type" => "text_link", "offset" => 20, "length" => 8, "url" => "https://example.org" }
+        ]
+      end
+
+      it "adds points per link" do
+        expect(score).to eq(2 * described_class::LINK_POINTS)
+      end
+    end
+
+    context "with url entities" do
+      let(:entities) do
+        [
+          { "type" => "url", "offset" => 0, "length" => 20 }
+        ]
+      end
+
+      it "does not score plain url entities" do
+        expect(score).to eq(0)
+      end
+    end
+
+    context "with links exceeding the cap" do
+      let(:entities) do
+        15.times.map do |i|
+          { "type" => "text_link", "offset" => i * 15, "length" => 10, "url" => "https://example.com/#{i}" }
+        end
+      end
+
+      it "caps the link score" do
+        expect(score).to eq(described_class::LINK_CAP)
+      end
+    end
+
+    context "with links and formatting entities" do
+      let(:entities) do
+        [
+          { "type" => "bold", "offset" => 0, "length" => 4 },
+          { "type" => "text_link", "offset" => 5, "length" => 10, "url" => "https://example.com" }
+        ]
+      end
+
+      it "sums both signals" do
+        expected = described_class::FORMATTING_POINTS + described_class::LINK_POINTS
+        expect(score).to eq(expected)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Add link signal to `Telegram::NewsScorer` — counts `text_link` entities, 3 points each, capped at 15
- Plain `url` entities (bare URLs without anchor text) are not scored

## Mutation testing
- Evilution: 100% (79/81, 2 equivalent)
- Mutant: 98.71% (154/156, 2 equivalent — `[]` → `.fetch()`)

## Test plan
- [x] 4 new specs: text_link scoring, plain url exclusion, cap, combined with formatting
- [x] All 14 specs pass
- [x] RuboCop clean

Closes #731
Beads: vm-68

🤖 Generated with [Claude Code](https://claude.com/claude-code)