### PR TITLE
NewsScorer: add photo signal

### DIFF
--- a/app/services/telegram/news_scorer.rb
+++ b/app/services/telegram/news_scorer.rb
@@ -10,6 +10,8 @@ module Telegram
     LINK_POINTS = 3
     LINK_CAP = 15
 
+    PHOTO_POINTS = 5
+
     def self.call(parsed_result)
       new(parsed_result).call
     end
@@ -19,7 +21,7 @@ module Telegram
     end
 
     def call
-      formatting_score + paragraph_score + link_score
+      formatting_score + paragraph_score + link_score + photo_score
     end
 
     private
@@ -37,6 +39,10 @@ module Telegram
     def link_score
       count = @parsed_result.entities.count { |e| e["type"] == "text_link" }
       [ count * LINK_POINTS, LINK_CAP ].min
+    end
+
+    def photo_score
+      @parsed_result.photo_file_id.present? ? PHOTO_POINTS : 0
     end
   end
 end

--- a/spec/services/telegram/news_scorer_spec.rb
+++ b/spec/services/telegram/news_scorer_spec.rb
@@ -180,5 +180,32 @@ RSpec.describe Telegram::NewsScorer do
         expect(score).to eq(expected)
       end
     end
+
+    context "with a photo attached" do
+      let(:parsed_result) do
+        Telegram::MessageParser::Result.new(
+          text: text,
+          html_content: "",
+          from_id: 42,
+          from_username: "testuser",
+          from_first_name: "Denis",
+          chat_id: 42,
+          photo_file_id: "some_photo_id",
+          raw_text_length: raw_text.length,
+          entities: entities,
+          raw_text: raw_text
+        )
+      end
+
+      it "adds photo bonus points" do
+        expect(score).to eq(described_class::PHOTO_POINTS)
+      end
+    end
+
+    context "without a photo" do
+      it "does not add photo points" do
+        expect(score).to eq(0)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Add photo signal to `Telegram::NewsScorer` — 5 bonus points when `photo_file_id` is present

## Mutation testing
- Evilution: 100% (92/94, 2 equivalent)
- Mutant: 98.35% (179/182, 3 equivalent — 2x `[]`→`.fetch()`, 1x `.present?`→truthy)

## Test plan
- [x] 2 new specs: with photo, without photo
- [x] All 16 specs pass
- [x] RuboCop clean

Closes #732
Beads: vm-69

🤖 Generated with [Claude Code](https://claude.com/claude-code)