### PR TITLE
Integrate NewsScorer into ProcessTelegramWebhookJob

### DIFF
--- a/app/jobs/process_telegram_webhook_job.rb
+++ b/app/jobs/process_telegram_webhook_job.rb
@@ -12,6 +12,7 @@ class ProcessTelegramWebhookJob < ApplicationJob
     author = TelegramAuthor.find_by_telegram_user_id(parsed.from_id)
     return if author.nil?
     return if author.user.nil?
+    return if below_score_threshold?(parsed)
 
     news = News.create!(
       title: parsed.text.truncate(MAX_TITLE_LENGTH),
@@ -25,6 +26,17 @@ class ProcessTelegramWebhookJob < ApplicationJob
   end
 
   private
+
+  SCORE_THRESHOLD_SETTING = "news_score_threshold"
+  DEFAULT_SCORE_THRESHOLD = 10
+
+  def below_score_threshold?(parsed)
+    return false unless FeatureToggle.enabled?(SCORE_THRESHOLD_SETTING)
+
+    threshold = FeatureToggle.value_for(SCORE_THRESHOLD_SETTING, default: DEFAULT_SCORE_THRESHOLD).to_i
+    score = Telegram::NewsScorer.call(parsed)
+    score < threshold
+  end
 
   def attach_photo(news, file_id)
     result = Telegram::DownloadFileService.call(file_id)

--- a/spec/jobs/process_telegram_webhook_job_spec.rb
+++ b/spec/jobs/process_telegram_webhook_job_spec.rb
@@ -329,5 +329,86 @@ RSpec.describe ProcessTelegramWebhookJob do
         expect(NotifyEditorsAboutDraftService).to have_received(:call).with(News.last)
       end
     end
+
+    context "when news score is below threshold" do
+      before do
+        allow(Telegram::NewsScorer).to receive(:call).and_return(0)
+        FeatureToggle.find_or_create_by!(key: "news_score_threshold") do |ft|
+          ft.enabled = true
+          ft.value = "10"
+          ft.description = "Minimum news score"
+        end
+      end
+
+      it "does not create a news article" do
+        expect { described_class.new.perform(payload) }.not_to change(News, :count)
+      end
+    end
+
+    context "when news score meets threshold" do
+      before do
+        allow(Telegram::NewsScorer).to receive(:call).and_return(10)
+        FeatureToggle.find_or_create_by!(key: "news_score_threshold") do |ft|
+          ft.enabled = true
+          ft.value = "10"
+          ft.description = "Minimum news score"
+        end
+      end
+
+      it "creates a news article" do
+        expect { described_class.new.perform(payload) }.to change(News, :count).by(1)
+      end
+
+      it "passes the parsed result to the scorer" do
+        described_class.new.perform(payload)
+        expect(Telegram::NewsScorer).to have_received(:call).with(an_instance_of(Telegram::MessageParser::Result))
+      end
+    end
+
+    context "when news score threshold has a custom value" do
+      before do
+        allow(Telegram::NewsScorer).to receive(:call).and_return(7)
+        FeatureToggle.find_or_create_by!(key: "news_score_threshold") do |ft|
+          ft.enabled = true
+          ft.value = "5"
+          ft.description = "Minimum news score"
+        end
+      end
+
+      it "creates a news article when score meets the custom threshold" do
+        expect { described_class.new.perform(payload) }.to change(News, :count).by(1)
+      end
+    end
+
+    context "when news score threshold toggle has blank value" do
+      before do
+        allow(Telegram::NewsScorer).to receive(:call).and_return(5)
+        FeatureToggle.find_or_create_by!(key: "news_score_threshold") do |ft|
+          ft.enabled = true
+          ft.value = ""
+          ft.description = "Minimum news score"
+        end
+      end
+
+      it "uses the default threshold and does not create a news article" do
+        expect { described_class.new.perform(payload) }.not_to change(News, :count)
+      end
+    end
+
+    context "when news score threshold toggle is disabled" do
+      before do
+        allow(Telegram::NewsScorer).to receive(:call).and_return(0)
+        FeatureToggle.find_or_create_by!(key: "news_score_threshold") do |ft|
+          ft.enabled = false
+          ft.value = "10"
+          ft.description = "Minimum news score"
+        end
+      end
+
+      it "skips scoring and creates a news article" do
+        expect { described_class.new.perform(payload) }.to change(News, :count).by(1)
+        expect(Telegram::NewsScorer).not_to have_received(:call)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Adds scoring gate to `ProcessTelegramWebhookJob`: when `news_score_threshold` toggle is enabled, messages are scored by `Telegram::NewsScorer` and rejected if below threshold
- When toggle is disabled, scoring is skipped entirely (backward compatible)
- Default threshold is 10, configurable via `FeatureToggle` value

## Mutation testing
- Evilution: 100% (28/28 mutants killed)
- Mutant: 97.91% (47/48 killed, 1 equivalent: `.to_i` → `Integer()`)

## Test plan
- [x] Score below threshold → no article created
- [x] Score meets threshold → article created
- [x] Custom threshold value respected
- [x] Blank value falls back to default threshold (10)
- [x] Toggle disabled → scoring skipped, article created
- [x] Scorer receives correct parsed result argument

Closes #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)