### PR TITLE
705: Add slug to Games for public URLs

### DIFF
--- a/app/avo/resources/game.rb
+++ b/app/avo/resources/game.rb
@@ -1,6 +1,9 @@
 class Avo::Resources::Game < Avo::BaseResource
   self.title = :full_name
   self.default_view_type = :table
+  self.find_record_method = -> {
+    query.find_by(slug: id) || query.find(id)
+  }
 
   self.search = {
     query: -> { query.where("name ILIKE ?", "%#{params[:q]}%") }

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,11 +1,11 @@
 class GamesController < ApplicationController
   def show
-    @game = Game.includes(competition: :parent).find(params[:id])
+    @game = Game.includes(competition: :parent).find_by!(slug: params[:slug])
     @participations = @game.game_participations.includes(:player, :role).order(Arel.sql("seat IS NULL"), seat: :asc, id: :asc)
   end
 
   def overlay
-    @game = Game.find(params[:id])
+    @game = Game.find_by!(slug: params[:slug])
     @participations_by_seat = @game.game_participations.includes(:player, :role).index_by(&:seat)
     @overlay_config = build_overlay_config
     render layout: "overlay"

--- a/app/controllers/judge/protocols_controller.rb
+++ b/app/controllers/judge/protocols_controller.rb
@@ -91,7 +91,7 @@ class Judge::ProtocolsController < ApplicationController
   end
 
   def set_game
-    @game = Game.find(params[:id])
+    @game = Game.find_by!(slug: params[:id])
   end
 
   def load_form_data

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,4 +1,7 @@
 class Game < ApplicationRecord
+  include Sluggable
+  slug_source :game_number
+
   RESULTS = {
     in_progress: "in_progress",
     peace_victory: "peace_victory",
@@ -28,5 +31,13 @@ class Game < ApplicationRecord
 
   def in_season_name
     "#{competition.name} #{I18n.t('common.game')} #{game_number}"
+  end
+
+  private
+
+  def slug_base
+    return SecureRandom.hex(Sluggable::TAIL_BYTES) unless competition
+
+    "#{competition.slug}-game-#{game_number}"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,7 @@ Rails.application.routes.draw do
   get "seasons/:season_number/series/:number", to: "legacy_redirects#series", as: :season_series
 
   resources :news, only: [ :index, :show ]
-  resources :games, only: [ :show ] do
+  resources :games, only: [ :show ], param: :slug do
     member do
       get :overlay
     end

--- a/db/migrate/20260412150543_add_slug_to_games.rb
+++ b/db/migrate/20260412150543_add_slug_to_games.rb
@@ -1,0 +1,6 @@
+class AddSlugToGames < ActiveRecord::Migration[8.1]
+  def change
+    add_column :games, :slug, :string
+    add_index :games, :slug, unique: true
+  end
+end

--- a/db/migrate/20260412150544_backfill_game_slugs.rb
+++ b/db/migrate/20260412150544_backfill_game_slugs.rb
@@ -1,0 +1,42 @@
+class BackfillGameSlugs < ActiveRecord::Migration[8.1]
+  TAIL_BYTES = 2
+  MAX_ATTEMPTS = 10
+
+  class MigrationGame < ActiveRecord::Base
+    self.table_name = "games"
+  end
+
+  class MigrationCompetition < ActiveRecord::Base
+    self.table_name = "competitions"
+  end
+
+  def up
+    MigrationGame.where(slug: nil).find_each do |game|
+      competition = MigrationCompetition.find(game.competition_id)
+      game.update_column(:slug, unique_slug_for(game, competition))
+    end
+  end
+
+  def down
+    MigrationGame.update_all(slug: nil)
+  end
+
+  private
+
+  def base_slug_for(game, competition)
+    "#{competition.slug}-game-#{game.game_number}"
+  end
+
+  def unique_slug_for(game, competition)
+    base = base_slug_for(game, competition)
+    candidate = base
+
+    MAX_ATTEMPTS.times do
+      return candidate unless MigrationGame.where.not(id: game.id).exists?(slug: candidate)
+
+      candidate = "#{base}-#{SecureRandom.hex(TAIL_BYTES)}"
+    end
+
+    raise "Unable to generate unique slug for Game ##{game.id} after #{MAX_ATTEMPTS} attempts"
+  end
+end

--- a/db/migrate/20260412150544_backfill_game_slugs.rb
+++ b/db/migrate/20260412150544_backfill_game_slugs.rb
@@ -11,9 +11,14 @@ class BackfillGameSlugs < ActiveRecord::Migration[8.1]
   end
 
   def up
-    MigrationGame.where(slug: nil).find_each do |game|
-      competition = MigrationCompetition.find(game.competition_id)
-      game.update_column(:slug, unique_slug_for(game, competition))
+    MigrationGame.where(slug: nil).in_batches do |batch|
+      competition_ids = batch.pluck(:competition_id).uniq
+      competitions_by_id = MigrationCompetition.where(id: competition_ids).index_by(&:id)
+
+      batch.each do |game|
+        competition = competitions_by_id.fetch(game.competition_id)
+        game.update_column(:slug, unique_slug_for(game, competition))
+      end
     end
   end
 

--- a/db/migrate/20260412150545_make_game_slug_not_null.rb
+++ b/db/migrate/20260412150545_make_game_slug_not_null.rb
@@ -1,0 +1,5 @@
+class MakeGameSlugNotNull < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :games, :slug, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_12_150544) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_12_150545) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -144,7 +144,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_150544) do
     t.string "name"
     t.date "played_on"
     t.string "result", default: "in_progress", null: false
