### PR TITLE
753: Auto-link player nicknames in Telegram news drafts

### DIFF
--- a/app/jobs/process_telegram_webhook_job.rb
+++ b/app/jobs/process_telegram_webhook_job.rb
@@ -22,6 +22,7 @@ class ProcessTelegramWebhookJob < ApplicationJob
     )
 
     attach_photo(news, parsed.photo_file_id) if parsed.photo_file_id.present?
+    AutolinkPlayersInNewsService.call(news)
     NotifyEditorsAboutDraftService.call(news)
   end
 

--- a/app/services/autolink_players_in_news_service.rb
+++ b/app/services/autolink_players_in_news_service.rb
@@ -1,3 +1,5 @@
+require "set"
+
 class AutolinkPlayersInNewsService
   FEATURE_KEY = "news_autolink_players".freeze
 
@@ -26,7 +28,7 @@ class AutolinkPlayersInNewsService
     return html if players.empty?
 
     fragment = Nokogiri::HTML.fragment(html)
-    linked_ids = []
+    linked_ids = Set.new
     fragment.traverse do |node|
       next unless node.text?
       next if inside_anchor?(node)
@@ -60,7 +62,7 @@ class AutolinkPlayersInNewsService
 
       [ match.begin(0), match.end(0), id, match[0] ]
     end
-    drop_overlaps(raw.sort_by { |start, _finish, _id, _matched| start })
+    drop_overlaps(raw.sort_by { |start, finish, _id, _matched| [ start, -(finish - start) ] })
   end
 
   def drop_overlaps(matches)

--- a/app/services/autolink_players_in_news_service.rb
+++ b/app/services/autolink_players_in_news_service.rb
@@ -1,0 +1,100 @@
+class AutolinkPlayersInNewsService
+  FEATURE_KEY = "news_autolink_players".freeze
+
+  def self.call(news)
+    new(news).call
+  end
+
+  def initialize(news)
+    @news = news
+  end
+
+  def call
+    return unless FeatureToggle.enabled?(FEATURE_KEY)
+
+    original_html = @news.content.body.to_html
+    new_html = rewrite_html(original_html)
+    return if new_html == original_html
+
+    @news.update!(content: new_html)
+  end
+
+  private
+
+  def rewrite_html(html)
+    players = players_by_length_desc
+    return html if players.empty?
+
+    fragment = Nokogiri::HTML.fragment(html)
+    linked_ids = []
+    fragment.traverse do |node|
+      next unless node.text?
+      next if inside_anchor?(node)
+
+      link_matches_in_node(node, players, linked_ids)
+    end
+    fragment.to_html
+  end
+
+  def players_by_length_desc
+    Player.pluck(:id, :name)
+          .sort_by { |_id, name| -name.length }
+          .map { |id, name| [ id, Regexp.new("(?<!\\p{L})#{Regexp.escape(name)}(?!\\p{L})", Regexp::IGNORECASE) ] }
+  end
+
+  def link_matches_in_node(text_node, players, linked_ids)
+    text = text_node.content
+    matches = collect_matches(text, players, linked_ids)
+    return if matches.empty?
+
+    replace_node_with_matches(text_node, text, matches)
+    matches.each { |_start, _finish, id, _matched| linked_ids << id }
+  end
+
+  def collect_matches(text, players, linked_ids)
+    raw = players.filter_map do |id, regex|
+      next if linked_ids.include?(id)
+
+      match = regex.match(text)
+      next unless match
+
+      [ match.begin(0), match.end(0), id, match[0] ]
+    end
+    drop_overlaps(raw.sort_by { |start, _finish, _id, _matched| start })
+  end
+
+  def drop_overlaps(matches)
+    result = []
+    last_end = 0
+    matches.each do |match|
+      start, finish, _id, _matched = match
+      next if start < last_end
+
+      result << match
+      last_end = finish
+    end
+    result
+  end
+
+  def replace_node_with_matches(text_node, text, matches)
+    doc = text_node.document
+    cursor = matches.reduce(0) do |pos, (start, finish, id, matched)|
+      text_node.add_previous_sibling(doc.create_text_node(text[pos...start]))
+      text_node.add_previous_sibling(build_anchor(doc, id, matched))
+      finish
+    end
+    text_node.add_previous_sibling(doc.create_text_node(text[cursor..]))
+    text_node.remove
+  end
+
+  def build_anchor(doc, id, matched)
+    anchor = Nokogiri::XML::Node.new("a", doc)
+    anchor["href"] = "/players/#{id}"
+    anchor.add_child(doc.create_text_node(matched))
+    anchor
+  end
+
+  def inside_anchor?(node)
+    node.ancestors.any? { |ancestor| ancestor.name == "a" }
+  end
+end

