### PR TITLE
Add news_score_threshold setting

### DIFF
--- a/app/models/feature_toggle.rb
+++ b/app/models/feature_toggle.rb
@@ -16,6 +16,7 @@ class FeatureToggle < ApplicationRecord
     news_per_page
     news_max_article_length
     news_score_keywords
+    news_score_threshold
   ].freeze
   CACHE_TTL = 5.minutes
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -40,7 +40,8 @@ toggle.save!
   { key: "news_infinite_scroll", description: "Use infinite scroll on news page" },
   { key: "news_per_page", description: "Number of news articles per page", enabled: false },
   { key: "news_max_article_length", description: "Max article length (chars) on news index before truncation", enabled: false },
-  { key: "news_score_keywords", description: "Comma-separated keywords for news scoring (e.g. игра,сезон,турнир)", enabled: true, value: "игра,сезон,турнир,рейтинг,мафия" }
+  { key: "news_score_keywords", description: "Comma-separated keywords for news scoring (e.g. игра,сезон,турнир)", enabled: true, value: "игра,сезон,турнир,рейтинг,мафия" },
+  { key: "news_score_threshold", description: "Minimum news score to create a draft from Telegram message", enabled: true, value: "10" }
 ].each do |attrs|
   block_toggle = FeatureToggle.find_or_initialize_by(key: attrs[:key])
   if block_toggle.new_record?


### PR DESCRIPTION
## Summary
- Add `news_score_threshold` to `FeatureToggle::KEYS`
- Seed with default value `"10"` (enabled)
- This threshold will be used by the job integration (vm-74) to gate draft creation

## Test plan
- [x] Existing FeatureToggle specs pass (19 examples)
- [x] RuboCop clean
- No mutation testing needed — pure config/data change

Closes #736
Beads: vm-73

🤖 Generated with [Claude Code](https://claude.com/claude-code)