-    t.string "slug"
+    t.string "slug", null: false
     t.datetime "updated_at", null: false
     t.index ["competition_id", "game_number"], name: "index_games_on_competition_id_and_game_number", unique: true
     t.index ["competition_id"], name: "index_games_on_competition_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_12_134330) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_12_150543) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -144,10 +144,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_134330) do
     t.string "name"
     t.date "played_on"
     t.string "result", default: "in_progress", null: false
+    t.string "slug"
     t.datetime "updated_at", null: false
     t.index ["competition_id", "game_number"], name: "index_games_on_competition_id_and_game_number", unique: true
     t.index ["competition_id"], name: "index_games_on_competition_id"
     t.index ["played_on", "game_number"], name: "index_games_on_played_on_and_game_number"
+    t.index ["slug"], name: "index_games_on_slug", unique: true
   end
 
   create_table "grants", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_12_150543) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_12_150544) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false

--- a/docs/superpowers/specs/2026-04-11-public-url-slugs-design.md
+++ b/docs/superpowers/specs/2026-04-11-public-url-slugs-design.md
@@ -1,0 +1,235 @@
+# Public URL Slugs — Design Spec
+
+**Epic:** vm-49 (gh-703) — Replace numeric IDs with slugs in public URLs
+**Date:** 2026-04-11
+**Status:** Approved
+
+## Goal
+
+Replace database record IDs with human-readable slugs in all public-facing URLs for players, games, news, podcast episodes, and podcast playlists. Competitions and help pages already use slugs. Admin routes are out of scope and keep numeric IDs.
+
+Hard cutover: no redirects from legacy numeric URLs. Old links will 404 after the rollout.
+
+## Architecture
+
+Two shared pieces of infrastructure built once, then each of the five affected entities applies them via a thin per-model task.
+
+### Shared infrastructure (vm-t11)
+
+**`CyrillicTransliterator`** — PORO in `app/services/cyrillic_transliterator.rb`. Single class method `.call(string)` returning an ASCII string via a lookup table covering all Russian letters (upper and lower case). Non-Cyrillic characters pass through unchanged. Empty or whitespace-only input returns an empty string.
+
+```ruby
+class CyrillicTransliterator
+  TABLE = {
+    "а"=>"a","б"=>"b","в"=>"v","г"=>"g","д"=>"d","е"=>"e","ё"=>"yo",
+    "ж"=>"zh","з"=>"z","и"=>"i","й"=>"y","к"=>"k","л"=>"l","м"=>"m",
+    "н"=>"n","о"=>"o","п"=>"p","р"=>"r","с"=>"s","т"=>"t","у"=>"u",
+    "ф"=>"f","х"=>"kh","ц"=>"ts","ч"=>"ch","ш"=>"sh","щ"=>"shch",
+    "ъ"=>"","ы"=>"y","ь"=>"","э"=>"e","ю"=>"yu","я"=>"ya"
+  }.freeze
+
+  def self.call(string)
+    string.to_s.each_char.map { |c| TABLE[c.downcase] || c }.join
+  end
+end
+```
+
+**`Sluggable` concern** — in `app/models/concerns/sluggable.rb`. Models include it and declare the source attribute. Provides slug generation, `to_param` override, and validation.
+
+```ruby
+module Sluggable
+  extend ActiveSupport::Concern
+
+  TAIL_BYTES = 2  # -> 4 hex characters
+
+  class_methods do
+    attr_reader :slug_source_attribute, :slug_source_condition
+
+    def slug_source(attribute, if: nil)
+      @slug_source_attribute = attribute
+      @slug_source_condition = binding.local_variable_get(:if)
+    end
+  end
+
+  included do
+    validates :slug, presence: true, uniqueness: true
+    before_validation :generate_slug, if: :should_generate_slug?
+  end
+
+  def to_param
+    slug
+  end
+
+  private
+
+  def should_generate_slug?
+    return false if slug.present?
+
+    condition = self.class.slug_source_condition
+    condition.nil? || instance_exec(&condition)
+  end
+
+  def generate_slug
+    base = slug_base
+    candidate = base
+    while self.class.where.not(id: id).exists?(slug: candidate)
+      candidate = "#{base}-#{SecureRandom.hex(Sluggable::TAIL_BYTES)}"
+    end
+    self.slug = candidate
+  end
+
+  def slug_base
+    raw = public_send(self.class.slug_source_attribute).to_s
+    CyrillicTransliterator.call(raw).parameterize.presence ||
+      SecureRandom.hex(Sluggable::TAIL_BYTES)
+  end
+end
+```
+
+Design notes:
+- **Freeze after create:** `should_generate_slug?` returns false once a slug exists, so editing the source attribute later does not change the URL.
+- **Pre-save uniqueness:** the `exists?` loop guarantees a free slug before validation. The `validates :slug, uniqueness: true` call is a belt-and-suspenders check. The unique database index is the final backstop for true races.
+- **No Rails internals overridden:** no monkey-patch of `save`/`create_or_update`. True concurrent races (vanishingly rare here — creation is single-threaded via importer or admin forms) raise `ActiveRecord::RecordNotUnique` from the index, which callers handle as a normal error.
+- **Extensible via override:** subclasses can override the private `slug_base` method to customise the generation logic (News uses this for the date prefix).
+- **Defensive fallback:** if transliteration yields an empty string (e.g., blank title), slug falls back to a random hex tail so the record is still valid.
+
+### Per-entity implementation (vm-50 .. vm-54)
+
+Each per-entity task follows the same six-step recipe:
+
+1. **Migration A** — add `slug:string` column (nullable), add unique index on `slug`
+2. **Data migration** — backfill slugs for existing records using the Sluggable machinery (`find_each` + `save!`)
+3. **Migration B** — flip `slug` to `NOT NULL` (News is the exception: stays nullable)
+4. **Model change** — `include Sluggable` + `slug_source :attr` declaration
+5. **Route change** — add `param: :slug` to the resource
+6. **Controller change** — look up by `find_by!(slug:)` instead of `find`
+7. **Call-site audit** — grep for hardcoded `/<entity>/#{id}` URLs and update (notably the autolink service for players)
+
+## Per-entity specifics
+
+### Players (vm-50)
+
+- `slug_source :nickname`
+- Cyrillic nicknames are transliterated. Collisions between players with the same transliterated nickname get a 4-hex-character tail (e.g., `ivan-petrov-a3f2`).
+- Public routes: `resources :players, only: [:show], param: :slug` and nested `resource :claim` / `resource :dispute`.
+- Controllers to update: `PlayersController#show`, `PlayerClaimsController#create`, `PlayerDisputesController#new`, `PlayerDisputesController#create`.
+- **Known call site:** `AutolinkPlayersInNewsService` builds anchors with `href="/players/#{id}"` and must be updated to use the slug.
+- **Importer:** phase 2 of `rake import:scrape` creates players via `Player.find_or_initialize_by(id:)` inside a wrapping transaction. Sluggable's auto-generation covers this on first run; re-runs are idempotent because generation is gated on `slug.blank?`. Acceptance criterion: re-running `rake import:scrape` against a seeded DB must succeed without errors.
+
+### Games (vm-51)
+
+- Slug is purely numeric: `season-<season>-game-<game_number>`. No transliteration needed, but the model still uses Sluggable for uniformity.
+- Because Game doesn't have a single source attribute that yields the desired format, the model either overrides `slug_base` or defines a `slug_source_text` method and declares `slug_source :slug_source_text`. The spec prefers the latter — less machinery, easier to test.
+- Public routes: `resources :games, only: [:show], param: :slug` including the `:overlay` member route.
+- Controllers: `GamesController#show`, `GamesController#overlay`.
+- **Importer:** same idempotency requirement as Players.
+
+### News (vm-52)
+
+Most complex of the five. News has draft and published states (`status` enum with `published_at` timestamp).
+
+- **Date-prefixed slug:** `YYYY-MM-DD-<transliterated title>`, e.g., `2026-04-11-alex-scored-hat-trick`.
+- **Generation gated on publish:** drafts have no slug. Slug is generated at the moment `published_at` becomes present (typically on first publish).
+- **Frozen after generation:** editing the title of a published article does not change the URL.
+- **Nullable slug column:** News does NOT add a NOT NULL constraint, because drafts legitimately have no slug. Public `NewsController#show` already filters to visible (published) news, so `News.visible.find_by!(slug: params[:slug])` is naturally safe.
+- **Backfill:** data migration backfills published articles only. Drafts keep `slug = NULL`.
+
+Model code:
+
+```ruby
+class News < ApplicationRecord
+  include Sluggable
+  slug_source :title, if: -> { published_at.present? }
+
+  # ...
+
+  private
+
+  def slug_base
+    date_prefix = published_at.to_date.iso8601
+    raw_title = CyrillicTransliterator.call(title.to_s).parameterize.presence || "news"
+    "#{date_prefix}-#{raw_title}"
+  end
+end
+```
+
+- Public route: `resources :news, only: [:index, :show], param: :slug`.
+- Admin routes (`/admin/news/:id`) keep numeric IDs — out of scope.
+
+### Podcast::Episode (vm-53)
+
+- `slug_source :title`, plain transliterated title, frozen on create.
+- Public routes under `namespace :podcast`: `resources :episodes, param: :slug` including nested `resource :position` and `resource :audio`.
+- Controllers: `Podcast::EpisodesController#show`, `Podcast::PlaybackPositionsController`, `Podcast::AudioController`.
+- **RSS feed investigation:** `Podcast::FeedController` generates the podcast XML feed. Before rolling out, check whether episode GUIDs in the feed are derived from URLs. If they are, switching episode URLs will appear as new episodes to existing podcast subscribers, breaking their playback history. If GUIDs are DB-ID-based (stable), it's a non-issue. This investigation happens as part of vm-53 and its finding is documented in the PR description. If breakage is expected, it must be coordinated with listeners before rollout.
+
+### Podcast::Playlist (vm-54)
+
+- `slug_source :title`, plain transliterated title, frozen on create.
+- Public route: `resources :playlists, param: :slug` under `namespace :podcast`.
+- Controller: `Podcast::PlaylistsController#show`.
+
+## Testing
+
+### vm-t11 (shared infrastructure)
+
+**`CyrillicTransliterator`:**
+- All 33 Russian letters (upper and lower case)
+- Mixed Cyrillic/Latin input
+- Non-Cyrillic passthrough (Latin, digits, punctuation, whitespace)
+- Empty string
+- Multi-character mappings (ё, ж, х, ц, ч, ш, щ, ю, я)
+- Soft/hard sign (ъ, ь) erasure
+
+**`Sluggable` concern:** tested via an anonymous test model created in the spec with `ActiveRecord::Base.connection.create_table`. Test cases:
+- Sets slug from source attribute on create
+- Transliterates Cyrillic source via `CyrillicTransliterator`
+- Overrides `to_param` to return slug
+- Appends hex tail on collision (seed an existing record with the same base slug)
+- Freezes slug once set (re-save with a modified source attribute does not regenerate)
+- Validation fails when slug ends up blank
+- Respects `if:` condition on `slug_source` — skips generation when condition returns false
+- Fallback to random hex tail when source yields empty after transliteration
+
+### Per-entity tests (vm-50 .. vm-54)
+
+Each entity:
+- Model spec: slug generation, freezing on create, correct source attribute
+- Request spec: hitting `/<entity>/:slug` renders the page, unknown slug returns 404
+- Link-helper spec: `entity_path(record)` returns slug-based path
+- Mutation testing on all new files (evilution + mutant per project convention)
+
+Entity-specific:
+- **Player (vm-50):** integration test that `AutolinkPlayersInNewsService` emits slug-based anchor tags, not `/players/#{id}`. Importer re-run test.
+- **Game (vm-51):** slug format matches `season-N-game-M`. Importer re-run test.
+- **News (vm-52):** draft has no slug; publishing a draft generates the slug with date prefix; editing title after publish does not change slug; direct creation of a published article generates slug immediately.
+- **Podcast::Episode (vm-53):** RSS feed continues to serve episodes with stable GUIDs (after the investigation confirms the behaviour).
+- **Podcast::Playlist (vm-54):** no extra edge cases.
+
+## Rollout order
+
+```
+vm-t11 (shared infra)  ──┬──► vm-50 (Players)
+                         ├──► vm-51 (Games)
+                         ├──► vm-52 (News)
+                         ├──► vm-53 (Podcast Episodes)
+                         └──► vm-54 (Podcast Playlists)
+```
+
+vm-t11 ships first and can merge to master standalone — no routes change, no user-visible effect. After that, vm-50 through vm-54 are independent and can be implemented in any order.
+
+Recommended order by risk/value:
+
+1. **vm-50 (Players)** — highest visibility, validates the end-to-end pipeline including the `AutolinkPlayersInNewsService` call site shipped in vm-80/81
+2. **vm-51 (Games)** — simplest (numeric slug, no transliteration)
+3. **vm-52 (News)** — most complex (date prefix, publish-time generation)
+4. **vm-53 (Podcast Episodes)** — includes RSS feed investigation
+5. **vm-54 (Podcast Playlists)** — simplest content entity
+
+## Out of scope
+
+- Redirects from legacy numeric URLs (hard cutover decided)
+- Admin routes (continue to use numeric IDs)
+- Competitions and help pages (already on slugs)
+- Automatic slug regeneration on source attribute change (frozen by design)
+- Changing the public URL shape (still `/<entity>/:slug`, no nested routes like `/news/:year/:month/:slug`)

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -118,4 +118,41 @@ RSpec.describe Game, type: :model do
       end
     end
   end
