### PR TITLE
vm-50: Add slug to Players for public URLs

### DIFF
--- a/app/avo/resources/player.rb
+++ b/app/avo/resources/player.rb
@@ -1,6 +1,9 @@
 class Avo::Resources::Player < Avo::BaseResource
   self.title = :name
   self.default_view_type = :table
+  self.find_record_method = -> {
+    query.find_by(slug: id) || query.find(id)
+  }
 
   self.search = {
     query: -> { query.where("name ILIKE ?", "%#{params[:q]}%") }

--- a/app/controllers/player_claims_controller.rb
+++ b/app/controllers/player_claims_controller.rb
@@ -4,7 +4,7 @@ class PlayerClaimsController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    player = Player.find(params[:player_id])
+    player = Player.find_by!(slug: params[:player_slug])
     result = ClaimPlayerService.call(user: current_user, player:)
 
     if result.success

--- a/app/controllers/player_disputes_controller.rb
+++ b/app/controllers/player_disputes_controller.rb
@@ -4,11 +4,11 @@ class PlayerDisputesController < ApplicationController
   before_action :authenticate_user!
 
   def new
-    @player = Player.find(params[:player_id])
+    @player = Player.find_by!(slug: params[:player_slug])
   end
 
   def create
-    @player = Player.find(params[:player_id])
+    @player = Player.find_by!(slug: params[:player_slug])
     dispute_params = params.require(:dispute).permit(:evidence, :selfie, documents: [])
     result = DisputePlayerService.call(
       user: current_user,

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -1,6 +1,6 @@
 class PlayersController < ApplicationController
   def show
-    result = PlayerProfileService.call(player_id: params[:id])
+    result = PlayerProfileService.call(player_slug: params[:slug])
     @player = result.player
     @competitions_with_games = result.competitions_with_games
     @player_awards = result.player_awards

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -1,4 +1,7 @@
 class Player < ApplicationRecord
+  include Sluggable
+  slug_source :name
+
   has_many :game_participations, dependent: :restrict_with_error
   has_many :games, through: :game_participations
   has_many :player_awards, dependent: :destroy

--- a/app/services/autolink_players_in_news_service.rb
+++ b/app/services/autolink_players_in_news_service.rb
@@ -48,9 +48,9 @@ class AutolinkPlayersInNewsService
   end
 
   def players_by_length_desc
-    Player.pluck(:id, :name)
-          .sort_by { |_id, name| -name.length }
-          .map { |id, name| [ id, PlayerNameRegex.build(name) ] }
+    Player.pluck(:id, :name, :slug)
+          .sort_by { |_id, name, _slug| -name.length }
+          .map { |id, name, slug| [ id, slug, PlayerNameRegex.build(name) ] }
   end
 
   def link_matches_in_node(text_node, players, linked_ids)
@@ -59,17 +59,17 @@ class AutolinkPlayersInNewsService
     return if matches.empty?
 
     replace_node_with_matches(text_node, text, matches)
-    matches.each { |_start, _finish, id, _matched| linked_ids << id }
+    matches.each { |_start, _finish, id, _slug, _matched| linked_ids << id }
   end
 
   def collect_matches(text, players, linked_ids)
-    raw = players.filter_map do |id, regex|
+    raw = players.filter_map do |id, slug, regex|
       next if linked_ids.include?(id)
 
       match = regex.match(text)
       next unless match
 
-      [ match.begin(0), match.end(0), id, match[0] ]
+      [ match.begin(0), match.end(0), id, slug, match[0] ]
     end
     drop_overlaps(raw.sort_by { |start, finish, _id, _matched| [ start, -(finish - start) ] })
   end
@@ -78,7 +78,7 @@ class AutolinkPlayersInNewsService
     result = []
     last_end = 0
     matches.each do |match|
-      start, finish, _id, _matched = match
+      start, finish, _id, _slug, _matched = match
       next if start < last_end
 
       result << match
@@ -89,18 +89,18 @@ class AutolinkPlayersInNewsService
 
   def replace_node_with_matches(text_node, text, matches)
     doc = text_node.document
-    cursor = matches.reduce(0) do |pos, (start, finish, id, matched)|
+    cursor = matches.reduce(0) do |pos, (start, finish, _id, slug, matched)|
       text_node.add_previous_sibling(doc.create_text_node(text[pos...start]))
-      text_node.add_previous_sibling(build_anchor(doc, id, matched))
+      text_node.add_previous_sibling(build_anchor(doc, slug, matched))
       finish
     end
     text_node.add_previous_sibling(doc.create_text_node(text[cursor..]))
     text_node.remove
   end
 
-  def build_anchor(doc, id, matched)
+  def build_anchor(doc, slug, matched)
     anchor = Nokogiri::XML::Node.new("a", doc)
-    anchor["href"] = "/players/#{id}"
+    anchor["href"] = "/players/#{slug}"
     anchor.add_child(doc.create_text_node(matched))
     anchor
   end

--- a/app/services/player_profile_service.rb
+++ b/app/services/player_profile_service.rb
@@ -4,16 +4,16 @@ class PlayerProfileService
   RoleStat = Data.define(:role_code, :role_name, :games, :wins, :win_rate)
   CompetitionGames = Data.define(:competition, :games)
 
-  def self.call(player_id:)
-    new(player_id).call
+  def self.call(player_slug:)
+    new(player_slug).call
   end
 
-  def initialize(player_id)
-    @player_id = player_id
+  def initialize(player_slug)
+    @player_slug = player_slug
   end
 
   def call
-    player = Player.find(@player_id)
+    player = Player.find_by!(slug: @player_slug)
     participations = player.game_participations.includes(:role, :game)
 
     Result.new(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,7 @@ Rails.application.routes.draw do
       get :overlay
     end
   end
-  resources :players, only: [ :show ] do
+  resources :players, only: [ :show ], param: :slug do
     resource :claim, only: [ :create ], controller: "player_claims"
     resource :dispute, only: [ :new, :create ], controller: "player_disputes"
   end

--- a/db/migrate/20260412134328_add_slug_to_players.rb
+++ b/db/migrate/20260412134328_add_slug_to_players.rb
@@ -1,0 +1,6 @@
+class AddSlugToPlayers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :players, :slug, :string
+    add_index :players, :slug, unique: true
+  end
+end

--- a/db/migrate/20260412134329_backfill_player_slugs.rb
+++ b/db/migrate/20260412134329_backfill_player_slugs.rb
@@ -1,0 +1,21 @@
+class BackfillPlayerSlugs < ActiveRecord::Migration[8.1]
+  def up
+    Player.where(slug: nil).find_each do |player|
+      base = CyrillicTransliterator.call(player.name.to_s).parameterize.presence ||
+             SecureRandom.hex(2)
+      candidate = base
+      Sluggable::MAX_SLUG_ATTEMPTS.times do
+        unless Player.where.not(id: player.id).exists?(slug: candidate)
+          player.update_column(:slug, candidate)
+          break
+        end
+        candidate = "#{base}-#{SecureRandom.hex(Sluggable::TAIL_BYTES)}"
+      end
+      player.update_column(:slug, candidate) if player.reload.slug.nil?
+    end
+  end
+
+  def down
+    Player.update_all(slug: nil)
+  end
+end

--- a/db/migrate/20260412134329_backfill_player_slugs.rb
+++ b/db/migrate/20260412134329_backfill_player_slugs.rb
@@ -1,21 +1,49 @@
 class BackfillPlayerSlugs < ActiveRecord::Migration[8.1]
+  CYRILLIC_TABLE = {
+    "а" => "a", "б" => "b", "в" => "v", "г" => "g", "д" => "d", "е" => "e", "ё" => "yo",
+    "ж" => "zh", "з" => "z", "и" => "i", "й" => "y", "к" => "k", "л" => "l", "м" => "m",
+    "н" => "n", "о" => "o", "п" => "p", "р" => "r", "с" => "s", "т" => "t", "у" => "u",
+    "ф" => "f", "х" => "kh", "ц" => "ts", "ч" => "ch", "ш" => "sh", "щ" => "shch",
+    "ъ" => "", "ы" => "y", "ь" => "", "э" => "e", "ю" => "yu", "я" => "ya"
+  }.freeze
+
+  TAIL_BYTES = 2
+  MAX_ATTEMPTS = 10
+
+  class MigrationPlayer < ActiveRecord::Base
+    self.table_name = "players"
+  end
+
   def up
-    Player.where(slug: nil).find_each do |player|
-      base = CyrillicTransliterator.call(player.name.to_s).parameterize.presence ||
-             SecureRandom.hex(2)
-      candidate = base
-      Sluggable::MAX_SLUG_ATTEMPTS.times do
-        unless Player.where.not(id: player.id).exists?(slug: candidate)
-          player.update_column(:slug, candidate)
-          break
-        end
-        candidate = "#{base}-#{SecureRandom.hex(Sluggable::TAIL_BYTES)}"
-      end
-      player.update_column(:slug, candidate) if player.reload.slug.nil?
+    MigrationPlayer.where(slug: nil).find_each do |player|
+      player.update_column(:slug, unique_slug_for(player))
     end
   end
 
   def down
-    Player.update_all(slug: nil)
+    MigrationPlayer.update_all(slug: nil)
+  end
+
+  private
+
+  def transliterate(string)
+    string.to_s.each_char.map { |c| CYRILLIC_TABLE[c.downcase] || c }.join
+  end
+
+  def base_slug_for(name)
+    transliterate(name).parameterize.presence || SecureRandom.hex(TAIL_BYTES)
+  end
+
+  def unique_slug_for(player)
+    base = base_slug_for(player.name)
+    candidate = base
+
+    MAX_ATTEMPTS.times do
+      return candidate unless MigrationPlayer.where.not(id: player.id).exists?(slug: candidate)
+
+      candidate = "#{base}-#{SecureRandom.hex(TAIL_BYTES)}"
+    end
+
+    raise "Unable to generate unique slug for Player ##{player.id} after #{MAX_ATTEMPTS} attempts"
   end
 end

--- a/db/migrate/20260412134330_make_player_slug_not_null.rb
+++ b/db/migrate/20260412134330_make_player_slug_not_null.rb
@@ -1,0 +1,5 @@
+class MakePlayerSlugNotNull < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :players, :slug, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_12_134328) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_12_134329) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_12_134329) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_12_134330) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -231,7 +231,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_134329) do
     t.datetime "created_at", null: false
     t.string "name", null: false
     t.integer "position"
