### PR TITLE
NewsScorer: add logging for score breakdown

### DIFF
--- a/app/jobs/process_telegram_webhook_job.rb
+++ b/app/jobs/process_telegram_webhook_job.rb
@@ -35,7 +35,13 @@ class ProcessTelegramWebhookJob < ApplicationJob
 
     threshold = FeatureToggle.value_for(SCORE_THRESHOLD_SETTING, default: DEFAULT_SCORE_THRESHOLD).to_i
     score = Telegram::NewsScorer.call(parsed)
-    score < threshold
+    if score < threshold
+      Rails.logger.debug("[TelegramWebhook] rejected: score=#{score} threshold=#{threshold} from_id=#{parsed.from_id}")
+      true
+    else
+      Rails.logger.info("[TelegramWebhook] accepted: score=#{score} threshold=#{threshold} from_id=#{parsed.from_id}")
+      false
+    end
   end
 
   def attach_photo(news, file_id)

--- a/app/services/telegram/news_scorer.rb
+++ b/app/services/telegram/news_scorer.rb
@@ -32,7 +32,19 @@ module Telegram
     end
 
     def call
-      formatting_score + paragraph_score + link_score + photo_score + keyword_score + first_person_penalty + question_penalty
+      scores = {
+        formatting: formatting_score,
+        paragraph: paragraph_score,
+        link: link_score,
+        photo: photo_score,
+        keyword: keyword_score,
+        first_person: first_person_penalty,
+        question: question_penalty
+      }
+      total = scores.values.sum
+      breakdown = scores.map { |k, v| "#{k}=#{v}" }.join(" ")
+      Rails.logger.debug("[NewsScorer] #{breakdown} total=#{total}")
+      total
     end
 
     private

--- a/spec/jobs/process_telegram_webhook_job_spec.rb
+++ b/spec/jobs/process_telegram_webhook_job_spec.rb
@@ -343,6 +343,12 @@ RSpec.describe ProcessTelegramWebhookJob do
       it "does not create a news article" do
         expect { described_class.new.perform(payload) }.not_to change(News, :count)
       end
+
+      it "logs the rejection at debug level" do
+        allow(Rails.logger).to receive(:debug)
+        described_class.new.perform(payload)
+        expect(Rails.logger).to have_received(:debug).with(/rejected.*score=0.*threshold=10.*from_id=12345/)
+      end
     end
 
     context "when news score meets threshold" do
@@ -362,6 +368,12 @@ RSpec.describe ProcessTelegramWebhookJob do
       it "passes the parsed result to the scorer" do
         described_class.new.perform(payload)
         expect(Telegram::NewsScorer).to have_received(:call).with(an_instance_of(Telegram::MessageParser::Result))
+      end
+
+      it "logs the acceptance at info level" do
+        allow(Rails.logger).to receive(:info)
+        described_class.new.perform(payload)
+        expect(Rails.logger).to have_received(:info).with(/accepted.*score=10.*threshold=10.*from_id=12345/)
       end
     end
 

--- a/spec/services/telegram/news_scorer_spec.rb
+++ b/spec/services/telegram/news_scorer_spec.rb
@@ -423,7 +423,9 @@ RSpec.describe Telegram::NewsScorer do
       it "logs the score breakdown at debug level" do
         allow(Rails.logger).to receive(:debug)
         described_class.call(parsed_result)
-        expect(Rails.logger).to have_received(:debug).with(/NewsScorer.*formatting=2.*paragraph=3.*total=5/)
+        expect(Rails.logger).to have_received(:debug).with(
+          /NewsScorer.*formatting=2.*paragraph=3.*link=0.*photo=0.*keyword=0.*first_person=0.*question=0.*total=5/
+        )
       end
     end
 

--- a/spec/services/telegram/news_scorer_spec.rb
+++ b/spec/services/telegram/news_scorer_spec.rb
@@ -414,6 +414,19 @@ RSpec.describe Telegram::NewsScorer do
       end
     end
 
+    context "logging" do
+      let(:raw_text) { "Bold heading\n\nSome body text." }
+      let(:entities) do
+        [ { "type" => "bold", "offset" => 0, "length" => 12 } ]
+      end
+
+      it "logs the score breakdown at debug level" do
+        allow(Rails.logger).to receive(:debug)
+        described_class.call(parsed_result)
+        expect(Rails.logger).to have_received(:debug).with(/NewsScorer.*formatting=2.*paragraph=3.*total=5/)
+      end
+    end
+
     context "with questions and positive signals" do
       let(:raw_text) { "Кто победил? Что думаете? Как оценить?\n\nОбзор сезона." }
       let(:entities) do


### PR DESCRIPTION
## Summary
- `Telegram::NewsScorer#call` logs the full signal breakdown (formatting, paragraph, link, photo, keyword, first_person, question, total) at debug level
- `ProcessTelegramWebhookJob` logs accept/reject decisions with score, threshold, and from_id — `info` for accepted, `debug` for rejected
- Enables tuning of weights and threshold by reviewing logs

## Mutation testing
- Evilution (scorer): 90% (45/50 killed, 5 equivalent on `.join` separator)
- Evilution (job): 90.2% (55/61 killed, 6 equivalent on boolean truthiness and log string formatting)
- Mutant (scorer): 90.32% (56/62 killed, 6 equivalent on hash key names and `.join`)
- Mutant (job): 98.86% (87/88 killed, 1 equivalent: `.to_i` → `Integer()`)

## Test plan
- [x] Scorer logs breakdown at debug level with all signal values
- [x] Job logs rejection at debug level with score, threshold, from_id
- [x] Job logs acceptance at info level with score, threshold, from_id

Closes #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)