+
+  describe "slug" do
+    describe "generation" do
+      let_it_be(:season) { create(:competition, :season, slug: "season-3") }
+      let_it_be(:series) { create(:competition, :series, slug: "season-3-series-1", parent: season) }
+
+      it "generates slug from competition slug and game number" do
+        game = create(:game, competition: series, game_number: 7)
+        expect(game.slug).to eq("season-3-series-1-game-7")
+      end
+
+      it "appends hex tail on collision" do
+        create(:game, competition: series, game_number: 10, slug: "season-3-series-1-game-11")
+        game = build(:game, competition: series, game_number: 11)
+        game.valid?
+        expect(game.slug).to start_with("season-3-series-1-game-11-")
+        expect(game.slug.length).to eq("season-3-series-1-game-11-".length + 4)
+      end
+
+      it "does not change slug when game_number is updated" do
+        game = create(:game, competition: series, game_number: 8)
+        original_slug = game.slug
+        game.update!(game_number: 99)
+        expect(game.slug).to eq(original_slug)
+      end
+    end
+
+    describe "#to_param" do
+      let_it_be(:season) { create(:competition, :season, slug: "season-4") }
+      let_it_be(:series) { create(:competition, :series, slug: "season-4-series-2", parent: season) }
+
+      it "returns the slug" do
+        game = create(:game, competition: series, game_number: 5)
+        expect(game.to_param).to eq("season-4-series-2-game-5")
+      end
+    end
+  end
 end

