### PR TITLE
NewsScorer: add first-person pronoun penalty

### DIFF
--- a/app/services/telegram/news_scorer.rb
+++ b/app/services/telegram/news_scorer.rb
@@ -16,6 +16,10 @@ module Telegram
     KEYWORD_CAP = 10
     KEYWORD_SETTING = "news_score_keywords"
 
+    FIRST_PERSON_PRONOUNS = %w[я мне мной меня мой моя моё мои моего моей моему моим моих моими].freeze
+    FIRST_PERSON_THRESHOLD = 0.08
+    FIRST_PERSON_PENALTY = -10
+
     def self.call(parsed_result)
       new(parsed_result).call
     end
@@ -25,7 +29,7 @@ module Telegram
     end
 
     def call
-      formatting_score + paragraph_score + link_score + photo_score + keyword_score
+      formatting_score + paragraph_score + link_score + photo_score + keyword_score + first_person_penalty
     end
 
     private
@@ -47,6 +51,15 @@ module Telegram
 
     def photo_score
       @parsed_result.photo_file_id.present? ? PHOTO_POINTS : 0
+    end
+
+    def first_person_penalty
+      words = @parsed_result.raw_text.downcase.split(/\s+/)
+      return 0 if words.empty?
+
+      pronoun_count = words.count { |w| FIRST_PERSON_PRONOUNS.include?(w) }
+      ratio = pronoun_count.to_f / words.size
+      ratio > FIRST_PERSON_THRESHOLD ? FIRST_PERSON_PENALTY : 0
     end
 
     def keyword_score

--- a/spec/services/telegram/news_scorer_spec.rb
+++ b/spec/services/telegram/news_scorer_spec.rb
@@ -329,5 +329,49 @@ RSpec.describe Telegram::NewsScorer do
         expect(score).to eq(0)
       end
     end
+
+    context "with high first-person pronoun ratio" do
+      let(:raw_text) { "Я пошёл на игру и мне очень понравилось. Я думаю что мой уровень вырос. Меня это радует." }
+
+      it "applies the penalty" do
+        expect(score).to eq(described_class::FIRST_PERSON_PENALTY)
+      end
+    end
+
+    context "with uppercase first-person pronouns" do
+      let(:raw_text) { "Я написал. Я сделал. Я решил. Я понял. Мне нравится." }
+
+      it "matches case-insensitively" do
+        expect(score).to eq(described_class::FIRST_PERSON_PENALTY)
+      end
+    end
+
+    context "with low first-person pronoun ratio" do
+      let(:raw_text) { "Турнир завершился победой команды Альфа. Участники показали отличную игру. Результаты опубликованы на сайте клуба." }
+
+      it "does not apply a penalty" do
+        expect(score).to eq(0)
+      end
+    end
+
+    context "with first-person pronouns below threshold" do
+      let(:raw_text) { "Обзор сезона показал интересные результаты. Я считаю что команда выступила достойно. Все участники заслужили уважение за проявленный характер." }
+
+      it "does not penalize when ratio is below threshold" do
+        expect(score).to eq(0)
+      end
+    end
+
+    context "with penalty combined with positive signals" do
+      let(:raw_text) { "Я написал обзор.\n\nЯ думаю мне понравилось. Я считаю мой уровень вырос. Меня это радует." }
+      let(:entities) do
+        [ { "type" => "bold", "offset" => 0, "length" => 2 } ]
+      end
+
+      it "reduces total score but does not go below penalty floor" do
+        positive = described_class::FORMATTING_POINTS + described_class::PARAGRAPH_POINTS
+        expect(score).to be < positive
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Add first-person pronoun penalty to `Telegram::NewsScorer`
- Detects 15 Russian first-person pronouns (я, мне, мной, меня, мой, моя, моё, мои, моего, моей, моему, моим, моих, моими)
- Penalizes -10 points when pronoun-to-word ratio exceeds 8%
- Case-insensitive matching

## Mutation testing
- Evilution: 100% (214/218, 4 equivalent)
- Mutant: 86.25% on `#first_person_penalty` (69/80) — 11 survivors are equivalent (split regex variants, empty guard removal)

## Test plan
- [x] 5 new specs: high ratio penalty, uppercase pronouns, low ratio, below threshold, combined with positive signals
- [x] All 29 specs pass
- [x] RuboCop clean

Closes #734
Beads: vm-71

🤖 Generated with [Claude Code](https://claude.com/claude-code)