-    t.string "slug"
+    t.string "slug", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_players_on_name", unique: true
     t.index ["slug"], name: "index_players_on_slug", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_10_170043) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_12_134328) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -231,8 +231,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_170043) do
     t.datetime "created_at", null: false
     t.string "name", null: false
     t.integer "position"
+    t.string "slug"
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_players_on_name", unique: true
+    t.index ["slug"], name: "index_players_on_slug", unique: true
   end
 
   create_table "playlist_episodes", force: :cascade do |t|

--- a/docs/superpowers/plans/2026-04-12-add-slug-to-players.md
+++ b/docs/superpowers/plans/2026-04-12-add-slug-to-players.md
@@ -1,0 +1,576 @@
+# Add Slug to Players — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace numeric IDs with human-readable slugs in all public player URLs (`/players/:slug`).
+
+**Architecture:** Add a `slug` column to `players`, include the `Sluggable` concern (from vm-t11) with `slug_source :name`, update routes to `param: :slug`, update controllers/services to look up by slug, and update `AutolinkPlayersInNewsService` to emit slug-based URLs instead of ID-based ones.
+
+**Tech Stack:** Rails 8.1, Ruby 4.0.1, RSpec, Sluggable concern, CyrillicTransliterator
+
+---
+
+### Task 1: Migration — add slug column with unique index
+
+**Files:**
+- Create: `db/migrate/20260412000001_add_slug_to_players.rb`
+
+- [ ] **Step 1: Generate the migration**
+
+Run:
+```bash
+bin/rails generate migration AddSlugToPlayers slug:string:uniq
+```
+
+- [ ] **Step 2: Edit the migration to make slug nullable initially**
+
+The migration should look like:
+
+```ruby
+class AddSlugToPlayers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :players, :slug, :string
+    add_index :players, :slug, unique: true
+  end
+end
+```
+
+Note: slug is nullable at first. We'll backfill, then add NOT NULL in a later migration.
+
+- [ ] **Step 3: Run the migration**
+
+Run: `bin/rails db:migrate`
+Expected: migration succeeds, `schema.rb` shows `slug` column on `players` table.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add db/migrate/*_add_slug_to_players.rb db/schema.rb
+git commit -m "vm-50: Add nullable slug column with unique index to players"
+```
+
+---
+
+### Task 2: Data migration — backfill slugs for existing players
+
+**Files:**
+- Create: `db/migrate/20260412000002_backfill_player_slugs.rb`
+
+- [ ] **Step 1: Create the data migration**
+
+```ruby
+class BackfillPlayerSlugs < ActiveRecord::Migration[8.1]
+  def up
+    Player.where(slug: nil).find_each do |player|
+      base = CyrillicTransliterator.call(player.name.to_s).parameterize.presence ||
+             SecureRandom.hex(2)
+      candidate = base
+      Sluggable::MAX_SLUG_ATTEMPTS.times do
+        unless Player.where.not(id: player.id).exists?(slug: candidate)
+          player.update_column(:slug, candidate)
+          break
+        end
+        candidate = "#{base}-#{SecureRandom.hex(Sluggable::TAIL_BYTES)}"
+      end
+      player.update_column(:slug, candidate) if player.slug.nil?
+    end
+  end
+
+  def down
+    Player.update_all(slug: nil)
+  end
+end
+```
+
+- [ ] **Step 2: Run the migration**
+
+Run: `bin/rails db:migrate`
+Expected: All players now have slugs. Verify:
+
+```bash
+bin/rails runner "puts Player.where(slug: nil).count"
+```
+
+Expected output: `0`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add db/migrate/*_backfill_player_slugs.rb db/schema.rb
+git commit -m "vm-50: Backfill slugs for existing players"
+```
+
+---
+
+### Task 3: Migration — make slug NOT NULL
+
+**Files:**
+- Create: `db/migrate/20260412000003_make_player_slug_not_null.rb`
+
+- [ ] **Step 1: Create the NOT NULL migration**
+
+```ruby
+class MakePlayerSlugNotNull < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :players, :slug, false
+  end
+end
+```
+
+- [ ] **Step 2: Run the migration**
+
+Run: `bin/rails db:migrate`
+Expected: `schema.rb` shows `t.string "slug", null: false` for players.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add db/migrate/*_make_player_slug_not_null.rb db/schema.rb
+git commit -m "vm-50: Make player slug NOT NULL"
+```
+
+---
+
+### Task 4: Player model — include Sluggable concern
+
+**Files:**
+- Modify: `app/models/player.rb`
+- Test: `spec/models/player_spec.rb`
+- Modify: `spec/factories/players.rb`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `spec/models/player_spec.rb` inside the top-level `RSpec.describe Player`:
+
+```ruby
+describe "slug" do
+  describe "generation" do
+    it "generates a slug from name on create" do
+      player = create(:player, name: "Алексей")
+      expect(player.slug).to eq("aleksey")
+    end
+
+    it "generates an ASCII slug from Latin name" do
+      player = create(:player, name: "John Doe")
+      expect(player.slug).to eq("john-doe")
+    end
+
+    it "appends hex tail on collision" do
+      create(:player, name: "Алексей")
+      duplicate = create(:player, name: "Алексей Другой")
+      duplicate.update_column(:slug, nil)
+      duplicate.update_column(:name, "Алексей")
+
+      # Force regeneration by clearing slug and re-validating
+      duplicate.slug = nil
+      duplicate.valid?
+      expect(duplicate.slug).to start_with("aleksey-")
+      expect(duplicate.slug).not_to eq("aleksey")
+    end
+
+    it "does not change slug when name is updated" do
+      player = create(:player, name: "Алексей")
+      original_slug = player.slug
+      player.update!(name: "Борис")
+      expect(player.slug).to eq(original_slug)
+    end
+  end
+
+  describe "#to_param" do
+    it "returns the slug" do
+      player = create(:player, name: "Алексей")
+      expect(player.to_param).to eq(player.slug)
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bundle exec rspec spec/models/player_spec.rb --tag slug -f doc`
+Expected: FAIL — Player does not include Sluggable yet.
+
+- [ ] **Step 3: Update the Player model**
+
+Add `include Sluggable` and `slug_source :name` to `app/models/player.rb`:
+
+```ruby
+class Player < ApplicationRecord
+  include Sluggable
+  slug_source :name
+
+  has_many :game_participations, dependent: :restrict_with_error
+  # ... rest unchanged
+end
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bundle exec rspec spec/models/player_spec.rb -f doc`
+Expected: all pass.
+
+- [ ] **Step 5: Run rubocop**
+
+Run: `bundle exec rubocop app/models/player.rb spec/models/player_spec.rb`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/models/player.rb spec/models/player_spec.rb
+git commit -m "vm-50: Include Sluggable in Player model with slug_source :name"
+```
+
+---
+
+### Task 5: Route — add `param: :slug` to players resource
+
+**Files:**
+- Modify: `config/routes.rb:49-52`
+
+- [ ] **Step 1: Update routes**
+
+Change lines 49–52 in `config/routes.rb` from:
+
+```ruby
+  resources :players, only: [ :show ] do
+    resource :claim, only: [ :create ], controller: "player_claims"
+    resource :dispute, only: [ :new, :create ], controller: "player_disputes"
+  end
+```
+
+to:
+
+```ruby
+  resources :players, only: [ :show ], param: :slug do
+    resource :claim, only: [ :create ], controller: "player_claims"
+    resource :dispute, only: [ :new, :create ], controller: "player_disputes"
+  end
+```
+
+- [ ] **Step 2: Verify route generation**
+
+Run:
+```bash
+bin/rails routes -g player
+```
+
+Expected: routes show `/players/:slug`, `/players/:player_slug/claim`, `/players/:player_slug/dispute/new`, `/players/:player_slug/dispute`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add config/routes.rb
+git commit -m "vm-50: Add param: :slug to players routes"
+```
+
+---
+
+### Task 6: Controllers and service — look up by slug
+
+**Files:**
+- Modify: `app/controllers/players_controller.rb:3`
+- Modify: `app/services/player_profile_service.rb:7-16`
+- Modify: `app/controllers/player_claims_controller.rb:7`
+- Modify: `app/controllers/player_disputes_controller.rb:7,11`
+
+- [ ] **Step 1: Write failing request spec for 404 on unknown slug**
+
+Add to `spec/requests/players_spec.rb` at the end, inside the top-level describe:
+
+```ruby
+context "when player does not exist" do
+  it "returns 404 for unknown slug" do
+    expect { get player_path(slug: "nonexistent-slug") }
+      .to raise_error(ActiveRecord::RecordNotFound)
+  end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bundle exec rspec spec/requests/players_spec.rb -e "unknown slug"`
+Expected: Might pass or fail depending on current lookup — either way confirms the route works.
+
+- [ ] **Step 3: Update PlayersController**
+
+Change `app/controllers/players_controller.rb` from:
+
+```ruby
+result = PlayerProfileService.call(player_id: params[:id])
+```
+
+to:
+
+```ruby
+result = PlayerProfileService.call(player_slug: params[:slug])
+```
+
+- [ ] **Step 4: Update PlayerProfileService**
+
+Change `app/services/player_profile_service.rb`:
+
+Replace the `self.call` method, `initialize`, and `Player.find` lookup:
+
+```ruby
+def self.call(player_slug:)
+  new(player_slug).call
+end
+
+def initialize(player_slug)
+  @player_slug = player_slug
+end
+
+def call
+  player = Player.find_by!(slug: @player_slug)
+  # ... rest unchanged
+end
+```
+
+- [ ] **Step 5: Update PlayerClaimsController**
+
+Change `app/controllers/player_claims_controller.rb:7` from:
+
+```ruby
+player = Player.find(params[:player_id])
+```
+
+to:
+
+```ruby
+player = Player.find_by!(slug: params[:player_slug])
+```
+
+- [ ] **Step 6: Update PlayerDisputesController**
+
+Change `app/controllers/player_disputes_controller.rb:7` and `:11` from:
+
+```ruby
+@player = Player.find(params[:player_id])
+```
+
+to:
+
+```ruby
+@player = Player.find_by!(slug: params[:player_slug])
+```
+
+(Both `new` and `create` actions.)
+
+- [ ] **Step 7: Run all player-related request specs**
+
+Run:
+```bash
+bundle exec rspec spec/requests/players_spec.rb spec/requests/player_claims_spec.rb spec/requests/player_disputes_spec.rb -f doc
+```
+
+Expected: All pass. The specs already use `player_path(player)`, and `to_param` now returns the slug, so route helpers automatically generate `/players/:slug`. The controllers now look up by slug.
+
+- [ ] **Step 8: Run rubocop**
+
+Run:
+```bash
+bundle exec rubocop app/controllers/players_controller.rb app/controllers/player_claims_controller.rb app/controllers/player_disputes_controller.rb app/services/player_profile_service.rb
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add app/controllers/players_controller.rb app/controllers/player_claims_controller.rb app/controllers/player_disputes_controller.rb app/services/player_profile_service.rb spec/requests/players_spec.rb
+git commit -m "vm-50: Look up players by slug in controllers and service"
+```
+
+---
+
+### Task 7: AutolinkPlayersInNewsService — emit slug-based URLs
+
+**Files:**
+- Modify: `app/services/autolink_players_in_news_service.rb:50-53,101-103`
+- Test: `spec/services/autolink_players_in_news_service_spec.rb`
+
+- [ ] **Step 1: Update the failing spec expectations**
+
+The spec at `spec/services/autolink_players_in_news_service_spec.rb` has ~30 hardcoded `/players/#{alex.id}` references. These all need to change to `/players/#{alex.slug}` (and similarly for `alex_smith`, `ivan`, etc.).
+
+Replace all occurrences of `"/players/#{alex.id}"` with `"/players/#{alex.slug}"` throughout the spec.
+Replace all occurrences of `"/players/#{alex_smith.id}"` with `"/players/#{alex_smith.slug}"`.
+Replace all occurrences of `"/players/#{ivan.id}"` with `"/players/#{ivan.slug}"`.
+
+Also update the dynamic player references:
+- Line 153: `"/players/#{dotted.id}"` → `"/players/#{dotted.slug}"`
+- Line 154: same
+- Line 183–184: `"/players/#{pot.id}"` → `"/players/#{pot.slug}"`
+- Line 191–192: same
+- Line 199–200: `"/players/#{team.id}"` → `"/players/#{team.slug}"`
+- Line 207–208: same
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bundle exec rspec spec/services/autolink_players_in_news_service_spec.rb`
+Expected: FAIL — the service still generates `/players/#{id}`.
+
+- [ ] **Step 3: Update `players_by_length_desc` to pluck slug**
+
+Change `app/services/autolink_players_in_news_service.rb:50-53` from:
+
+```ruby
+def players_by_length_desc
+  Player.pluck(:id, :name)
+        .sort_by { |_id, name| -name.length }
+        .map { |id, name| [ id, PlayerNameRegex.build(name) ] }
+end
+```
+
+to:
+
+```ruby
+def players_by_length_desc
+  Player.pluck(:id, :name, :slug)
+        .sort_by { |_id, name, _slug| -name.length }
+        .map { |id, name, slug| [ id, slug, PlayerNameRegex.build(name) ] }
+end
+```
+
+- [ ] **Step 4: Update callers to pass slug through the pipeline**
+
+The pipeline passes `(id, regex)` tuples. Now it passes `(id, slug, regex)` tuples. Update all destructuring:
+
+In `collect_matches` (line 66), change:
+
+```ruby
+raw = players.filter_map do |id, regex|
+  next if linked_ids.include?(id)
+
+  match = regex.match(text)
+  next unless match
+
+  [ match.begin(0), match.end(0), id, match[0] ]
+end
+```
+
+to:
+
+```ruby
+raw = players.filter_map do |id, slug, regex|
+  next if linked_ids.include?(id)
+
+  match = regex.match(text)
+  next unless match
+
+  [ match.begin(0), match.end(0), id, slug, match[0] ]
+end
+```
+
+In `drop_overlaps` (line 77), update destructuring:
+
+```ruby
+matches.each do |match|
+  start, finish, _id, _slug, _matched = match
+  next if start < last_end
+
+  result << match
+  last_end = finish
+end
+```
+
+In `link_matches_in_node` (line 56), update destructuring:
+
+```ruby
+matches.each { |_start, _finish, id, _slug, _matched| linked_ids << id }
+```
+
+In `replace_node_with_matches` (line 92), update destructuring:
+
+```ruby
+cursor = matches.reduce(0) do |pos, (start, finish, _id, slug, matched)|
+  text_node.add_previous_sibling(doc.create_text_node(text[pos...start]))
+  text_node.add_previous_sibling(build_anchor(doc, slug, matched))
+  finish
+end
+```
+
+In `build_anchor` (line 101), change the parameter and URL:
+
+```ruby
+def build_anchor(doc, slug, matched)
+  anchor = Nokogiri::XML::Node.new("a", doc)
+  anchor["href"] = "/players/#{slug}"
+  anchor.add_child(doc.create_text_node(matched))
+  anchor
+end
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `bundle exec rspec spec/services/autolink_players_in_news_service_spec.rb -f doc`
+Expected: All pass.
+
+- [ ] **Step 6: Run rubocop**
+
+Run: `bundle exec rubocop app/services/autolink_players_in_news_service.rb spec/services/autolink_players_in_news_service_spec.rb`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/services/autolink_players_in_news_service.rb spec/services/autolink_players_in_news_service_spec.rb
+git commit -m "vm-50: AutolinkPlayersInNewsService emits slug-based URLs"
+```
+
+---
+
+### Task 8: Full test suite + mutation testing
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `bundle exec rspec`
+Expected: All green.
+
+- [ ] **Step 2: Run evilution on Player model**
+
+Run: `bundle exec evilution run app/models/player.rb`
+Expected: high kill score. Fix any surviving mutants.
+
+- [ ] **Step 3: Run evilution on AutolinkPlayersInNewsService**
+
+Run: `bundle exec evilution run app/services/autolink_players_in_news_service.rb`
+Expected: high kill score. Fix any surviving mutants.
+
+- [ ] **Step 4: Run mutant on Player**
+
+Run: `bundle exec mutant run --jobs 1 -- 'Player'`
+Expected: high kill score.
+
+- [ ] **Step 5: Run mutant on AutolinkPlayersInNewsService**
+
+Run: `bundle exec mutant run --jobs 1 -- 'AutolinkPlayersInNewsService'`
+Expected: high kill score.
+
+- [ ] **Step 6: Run mutant on PlayerProfileService**
+
+Run: `bundle exec mutant run --jobs 1 -- 'PlayerProfileService'`
+Expected: high kill score.
+
+- [ ] **Step 7: Commit any mutation-killing test fixes**
+
+```bash
+git add -A
+git commit -m "vm-50: Fix surviving mutants in player slug implementation"
+```
+
+---
+
+### Task 9: Importer re-run verification
+
+**Files:** None (manual verification)
+
+- [ ] **Step 1: Verify import rake task is compatible**
+
+The importer at `lib/tasks/import.rake:220` uses `Player.find_or_initialize_by(id:)` then `player.save!`. Since `Sluggable` auto-generates a slug when `slug.blank?`, new players will get slugs automatically. Re-runs are idempotent because `should_generate_slug?` returns `false` when slug is already present.
+
+Run against the test/dev database to confirm no errors:
+```bash
+bin/rails runner "p = Player.find_or_initialize_by(id: 99999); p.name = 'Test Import'; p.save!; puts p.slug; p.destroy!"
+```
+
+Expected: creates player with auto-generated slug, then cleans up.

--- a/docs/superpowers/specs/2026-04-11-public-url-slugs-design.md
+++ b/docs/superpowers/specs/2026-04-11-public-url-slugs-design.md
@@ -1,0 +1,235 @@
+# Public URL Slugs — Design Spec
+
+**Epic:** vm-49 (gh-703) — Replace numeric IDs with slugs in public URLs
+**Date:** 2026-04-11
+**Status:** Approved
+
+## Goal
+
+Replace database record IDs with human-readable slugs in all public-facing URLs for players, games, news, podcast episodes, and podcast playlists. Competitions and help pages already use slugs. Admin routes are out of scope and keep numeric IDs.
+
+Hard cutover: no redirects from legacy numeric URLs. Old links will 404 after the rollout.
+
+## Architecture
+
+Two shared pieces of infrastructure built once, then each of the five affected entities applies them via a thin per-model task.
+
+### Shared infrastructure (vm-t11)
+
+**`CyrillicTransliterator`** — PORO in `app/services/cyrillic_transliterator.rb`. Single class method `.call(string)` returning an ASCII string via a lookup table covering all Russian letters (upper and lower case). Non-Cyrillic characters pass through unchanged. Empty or whitespace-only input returns an empty string.
+
+```ruby
+class CyrillicTransliterator
+  TABLE = {
+    "а"=>"a","б"=>"b","в"=>"v","г"=>"g","д"=>"d","е"=>"e","ё"=>"yo",
+    "ж"=>"zh","з"=>"z","и"=>"i","й"=>"y","к"=>"k","л"=>"l","м"=>"m",
+    "н"=>"n","о"=>"o","п"=>"p","р"=>"r","с"=>"s","т"=>"t","у"=>"u",
+    "ф"=>"f","х"=>"kh","ц"=>"ts","ч"=>"ch","ш"=>"sh","щ"=>"shch",
+    "ъ"=>"","ы"=>"y","ь"=>"","э"=>"e","ю"=>"yu","я"=>"ya"
+  }.freeze
+
+  def self.call(string)
+    string.to_s.each_char.map { |c| TABLE[c.downcase] || c }.join
+  end
+end
+```
+
+**`Sluggable` concern** — in `app/models/concerns/sluggable.rb`. Models include it and declare the source attribute. Provides slug generation, `to_param` override, and validation.
+
+```ruby
+module Sluggable
+  extend ActiveSupport::Concern
+
+  TAIL_BYTES = 2  # -> 4 hex characters
+
+  class_methods do
+    attr_reader :slug_source_attribute, :slug_source_condition
+
+    def slug_source(attribute, if: nil)
+      @slug_source_attribute = attribute
+      @slug_source_condition = binding.local_variable_get(:if)
+    end
+  end
+
+  included do
+    validates :slug, presence: true, uniqueness: true
+    before_validation :generate_slug, if: :should_generate_slug?
+  end
+
+  def to_param
+    slug
+  end
+
+  private
+
+  def should_generate_slug?
+    return false if slug.present?
+
+    condition = self.class.slug_source_condition
+    condition.nil? || instance_exec(&condition)
+  end
+
+  def generate_slug
+    base = slug_base
+    candidate = base
+    while self.class.where.not(id: id).exists?(slug: candidate)
+      candidate = "#{base}-#{SecureRandom.hex(Sluggable::TAIL_BYTES)}"
+    end
+    self.slug = candidate
+  end
+
+  def slug_base
+    raw = public_send(self.class.slug_source_attribute).to_s
+    CyrillicTransliterator.call(raw).parameterize.presence ||
+      SecureRandom.hex(Sluggable::TAIL_BYTES)
+  end
+end
+```
+
+Design notes:
+- **Freeze after create:** `should_generate_slug?` returns false once a slug exists, so editing the source attribute later does not change the URL.
+- **Pre-save uniqueness:** the `exists?` loop guarantees a free slug before validation. The `validates :slug, uniqueness: true` call is a belt-and-suspenders check. The unique database index is the final backstop for true races.
+- **No Rails internals overridden:** no monkey-patch of `save`/`create_or_update`. True concurrent races (vanishingly rare here — creation is single-threaded via importer or admin forms) raise `ActiveRecord::RecordNotUnique` from the index, which callers handle as a normal error.
+- **Extensible via override:** subclasses can override the private `slug_base` method to customise the generation logic (News uses this for the date prefix).
+- **Defensive fallback:** if transliteration yields an empty string (e.g., blank title), slug falls back to a random hex tail so the record is still valid.
+
+### Per-entity implementation (vm-50 .. vm-54)
+
+Each per-entity task follows the same six-step recipe:
+
+1. **Migration A** — add `slug:string` column (nullable), add unique index on `slug`
+2. **Data migration** — backfill slugs for existing records using the Sluggable machinery (`find_each` + `save!`)
+3. **Migration B** — flip `slug` to `NOT NULL` (News is the exception: stays nullable)
+4. **Model change** — `include Sluggable` + `slug_source :attr` declaration
+5. **Route change** — add `param: :slug` to the resource
+6. **Controller change** — look up by `find_by!(slug:)` instead of `find`
+7. **Call-site audit** — grep for hardcoded `/<entity>/#{id}` URLs and update (notably the autolink service for players)
+
+## Per-entity specifics
+
+### Players (vm-50)
+
+- `slug_source :nickname`
+- Cyrillic nicknames are transliterated. Collisions between players with the same transliterated nickname get a 4-hex-character tail (e.g., `ivan-petrov-a3f2`).
+- Public routes: `resources :players, only: [:show], param: :slug` and nested `resource :claim` / `resource :dispute`.
+- Controllers to update: `PlayersController#show`, `PlayerClaimsController#create`, `PlayerDisputesController#new`, `PlayerDisputesController#create`.
+- **Known call site:** `AutolinkPlayersInNewsService` builds anchors with `href="/players/#{id}"` and must be updated to use the slug.
+- **Importer:** phase 2 of `rake import:scrape` creates players via `Player.find_or_initialize_by(id:)` inside a wrapping transaction. Sluggable's auto-generation covers this on first run; re-runs are idempotent because generation is gated on `slug.blank?`. Acceptance criterion: re-running `rake import:scrape` against a seeded DB must succeed without errors.
+
+### Games (vm-51)
+
+- Slug is purely numeric: `season-<season>-game-<game_number>`. No transliteration needed, but the model still uses Sluggable for uniformity.
+- Because Game doesn't have a single source attribute that yields the desired format, the model either overrides `slug_base` or defines a `slug_source_text` method and declares `slug_source :slug_source_text`. The spec prefers the latter — less machinery, easier to test.
+- Public routes: `resources :games, only: [:show], param: :slug` including the `:overlay` member route.
+- Controllers: `GamesController#show`, `GamesController#overlay`.
+- **Importer:** same idempotency requirement as Players.
+
+### News (vm-52)
+
+Most complex of the five. News has draft and published states (`status` enum with `published_at` timestamp).
+
+- **Date-prefixed slug:** `YYYY-MM-DD-<transliterated title>`, e.g., `2026-04-11-alex-scored-hat-trick`.
+- **Generation gated on publish:** drafts have no slug. Slug is generated at the moment `published_at` becomes present (typically on first publish).
+- **Frozen after generation:** editing the title of a published article does not change the URL.
+- **Nullable slug column:** News does NOT add a NOT NULL constraint, because drafts legitimately have no slug. Public `NewsController#show` already filters to visible (published) news, so `News.visible.find_by!(slug: params[:slug])` is naturally safe.
+- **Backfill:** data migration backfills published articles only. Drafts keep `slug = NULL`.
+
+Model code:
+
+```ruby
+class News < ApplicationRecord
+  include Sluggable
+  slug_source :title, if: -> { published_at.present? }
+
+  # ...
+
+  private
+
+  def slug_base
+    date_prefix = published_at.to_date.iso8601
+    raw_title = CyrillicTransliterator.call(title.to_s).parameterize.presence || "news"
+    "#{date_prefix}-#{raw_title}"
+  end
+end
+```
+
+- Public route: `resources :news, only: [:index, :show], param: :slug`.
+- Admin routes (`/admin/news/:id`) keep numeric IDs — out of scope.
+
+### Podcast::Episode (vm-53)
+
+- `slug_source :title`, plain transliterated title, frozen on create.
+- Public routes under `namespace :podcast`: `resources :episodes, param: :slug` including nested `resource :position` and `resource :audio`.
+- Controllers: `Podcast::EpisodesController#show`, `Podcast::PlaybackPositionsController`, `Podcast::AudioController`.
+- **RSS feed investigation:** `Podcast::FeedController` generates the podcast XML feed. Before rolling out, check whether episode GUIDs in the feed are derived from URLs. If they are, switching episode URLs will appear as new episodes to existing podcast subscribers, breaking their playback history. If GUIDs are DB-ID-based (stable), it's a non-issue. This investigation happens as part of vm-53 and its finding is documented in the PR description. If breakage is expected, it must be coordinated with listeners before rollout.
+
+### Podcast::Playlist (vm-54)
+
+- `slug_source :title`, plain transliterated title, frozen on create.
+- Public route: `resources :playlists, param: :slug` under `namespace :podcast`.
+- Controller: `Podcast::PlaylistsController#show`.
+
+## Testing
+
+### vm-t11 (shared infrastructure)
+
+**`CyrillicTransliterator`:**
+- All 33 Russian letters (upper and lower case)
+- Mixed Cyrillic/Latin input
+- Non-Cyrillic passthrough (Latin, digits, punctuation, whitespace)
+- Empty string
+- Multi-character mappings (ё, ж, х, ц, ч, ш, щ, ю, я)
+- Soft/hard sign (ъ, ь) erasure
+
+**`Sluggable` concern:** tested via an anonymous test model created in the spec with `ActiveRecord::Base.connection.create_table`. Test cases:
+- Sets slug from source attribute on create
+- Transliterates Cyrillic source via `CyrillicTransliterator`
+- Overrides `to_param` to return slug
+- Appends hex tail on collision (seed an existing record with the same base slug)
+- Freezes slug once set (re-save with a modified source attribute does not regenerate)
+- Validation fails when slug ends up blank
+- Respects `if:` condition on `slug_source` — skips generation when condition returns false
+- Fallback to random hex tail when source yields empty after transliteration
+
+### Per-entity tests (vm-50 .. vm-54)
+
+Each entity:
+- Model spec: slug generation, freezing on create, correct source attribute
+- Request spec: hitting `/<entity>/:slug` renders the page, unknown slug returns 404
+- Link-helper spec: `entity_path(record)` returns slug-based path
+- Mutation testing on all new files (evilution + mutant per project convention)
+
+Entity-specific:
+- **Player (vm-50):** integration test that `AutolinkPlayersInNewsService` emits slug-based anchor tags, not `/players/#{id}`. Importer re-run test.
+- **Game (vm-51):** slug format matches `season-N-game-M`. Importer re-run test.
+- **News (vm-52):** draft has no slug; publishing a draft generates the slug with date prefix; editing title after publish does not change slug; direct creation of a published article generates slug immediately.
+- **Podcast::Episode (vm-53):** RSS feed continues to serve episodes with stable GUIDs (after the investigation confirms the behaviour).
+- **Podcast::Playlist (vm-54):** no extra edge cases.
+
+## Rollout order
+
+```
+vm-t11 (shared infra)  ──┬──► vm-50 (Players)
+                         ├──► vm-51 (Games)
+                         ├──► vm-52 (News)
+                         ├──► vm-53 (Podcast Episodes)
+                         └──► vm-54 (Podcast Playlists)
+```
+
+vm-t11 ships first and can merge to master standalone — no routes change, no user-visible effect. After that, vm-50 through vm-54 are independent and can be implemented in any order.
+
+Recommended order by risk/value:
+
+1. **vm-50 (Players)** — highest visibility, validates the end-to-end pipeline including the `AutolinkPlayersInNewsService` call site shipped in vm-80/81
+2. **vm-51 (Games)** — simplest (numeric slug, no transliteration)
+3. **vm-52 (News)** — most complex (date prefix, publish-time generation)
+4. **vm-53 (Podcast Episodes)** — includes RSS feed investigation
+5. **vm-54 (Podcast Playlists)** — simplest content entity
+
+## Out of scope
+
+- Redirects from legacy numeric URLs (hard cutover decided)
+- Admin routes (continue to use numeric IDs)
+- Competitions and help pages (already on slugs)
+- Automatic slug regeneration on source attribute change (frozen by design)
+- Changing the public URL shape (still `/<entity>/:slug`, no nested routes like `/news/:year/:month/:slug`)

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Player, type: :model do
   end
 
   describe 'validations' do
-    subject { build(:player) }
+    subject { create(:player) }
 
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name) }
@@ -242,6 +242,42 @@ RSpec.describe Player, type: :model do
         result = Player.with_stats_for_competition(competition).find(player.id)
 
         expect(result.total_rating).to eq(1.5)
+      end
+    end
+  end
+
+  describe "slug" do
+    describe "generation" do
+      it "generates a slug from Cyrillic name on create" do
+        player = create(:player, name: "Алексей")
+        expect(player.slug).to eq("aleksey")
+      end
+
+      it "generates a slug from Latin name on create" do
+        player = create(:player, name: "John Doe")
+        expect(player.slug).to eq("john-doe")
+      end
+
+      it "appends hex tail on collision" do
+        create(:player, name: "Алексей", slug: "aleksey")
+        collider = build(:player, name: "Алексей")
+        collider.valid?
+        expect(collider.slug).to start_with("aleksey-")
+        expect(collider.slug.length).to eq("aleksey-".length + 4)
+      end
+
+      it "does not change slug when name is updated" do
+        player = create(:player, name: "Алексей")
+        original_slug = player.slug
+        player.update!(name: "Борис")
+        expect(player.slug).to eq(original_slug)
+      end
+    end
+
+    describe "#to_param" do
+      it "returns the slug" do
+        player = create(:player, name: "Алексей Петров")
+        expect(player.to_param).to eq("aleksey-petrov")
       end
     end
   end

--- a/spec/requests/players_spec.rb
+++ b/spec/requests/players_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe PlayersController do
     end
 
     context "when player does not exist" do
-      before { get player_path(id: -1) }
+      before { get player_path(slug: "nonexistent-slug") }
 
       it "returns not found" do
         expect(response).to have_http_status(:not_found)

--- a/spec/services/autolink_players_in_news_service_spec.rb
+++ b/spec/services/autolink_players_in_news_service_spec.rb
@@ -36,13 +36,13 @@ RSpec.describe AutolinkPlayersInNewsService do
 
     it "wraps a single player mention in a link to the profile" do
       news = build_news("<div>Alex scored a goal</div>")
-      expect(rewritten_html(news)).to include(%(<a href="/players/#{alex.id}">Alex</a>))
+      expect(rewritten_html(news)).to include(%(<a href="/players/#{alex.slug}">Alex</a>))
     end
 
     it "links only the first occurrence of a player name" do
       news = build_news("<div>Alex passed to Alex again</div>")
       html = rewritten_html(news)
-      expect(html.scan(%r{<a href="/players/#{alex.id}">Alex</a>}).size).to eq(1)
+      expect(html.scan(%r{<a href="/players/#{alex.slug}">Alex</a>}).size).to eq(1)
       expect(html).to include("to Alex again")
     end
 
@@ -50,72 +50,72 @@ RSpec.describe AutolinkPlayersInNewsService do
       news = build_news("<div>Alex passed to Иван</div>")
       html = rewritten_html(news)
       expect(html).to include(
-        %(<a href="/players/#{alex.id}">Alex</a> passed to <a href="/players/#{ivan.id}">Иван</a>)
+        %(<a href="/players/#{alex.slug}">Alex</a> passed to <a href="/players/#{ivan.slug}">Иван</a>)
       )
     end
 
     it "preserves text that appears before the first match" do
       news = build_news("<div>Hello Alex world</div>")
-      expect(rewritten_html(news)).to include(%(Hello <a href="/players/#{alex.id}">Alex</a> world))
+      expect(rewritten_html(news)).to include(%(Hello <a href="/players/#{alex.slug}">Alex</a> world))
     end
 
     it "links matches regardless of the order they appear in the text" do
       news = build_news("<div>Иван then Alex</div>")
       html = rewritten_html(news)
       expect(html).to include(
-        %(<a href="/players/#{ivan.id}">Иван</a> then <a href="/players/#{alex.id}">Alex</a>)
+        %(<a href="/players/#{ivan.slug}">Иван</a> then <a href="/players/#{alex.slug}">Alex</a>)
       )
     end
 
     it "links the first occurrence across separate elements" do
       news = build_news("<div><p>Alex scored</p><p>Alex passed again</p></div>")
       html = rewritten_html(news)
-      expect(html.scan(%r{<a href="/players/#{alex.id}">Alex</a>}).size).to eq(1)
+      expect(html.scan(%r{<a href="/players/#{alex.slug}">Alex</a>}).size).to eq(1)
       expect(html).to include("Alex passed again")
     end
 
     it "keeps a non-overlapping later match when an earlier overlap is dropped" do
       news = build_news("<div>Alex Smith passed to Иван</div>")
       html = rewritten_html(news)
-      expect(html).to include(%(<a href="/players/#{alex_smith.id}">Alex Smith</a>))
-      expect(html).to include(%(<a href="/players/#{ivan.id}">Иван</a>))
-      expect(html).not_to include(%(<a href="/players/#{alex.id}">))
+      expect(html).to include(%(<a href="/players/#{alex_smith.slug}">Alex Smith</a>))
+      expect(html).to include(%(<a href="/players/#{ivan.slug}">Иван</a>))
+      expect(html).not_to include(%(<a href="/players/#{alex.slug}">))
     end
 
     it "matches case-insensitively and preserves original casing" do
       news = build_news("<div>ALEX and alex play together</div>")
       html = rewritten_html(news)
-      expect(html).to include(%(<a href="/players/#{alex.id}">ALEX</a>))
+      expect(html).to include(%(<a href="/players/#{alex.slug}">ALEX</a>))
       expect(html).to include("and alex play")
     end
 
     it "does not match a name that is a substring of a longer word" do
       news = build_news("<div>Alexander scored</div>")
-      expect(rewritten_html(news)).not_to include(%(<a href="/players/#{alex.id}">))
+      expect(rewritten_html(news)).not_to include(%(<a href="/players/#{alex.slug}">))
     end
 
     it "does not match a name preceded by a letter" do
       news = build_news("<div>xxAlex scored</div>")
-      expect(rewritten_html(news)).not_to include(%(<a href="/players/#{alex.id}">))
+      expect(rewritten_html(news)).not_to include(%(<a href="/players/#{alex.slug}">))
     end
 
     it "does not match Cyrillic name inside a longer word" do
       news = build_news("<div>Иванов забил гол</div>")
-      expect(rewritten_html(news)).not_to include(%(<a href="/players/#{ivan.id}">))
+      expect(rewritten_html(news)).not_to include(%(<a href="/players/#{ivan.slug}">))
     end
 
     it "prefers the longer player name when names overlap" do
       news = build_news("<div>Alex Smith played well</div>")
       html = rewritten_html(news)
-      expect(html).to include(%(<a href="/players/#{alex_smith.id}">Alex Smith</a>))
-      expect(html).not_to include(%(<a href="/players/#{alex.id}">Alex</a>))
+      expect(html).to include(%(<a href="/players/#{alex_smith.slug}">Alex Smith</a>))
+      expect(html).not_to include(%(<a href="/players/#{alex.slug}">Alex</a>))
     end
 
     it "skips text already inside an anchor tag" do
       news = build_news(%(<div><a href="/other">Alex</a> scored</div>))
       html = rewritten_html(news)
       expect(html).to include(%(<a href="/other">Alex</a>))
-      expect(html).not_to include(%(<a href="/players/#{alex.id}">))
+      expect(html).not_to include(%(<a href="/players/#{alex.slug}">))
     end
 
     it "leaves content unchanged when no players are mentioned" do
@@ -126,7 +126,7 @@ RSpec.describe AutolinkPlayersInNewsService do
     end
 
     it "does nothing when there are no players in the database" do
-      allow(Player).to receive(:pluck).with(:id, :name).and_return([])
+      allow(Player).to receive(:pluck).with(:id, :name, :slug).and_return([])
       news = build_news("<div>Alex scored</div>")
       expect(news).not_to receive(:update!)
       described_class.call(news)
@@ -135,23 +135,23 @@ RSpec.describe AutolinkPlayersInNewsService do
     it "processes text nodes in sibling elements after one element" do
       news = build_news("<div><p>Alex</p><p>Иван</p></div>")
       html = rewritten_html(news)
-      expect(html).to include(%(<a href="/players/#{alex.id}">Alex</a>))
-      expect(html).to include(%(<a href="/players/#{ivan.id}">Иван</a>))
+      expect(html).to include(%(<a href="/players/#{alex.slug}">Alex</a>))
+      expect(html).to include(%(<a href="/players/#{ivan.slug}">Иван</a>))
     end
 
     it "processes text after an existing anchor" do
       news = build_news(%(<div><a href="/other">Link</a> and Иван</div>))
       html = rewritten_html(news)
       expect(html).to include(%(<a href="/other">Link</a>))
-      expect(html).to include(%(<a href="/players/#{ivan.id}">Иван</a>))
+      expect(html).to include(%(<a href="/players/#{ivan.slug}">Иван</a>))
     end
 
     it "escapes regex metacharacters in player names" do
       dotted = create(:player, name: "A.B")
       news = build_news("<div>AXB did not score, A.B did</div>")
       html = rewritten_html(news)
-      expect(html).to include(%(<a href="/players/#{dotted.id}">A.B</a>))
-      expect(html).not_to include(%(<a href="/players/#{dotted.id}">AXB</a>))
+      expect(html).to include(%(<a href="/players/#{dotted.slug}">A.B</a>))
+      expect(html).not_to include(%(<a href="/players/#{dotted.slug}">AXB</a>))
     end
 
     it "replaces the original text node rather than duplicating it" do
@@ -164,24 +164,24 @@ RSpec.describe AutolinkPlayersInNewsService do
     context "Russian morphology" do
       it "links Ивана (genitive) back to Иван preserving the matched form" do
         news = build_news("<div>пас от Ивана был точным</div>")
-        expect(rewritten_html(news)).to include(%(<a href="/players/#{ivan.id}">Ивана</a>))
+        expect(rewritten_html(news)).to include(%(<a href="/players/#{ivan.slug}">Ивана</a>))
       end
 
       it "links Иваном (instrumental)" do
         news = build_news("<div>игра с Иваном удалась</div>")
-        expect(rewritten_html(news)).to include(%(<a href="/players/#{ivan.id}">Иваном</a>))
+        expect(rewritten_html(news)).to include(%(<a href="/players/#{ivan.slug}">Иваном</a>))
       end
 
       it "does not match the surname Иванов" do
         news = build_news("<div>Иванов забил гол</div>")
-        expect(rewritten_html(news)).not_to include(%(<a href="/players/#{ivan.id}">))
+        expect(rewritten_html(news)).not_to include(%(<a href="/players/#{ivan.slug}">))
       end
 
       it "links a multi-word feminine nickname across all cases" do
         pot = create(:player, name: "Свирепая Кастрюля")
         news = build_news("<div>встретил Свирепую Кастрюлю на поле</div>")
         expect(rewritten_html(news)).to include(
-          %(<a href="/players/#{pot.id}">Свирепую Кастрюлю</a>)
+          %(<a href="/players/#{pot.slug}">Свирепую Кастрюлю</a>)
         )
       end
 
@@ -189,7 +189,7 @@ RSpec.describe AutolinkPlayersInNewsService do
         pot = create(:player, name: "Свирепая Кастрюля")
         news = build_news("<div>гол Свирепой Кастрюли был красивым</div>")
         expect(rewritten_html(news)).to include(
-          %(<a href="/players/#{pot.id}">Свирепой Кастрюли</a>)
+          %(<a href="/players/#{pot.slug}">Свирепой Кастрюли</a>)
         )
       end
 
@@ -197,7 +197,7 @@ RSpec.describe AutolinkPlayersInNewsService do
         team = create(:player, name: "Грибочки")
         news = build_news("<div>победа Грибочков была заслуженной</div>")
         expect(rewritten_html(news)).to include(
-          %(<a href="/players/#{team.id}">Грибочков</a>)
+          %(<a href="/players/#{team.slug}">Грибочков</a>)
         )
       end
 
@@ -205,7 +205,7 @@ RSpec.describe AutolinkPlayersInNewsService do
         team = create(:player, name: "Вдохи")
         news = build_news("<div>играли с Вдохами в финале</div>")
         expect(rewritten_html(news)).to include(
-          %(<a href="/players/#{team.id}">Вдохами</a>)
+          %(<a href="/players/#{team.slug}">Вдохами</a>)
         )
       end
     end

--- a/spec/services/player_profile_service_spec.rb
+++ b/spec/services/player_profile_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe PlayerProfileService do
     let_it_be(:award2) { create(:award, title: "Лучший стратег") }
     let_it_be(:player_award1) { create(:player_award, player: player, award: award1, position: 2) }
     let_it_be(:player_award2) { create(:player_award, player: player, award: award2, position: 1) }
-    let(:result) { described_class.call(player_id: player.id) }
+    let(:result) { described_class.call(player_slug: player.slug) }
 
     it "returns a Result" do
       expect(result).to be_a(described_class::Result)
@@ -49,7 +49,7 @@ RSpec.describe PlayerProfileService do
       end
 
       it "groups games from child competitions under their root" do
-        root_result = described_class.call(player_id: root_player.id)
+        root_result = described_class.call(player_slug: root_player.slug)
         expect(root_result.competitions_with_games.size).to eq(1)
         expect(root_result.competitions_with_games.first.competition).to eq(season)
         expect(root_result.competitions_with_games.first.games).to match_array([ root_game1, root_game2 ])
@@ -69,7 +69,7 @@ RSpec.describe PlayerProfileService do
       end
 
       it "orders competitions by started_on descending" do
-        order_result = described_class.call(player_id: order_player.id)
+        order_result = described_class.call(player_slug: order_player.slug)
         competitions = order_result.competitions_with_games.map(&:competition)
         expect(competitions).to eq([ new_comp, old_comp ])
       end
@@ -87,7 +87,7 @@ RSpec.describe PlayerProfileService do
       end
 
       it "orders games by played_on and game_number" do
-        ordering_result = described_class.call(player_id: ordering_player.id)
+        ordering_result = described_class.call(player_slug: ordering_player.slug)
         entry = ordering_result.competitions_with_games.first
         expect(entry.games).to eq([ early_game, late_game ])
       end
@@ -161,7 +161,7 @@ RSpec.describe PlayerProfileService do
         create(:game_participation, game: stats_game3, player: stats_player, role: peace_role, win: false)
       end
 
-      let(:stats) { described_class.call(player_id: stats_player.id).stats }
+      let(:stats) { described_class.call(player_slug: stats_player.slug).stats }
 
       it "returns total games count" do
         expect(stats.total_games).to eq(3)
@@ -192,7 +192,7 @@ RSpec.describe PlayerProfileService do
 
       context "when player has no games" do
         let_it_be(:no_games_player) { create(:player, name: "Новичок") }
-        let(:empty_stats) { described_class.call(player_id: no_games_player.id).stats }
+        let(:empty_stats) { described_class.call(player_slug: no_games_player.slug).stats }
 
         it "returns zero total games" do
           expect(empty_stats.total_games).to eq(0)
@@ -214,7 +214,7 @@ RSpec.describe PlayerProfileService do
 
     context "when player has no games or awards" do
       let_it_be(:lonely_player) { create(:player, name: "Одинокий") }
-      let(:lonely_result) { described_class.call(player_id: lonely_player.id) }
+      let(:lonely_result) { described_class.call(player_slug: lonely_player.slug) }
 
       it "returns empty competitions_with_games" do
         expect(lonely_result.competitions_with_games).to be_empty
@@ -231,7 +231,7 @@ RSpec.describe PlayerProfileService do
 
     context "when player does not exist" do
       it "raises ActiveRecord::RecordNotFound" do
-        expect { described_class.call(player_id: -1) }.to raise_error(ActiveRecord::RecordNotFound)
+        expect { described_class.call(player_slug: "nonexistent") }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end


### PR DESCRIPTION
## Summary

- Add `slug` column to `players` table (nullable → backfill → NOT NULL) with unique index
- Include `Sluggable` concern in Player model with `slug_source :name` — Cyrillic names are transliterated to ASCII slugs
- Update routes to `param: :slug`, controllers and `PlayerProfileService` to look up by slug
- Update `AutolinkPlayersInNewsService` to emit `/players/:slug` URLs instead of `/players/:id`

Closes #704

## Mutation Testing

- **Player**: Evilution 100% (11/11), Mutant 100% (18/18)
- **AutolinkPlayersInNewsService**: Evilution 100%, Mutant 99.46% (557/560 — 3 alive in pre-existing unchanged code)
- **PlayerProfileService**: Evilution 100%, Mutant 87.66% (327/373 — 46 alive in pre-existing unchanged code)

## Test plan

- [x] Full test suite passes (1852 examples, 0 failures)
- [x] Player slug generated from Cyrillic name (`Алексей` → `aleksey`)
- [x] Slug frozen after create — editing name does not change URL
- [x] Collision handling appends hex tail
- [x] `to_param` returns slug, route helpers generate slug-based paths
- [x] All player controllers/services find by slug
- [x] AutolinkPlayersInNewsService emits slug-based anchor hrefs
- [x] Unknown slug returns 404
- [x] Importer compatibility verified (auto-generates slug on new players)
- [x] Mutation testing run on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)