--- a/spec/requests/games_overlay_spec.rb
+++ b/spec/requests/games_overlay_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Games#overlay" do
     end
 
     it "returns not found for non-existent game" do
-      get overlay_game_path(id: -1)
+      get overlay_game_path(slug: "nonexistent-slug")
 
       expect(response).to have_http_status(:not_found)
     end

--- a/spec/requests/games_spec.rb
+++ b/spec/requests/games_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe GamesController do
-  describe "GET /games/:id" do
+  describe "GET /games/:slug" do
     let_it_be(:season) { create(:competition, :season, name: "Сезон 1") }
     let_it_be(:series) { create(:competition, :series, name: "Серия 1", parent: season) }
     let_it_be(:game) { create(:game, competition: series, game_number: 1) }
@@ -56,7 +56,7 @@ RSpec.describe GamesController do
     end
 
     context "when game does not exist" do
-      before { get game_path(id: -1) }
+      before { get game_path(slug: "nonexistent-slug") }
 
       it "returns not found" do
         expect(response).to have_http_status(:not_found)


### PR DESCRIPTION
## Summary
- Add `Sluggable` concern to `Game` model with custom `slug_base` producing `{competition.slug}-game-{game_number}` format
- Three-step migration: add nullable slug column, backfill existing games, enforce NOT NULL
- Update `GamesController`, `Judge::ProtocolsController`, and routes to use slug-based lookup
- Add `find_record_method` to Avo Game resource for slug/ID compatibility

Closes #705

## Mutation Testing
- Evilution: N/A — all mutations errored due to enum re-registration conflicts (pre-existing limitation with `enum` DSL)
- Mutant: Game#slug_base 96.15% (25/26, 1 neutral), GamesController 98.05% (101/103, 2 neutrals)
- All "alive" mutations were neutrals (unmutated code also fails due to acceptance spec `let_it_be` collision)

## Test plan
- [x] All 1878 specs pass (0 failures)
- [x] Game show page uses slug in URL
- [x] Game overlay uses slug in URL
- [x] Protocol edit/autosave works with slug-based `to_param`
- [x] Avo admin handles both slug and numeric ID lookups
- [x] Slug collision appends hex tail
- [x] Slug is immutable after creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)