--- a/spec/jobs/process_telegram_webhook_job_spec.rb
+++ b/spec/jobs/process_telegram_webhook_job_spec.rb
@@ -328,6 +328,12 @@ RSpec.describe ProcessTelegramWebhookJob do
         described_class.new.perform(payload)
         expect(NotifyEditorsAboutDraftService).to have_received(:call).with(News.last)
       end
+
+      it "runs the player autolink service on the created news" do
+        allow(AutolinkPlayersInNewsService).to receive(:call)
+        described_class.new.perform(payload)
+        expect(AutolinkPlayersInNewsService).to have_received(:call).with(News.last)
+      end
     end
 
     context "when news score is below threshold" do

--- a/spec/services/autolink_players_in_news_service_spec.rb
+++ b/spec/services/autolink_players_in_news_service_spec.rb
@@ -1,0 +1,164 @@
+require "rails_helper"
+
+RSpec.describe AutolinkPlayersInNewsService do
+  let_it_be(:alex) { create(:player, name: "Alex") }
+  let_it_be(:alex_smith) { create(:player, name: "Alex Smith") }
+  let_it_be(:ivan) { create(:player, name: "Иван") }
+
+  before { create(:feature_toggle, key: "news_autolink_players", enabled: true) }
+
+  def build_news(html)
+    create(:news, content: html)
+  end
+
+  def rewritten_html(news)
+    described_class.call(news)
+    news.reload.content.body.to_html
+  end
+
+  describe ".call" do
+    context "when the feature toggle is disabled" do
+      before { FeatureToggle.find_by!(key: "news_autolink_players").update!(enabled: false) }
+
+      it "does not modify the content" do
+        news = build_news("<div>Alex scored a goal</div>")
+        expect { described_class.call(news) }
+          .not_to change { news.reload.content.body.to_html }
+      end
+    end
+
+    context "when the content is blank" do
+      it "does not raise" do
+        news = build_news("")
+        expect { described_class.call(news) }.not_to raise_error
+      end
+    end
+
+    it "wraps a single player mention in a link to the profile" do
+      news = build_news("<div>Alex scored a goal</div>")
+      expect(rewritten_html(news)).to include(%(<a href="/players/#{alex.id}">Alex</a>))
+    end
+
+    it "links only the first occurrence of a player name" do
+      news = build_news("<div>Alex passed to Alex again</div>")
+      html = rewritten_html(news)
+      expect(html.scan(%r{<a href="/players/#{alex.id}">Alex</a>}).size).to eq(1)
+      expect(html).to include("to Alex again")
+    end
+
+    it "links each player once when multiple players are mentioned" do
+      news = build_news("<div>Alex passed to Иван</div>")
+      html = rewritten_html(news)
+      expect(html).to include(
+        %(<a href="/players/#{alex.id}">Alex</a> passed to <a href="/players/#{ivan.id}">Иван</a>)
+      )
+    end
+
+    it "preserves text that appears before the first match" do
+      news = build_news("<div>Hello Alex world</div>")
+      expect(rewritten_html(news)).to include(%(Hello <a href="/players/#{alex.id}">Alex</a> world))
+    end
+
+    it "links matches regardless of the order they appear in the text" do
+      news = build_news("<div>Иван then Alex</div>")
+      html = rewritten_html(news)
+      expect(html).to include(
+        %(<a href="/players/#{ivan.id}">Иван</a> then <a href="/players/#{alex.id}">Alex</a>)
+      )
+    end
+
+    it "links the first occurrence across separate elements" do
+      news = build_news("<div><p>Alex scored</p><p>Alex passed again</p></div>")
+      html = rewritten_html(news)
+      expect(html.scan(%r{<a href="/players/#{alex.id}">Alex</a>}).size).to eq(1)
+      expect(html).to include("Alex passed again")
+    end
+
+    it "keeps a non-overlapping later match when an earlier overlap is dropped" do
+      news = build_news("<div>Alex Smith passed to Иван</div>")
+      html = rewritten_html(news)
+      expect(html).to include(%(<a href="/players/#{alex_smith.id}">Alex Smith</a>))
+      expect(html).to include(%(<a href="/players/#{ivan.id}">Иван</a>))
+      expect(html).not_to include(%(<a href="/players/#{alex.id}">))
+    end
+
+    it "matches case-insensitively and preserves original casing" do
+      news = build_news("<div>ALEX and alex play together</div>")
+      html = rewritten_html(news)
+      expect(html).to include(%(<a href="/players/#{alex.id}">ALEX</a>))
+      expect(html).to include("and alex play")
+    end
+
+    it "does not match a name that is a substring of a longer word" do
+      news = build_news("<div>Alexander scored</div>")
+      expect(rewritten_html(news)).not_to include(%(<a href="/players/#{alex.id}">))
+    end
+
+    it "does not match a name preceded by a letter" do
+      news = build_news("<div>xxAlex scored</div>")
+      expect(rewritten_html(news)).not_to include(%(<a href="/players/#{alex.id}">))
+    end
+
+    it "does not match Cyrillic name inside a longer word" do
+      news = build_news("<div>Иванов забил гол</div>")
+      expect(rewritten_html(news)).not_to include(%(<a href="/players/#{ivan.id}">))
+    end
+
+    it "prefers the longer player name when names overlap" do
+      news = build_news("<div>Alex Smith played well</div>")
+      html = rewritten_html(news)
+      expect(html).to include(%(<a href="/players/#{alex_smith.id}">Alex Smith</a>))
+      expect(html).not_to include(%(<a href="/players/#{alex.id}">Alex</a>))
+    end
+
+    it "skips text already inside an anchor tag" do
+      news = build_news(%(<div><a href="/other">Alex</a> scored</div>))
+      html = rewritten_html(news)
+      expect(html).to include(%(<a href="/other">Alex</a>))
+      expect(html).not_to include(%(<a href="/players/#{alex.id}">))
+    end
+
+    it "leaves content unchanged when no players are mentioned" do
+      news = build_news("<div>Nobody relevant here</div>")
+      expect(news).not_to receive(:update!)
+      expect { described_class.call(news) }
+        .not_to change { news.reload.content.body.to_html }
+    end
+
+    it "does nothing when there are no players in the database" do
+      allow(Player).to receive(:pluck).with(:id, :name).and_return([])
+      news = build_news("<div>Alex scored</div>")
+      expect(news).not_to receive(:update!)
+      described_class.call(news)
+    end
+
+    it "processes text nodes in sibling elements after one element" do
+      news = build_news("<div><p>Alex</p><p>Иван</p></div>")
+      html = rewritten_html(news)
+      expect(html).to include(%(<a href="/players/#{alex.id}">Alex</a>))
+      expect(html).to include(%(<a href="/players/#{ivan.id}">Иван</a>))
+    end
+
+    it "processes text after an existing anchor" do
+      news = build_news(%(<div><a href="/other">Link</a> and Иван</div>))
+      html = rewritten_html(news)
+      expect(html).to include(%(<a href="/other">Link</a>))
+      expect(html).to include(%(<a href="/players/#{ivan.id}">Иван</a>))
+    end
+
+    it "escapes regex metacharacters in player names" do
+      dotted = create(:player, name: "A.B")
+      news = build_news("<div>AXB did not score, A.B did</div>")
+      html = rewritten_html(news)
+      expect(html).to include(%(<a href="/players/#{dotted.id}">A.B</a>))
+      expect(html).not_to include(%(<a href="/players/#{dotted.id}">AXB</a>))
+    end
+
+    it "replaces the original text node rather than duplicating it" do
+      news = build_news("<div>Alex scored a goal</div>")
+      html = rewritten_html(news)
+      expect(html.scan("Alex").size).to eq(1)
+      expect(html.scan("scored a goal").size).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- New `AutolinkPlayersInNewsService` post-processes News drafts created from Telegram messages, wrapping the first occurrence of each known player nickname in a link to their profile (`/players/:id`)
- Case-insensitive exact matching with Unicode word boundaries (handles Cyrillic), longer-name-wins on overlap, skips text already inside `<a>` tags, escapes regex metacharacters in player names
- Gated behind the existing `news_autolink_players` feature toggle, called from `ProcessTelegramWebhookJob` after `News.create!`

## Mutation testing
- Evilution: 94.46% (324/343 mutants killed)
- Mutant: 96.00% (481/501 mutants killed)

Both well above the 80% gate. Remaining survivors are micro-equivalences (`length`/`size`, `each`/`map`, `update!`/`update`, beginless/endless ranges) — see `.artifacts.local/regular-evilution-feedback.log` for the full analysis.

## Test plan
- [x] Unit specs for the service (21 examples) covering toggle on/off, blank content, single/multi/case-insensitive matches, Latin & Cyrillic word boundaries, overlapping names, anchor skipping, multi-element traversal, regex-special names
- [x] Job spec verifies the service is called after `News.create!`
- [x] `bundle exec rubocop` clean on changed files
- [ ] Manual smoke test: enable `news_autolink_players` in admin, post a Telegram message mentioning a known player, verify the draft has the player linked

Closes #753

🤖 Generated with [Claude Code](https://claude.com/claude-code)