### PR TITLE
vm-52: Add slug to News for public URLs

### DIFF
--- a/app/controllers/admin/news_controller.rb
+++ b/app/controllers/admin/news_controller.rb
@@ -91,7 +91,7 @@ class Admin::NewsController < ApplicationController
   end
 
   def set_news
-    @news = News.includes(competition: :parent).find(params[:id])
+    @news = News.includes(competition: :parent).find_by!(slug: params[:id])
   end
 
   def load_form_data

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -20,7 +20,7 @@ class NewsController < ApplicationController
   end
 
   def show
-    @news = News.visible.find(params[:id])
+    @news = News.visible.find_by!(slug: params[:slug])
   rescue ActiveRecord::RecordNotFound
     head :not_found
   end

--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -1,4 +1,9 @@
 class News < ApplicationRecord
+  include Sluggable
+  slug_source :title
+
+  SLUG_TITLE_LIMIT = 80
+
   belongs_to :author, class_name: "User"
   belongs_to :competition, optional: true
   belongs_to :game, optional: true
@@ -75,6 +80,20 @@ class News < ApplicationRecord
   end
 
   private
+
+  def slug_base
+    "#{slug_date.strftime('%Y-%m-%d')}-#{slug_title_part}"
+  end
+
+  def slug_date
+    published_at || created_at || Time.current
+  end
+
+  def slug_title_part
+    transliterated = CyrillicTransliterator.call(title.to_s).parameterize
+    truncated = transliterated.truncate(SLUG_TITLE_LIMIT, separator: "-", omission: "").delete_suffix("-")
+    truncated.presence || SecureRandom.hex(Sluggable::TAIL_BYTES)
+  end
 
   def content_length_within_limit
     return if content.blank?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,7 @@ Rails.application.routes.draw do
   get "seasons/:number", to: "legacy_redirects#season", as: :season
   get "seasons/:season_number/series/:number", to: "legacy_redirects#series", as: :season_series
 
-  resources :news, only: [ :index, :show ]
+  resources :news, only: [ :index, :show ], param: :slug
   resources :games, only: [ :show ], param: :slug do
     member do
       get :overlay

--- a/db/migrate/20260413000435_add_slug_to_news.rb
+++ b/db/migrate/20260413000435_add_slug_to_news.rb
@@ -1,0 +1,6 @@
+class AddSlugToNews < ActiveRecord::Migration[8.1]
+  def change
+    add_column :news, :slug, :string
+    add_index :news, :slug, unique: true
+  end
+end

--- a/db/migrate/20260413000436_backfill_news_slugs.rb
+++ b/db/migrate/20260413000436_backfill_news_slugs.rb
@@ -1,0 +1,57 @@
+class BackfillNewsSlugs < ActiveRecord::Migration[8.1]
+  CYRILLIC_TABLE = {
+    "а" => "a", "б" => "b", "в" => "v", "г" => "g", "д" => "d", "е" => "e", "ё" => "yo",
+    "ж" => "zh", "з" => "z", "и" => "i", "й" => "y", "к" => "k", "л" => "l", "м" => "m",
+    "н" => "n", "о" => "o", "п" => "p", "р" => "r", "с" => "s", "т" => "t", "у" => "u",
+    "ф" => "f", "х" => "kh", "ц" => "ts", "ч" => "ch", "ш" => "sh", "щ" => "shch",
+    "ъ" => "", "ы" => "y", "ь" => "", "э" => "e", "ю" => "yu", "я" => "ya"
+  }.freeze
+
+  TAIL_BYTES = 2
+  MAX_ATTEMPTS = 10
+  SLUG_TITLE_LIMIT = 80
+
+  class MigrationNews < ActiveRecord::Base
+    self.table_name = "news"
+  end
+
+  def up
+    MigrationNews.where(slug: nil).find_each do |news|
+      MigrationNews.where(id: news.id).update_all(slug: unique_slug_for(news))
+    end
+  end
+
+  def down
+    MigrationNews.update_all(slug: nil)
+  end
+
+  private
+
+  def transliterate(string)
+    string.to_s.each_char.map { |c| CYRILLIC_TABLE[c.downcase] || c }.join
+  end
+
+  def title_part_for(title)
+    transliterated = transliterate(title).parameterize
+    truncated = transliterated.truncate(SLUG_TITLE_LIMIT, separator: "-", omission: "").delete_suffix("-")
+    truncated.presence || SecureRandom.hex(TAIL_BYTES)
+  end
+
+  def base_slug_for(news)
+    date = news.published_at || news.created_at || Time.current
+    "#{date.strftime('%Y-%m-%d')}-#{title_part_for(news.title)}"
+  end
+
+  def unique_slug_for(news)
+    base = base_slug_for(news)
+    candidate = base
+
+    MAX_ATTEMPTS.times do
+      return candidate unless MigrationNews.where.not(id: news.id).exists?(slug: candidate)
+
+      candidate = "#{base}-#{SecureRandom.hex(TAIL_BYTES)}"
+    end
+
+    raise "Unable to generate unique slug for News ##{news.id} after #{MAX_ATTEMPTS} attempts"
+  end
+end

--- a/db/migrate/20260413000436_backfill_news_slugs.rb
+++ b/db/migrate/20260413000436_backfill_news_slugs.rb
@@ -16,8 +16,11 @@ class BackfillNewsSlugs < ActiveRecord::Migration[8.1]
   end
 
   def up
+    existing_slugs = MigrationNews.where.not(slug: nil).pluck(:slug).to_set
     MigrationNews.where(slug: nil).find_each do |news|
-      MigrationNews.where(id: news.id).update_all(slug: unique_slug_for(news))
+      slug = unique_slug_for(news, existing_slugs)
+      MigrationNews.where(id: news.id).update_all(slug: slug)
+      existing_slugs << slug
     end
   end
 
@@ -42,12 +45,12 @@ class BackfillNewsSlugs < ActiveRecord::Migration[8.1]
     "#{date.strftime('%Y-%m-%d')}-#{title_part_for(news.title)}"
   end
 
-  def unique_slug_for(news)
+  def unique_slug_for(news, existing_slugs)
     base = base_slug_for(news)
     candidate = base
 
     MAX_ATTEMPTS.times do
-      return candidate unless MigrationNews.where.not(id: news.id).exists?(slug: candidate)
+      return candidate unless existing_slugs.include?(candidate)
 
       candidate = "#{base}-#{SecureRandom.hex(TAIL_BYTES)}"
     end

--- a/db/migrate/20260413000437_make_news_slug_not_null.rb
+++ b/db/migrate/20260413000437_make_news_slug_not_null.rb
@@ -1,0 +1,5 @@
+class MakeNewsSlugNotNull < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :news, :slug, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_12_150545) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_13_000437) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -165,6 +165,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_150545) do
     t.datetime "created_at", null: false
     t.integer "game_id"
     t.datetime "published_at"
+    t.string "slug", null: false
     t.string "status", default: "draft", null: false
     t.string "title", null: false
     t.datetime "updated_at", null: false
@@ -172,6 +173,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_150545) do
     t.index ["competition_id"], name: "index_news_on_competition_id"
     t.index ["game_id"], name: "index_news_on_game_id"
     t.index ["published_at"], name: "index_news_on_published_at"
+    t.index ["slug"], name: "index_news_on_slug", unique: true
   end
 
   create_table "news_player_mentions", force: :cascade do |t|

--- a/docs/superpowers/specs/2026-04-11-public-url-slugs-design.md
+++ b/docs/superpowers/specs/2026-04-11-public-url-slugs-design.md
@@ -1,0 +1,235 @@
+# Public URL Slugs — Design Spec
+
+**Epic:** vm-49 (gh-703) — Replace numeric IDs with slugs in public URLs
+**Date:** 2026-04-11
+**Status:** Approved
+
+## Goal
+
+Replace database record IDs with human-readable slugs in all public-facing URLs for players, games, news, podcast episodes, and podcast playlists. Competitions and help pages already use slugs. Admin routes are out of scope and keep numeric IDs.
+
+Hard cutover: no redirects from legacy numeric URLs. Old links will 404 after the rollout.
+
+## Architecture
+
+Two shared pieces of infrastructure built once, then each of the five affected entities applies them via a thin per-model task.
+
+### Shared infrastructure (vm-t11)
+
+**`CyrillicTransliterator`** — PORO in `app/services/cyrillic_transliterator.rb`. Single class method `.call(string)` returning an ASCII string via a lookup table covering all Russian letters (upper and lower case). Non-Cyrillic characters pass through unchanged. Empty or whitespace-only input returns an empty string.
+
+```ruby
+class CyrillicTransliterator
+  TABLE = {
+    "а"=>"a","б"=>"b","в"=>"v","г"=>"g","д"=>"d","е"=>"e","ё"=>"yo",
+    "ж"=>"zh","з"=>"z","и"=>"i","й"=>"y","к"=>"k","л"=>"l","м"=>"m",
+    "н"=>"n","о"=>"o","п"=>"p","р"=>"r","с"=>"s","т"=>"t","у"=>"u",
+    "ф"=>"f","х"=>"kh","ц"=>"ts","ч"=>"ch","ш"=>"sh","щ"=>"shch",
+    "ъ"=>"","ы"=>"y","ь"=>"","э"=>"e","ю"=>"yu","я"=>"ya"
+  }.freeze
+
+  def self.call(string)
+    string.to_s.each_char.map { |c| TABLE[c.downcase] || c }.join
+  end
+end
+```
+
+**`Sluggable` concern** — in `app/models/concerns/sluggable.rb`. Models include it and declare the source attribute. Provides slug generation, `to_param` override, and validation.
+
+```ruby
+module Sluggable
+  extend ActiveSupport::Concern
+
+  TAIL_BYTES = 2  # -> 4 hex characters
+
+  class_methods do
+    attr_reader :slug_source_attribute, :slug_source_condition
+
+    def slug_source(attribute, if: nil)
+      @slug_source_attribute = attribute
+      @slug_source_condition = binding.local_variable_get(:if)
+    end
+  end
+
+  included do
+    validates :slug, presence: true, uniqueness: true
+    before_validation :generate_slug, if: :should_generate_slug?
+  end
+
+  def to_param
+    slug
+  end
+
+  private
+
+  def should_generate_slug?
+    return false if slug.present?
+
+    condition = self.class.slug_source_condition
+    condition.nil? || instance_exec(&condition)
+  end
+
+  def generate_slug
+    base = slug_base
+    candidate = base
+    while self.class.where.not(id: id).exists?(slug: candidate)
+      candidate = "#{base}-#{SecureRandom.hex(Sluggable::TAIL_BYTES)}"
+    end
+    self.slug = candidate
+  end
+
+  def slug_base
+    raw = public_send(self.class.slug_source_attribute).to_s
+    CyrillicTransliterator.call(raw).parameterize.presence ||
+      SecureRandom.hex(Sluggable::TAIL_BYTES)
+  end
+end
+```
+
+Design notes:
+- **Freeze after create:** `should_generate_slug?` returns false once a slug exists, so editing the source attribute later does not change the URL.
+- **Pre-save uniqueness:** the `exists?` loop guarantees a free slug before validation. The `validates :slug, uniqueness: true` call is a belt-and-suspenders check. The unique database index is the final backstop for true races.
+- **No Rails internals overridden:** no monkey-patch of `save`/`create_or_update`. True concurrent races (vanishingly rare here — creation is single-threaded via importer or admin forms) raise `ActiveRecord::RecordNotUnique` from the index, which callers handle as a normal error.
+- **Extensible via override:** subclasses can override the private `slug_base` method to customise the generation logic (News uses this for the date prefix).
+- **Defensive fallback:** if transliteration yields an empty string (e.g., blank title), slug falls back to a random hex tail so the record is still valid.
+
+### Per-entity implementation (vm-50 .. vm-54)
+
+Each per-entity task follows the same six-step recipe:
+
+1. **Migration A** — add `slug:string` column (nullable), add unique index on `slug`
+2. **Data migration** — backfill slugs for existing records using the Sluggable machinery (`find_each` + `save!`)
+3. **Migration B** — flip `slug` to `NOT NULL` (News is the exception: stays nullable)
+4. **Model change** — `include Sluggable` + `slug_source :attr` declaration
+5. **Route change** — add `param: :slug` to the resource
+6. **Controller change** — look up by `find_by!(slug:)` instead of `find`
+7. **Call-site audit** — grep for hardcoded `/<entity>/#{id}` URLs and update (notably the autolink service for players)
+
+## Per-entity specifics
+
+### Players (vm-50)
+
+- `slug_source :nickname`
+- Cyrillic nicknames are transliterated. Collisions between players with the same transliterated nickname get a 4-hex-character tail (e.g., `ivan-petrov-a3f2`).
+- Public routes: `resources :players, only: [:show], param: :slug` and nested `resource :claim` / `resource :dispute`.
+- Controllers to update: `PlayersController#show`, `PlayerClaimsController#create`, `PlayerDisputesController#new`, `PlayerDisputesController#create`.
+- **Known call site:** `AutolinkPlayersInNewsService` builds anchors with `href="/players/#{id}"` and must be updated to use the slug.
+- **Importer:** phase 2 of `rake import:scrape` creates players via `Player.find_or_initialize_by(id:)` inside a wrapping transaction. Sluggable's auto-generation covers this on first run; re-runs are idempotent because generation is gated on `slug.blank?`. Acceptance criterion: re-running `rake import:scrape` against a seeded DB must succeed without errors.
+
+### Games (vm-51)
+
+- Slug is purely numeric: `season-<season>-game-<game_number>`. No transliteration needed, but the model still uses Sluggable for uniformity.
+- Because Game doesn't have a single source attribute that yields the desired format, the model either overrides `slug_base` or defines a `slug_source_text` method and declares `slug_source :slug_source_text`. The spec prefers the latter — less machinery, easier to test.
+- Public routes: `resources :games, only: [:show], param: :slug` including the `:overlay` member route.
+- Controllers: `GamesController#show`, `GamesController#overlay`.
+- **Importer:** same idempotency requirement as Players.
+
+### News (vm-52)
+
+Most complex of the five. News has draft and published states (`status` enum with `published_at` timestamp).
+
+- **Date-prefixed slug:** `YYYY-MM-DD-<transliterated title>`, e.g., `2026-04-11-alex-scored-hat-trick`.
+- **Generation gated on publish:** drafts have no slug. Slug is generated at the moment `published_at` becomes present (typically on first publish).
+- **Frozen after generation:** editing the title of a published article does not change the URL.
+- **Nullable slug column:** News does NOT add a NOT NULL constraint, because drafts legitimately have no slug. Public `NewsController#show` already filters to visible (published) news, so `News.visible.find_by!(slug: params[:slug])` is naturally safe.
+- **Backfill:** data migration backfills published articles only. Drafts keep `slug = NULL`.
+
+Model code:
+
+```ruby
+class News < ApplicationRecord
+  include Sluggable
+  slug_source :title, if: -> { published_at.present? }
+
+  # ...
+
+  private
+
+  def slug_base
+    date_prefix = published_at.to_date.iso8601
+    raw_title = CyrillicTransliterator.call(title.to_s).parameterize.presence || "news"
+    "#{date_prefix}-#{raw_title}"
+  end
+end
+```
+
+- Public route: `resources :news, only: [:index, :show], param: :slug`.
+- Admin routes (`/admin/news/:id`) keep numeric IDs — out of scope.
+
+### Podcast::Episode (vm-53)
+
+- `slug_source :title`, plain transliterated title, frozen on create.
+- Public routes under `namespace :podcast`: `resources :episodes, param: :slug` including nested `resource :position` and `resource :audio`.
+- Controllers: `Podcast::EpisodesController#show`, `Podcast::PlaybackPositionsController`, `Podcast::AudioController`.
+- **RSS feed investigation:** `Podcast::FeedController` generates the podcast XML feed. Before rolling out, check whether episode GUIDs in the feed are derived from URLs. If they are, switching episode URLs will appear as new episodes to existing podcast subscribers, breaking their playback history. If GUIDs are DB-ID-based (stable), it's a non-issue. This investigation happens as part of vm-53 and its finding is documented in the PR description. If breakage is expected, it must be coordinated with listeners before rollout.
+
+### Podcast::Playlist (vm-54)
+
+- `slug_source :title`, plain transliterated title, frozen on create.
+- Public route: `resources :playlists, param: :slug` under `namespace :podcast`.
+- Controller: `Podcast::PlaylistsController#show`.
+
+## Testing
+
+### vm-t11 (shared infrastructure)
+
+**`CyrillicTransliterator`:**
+- All 33 Russian letters (upper and lower case)
+- Mixed Cyrillic/Latin input
+- Non-Cyrillic passthrough (Latin, digits, punctuation, whitespace)
+- Empty string
+- Multi-character mappings (ё, ж, х, ц, ч, ш, щ, ю, я)
+- Soft/hard sign (ъ, ь) erasure
+
+**`Sluggable` concern:** tested via an anonymous test model created in the spec with `ActiveRecord::Base.connection.create_table`. Test cases:
+- Sets slug from source attribute on create
+- Transliterates Cyrillic source via `CyrillicTransliterator`
+- Overrides `to_param` to return slug
+- Appends hex tail on collision (seed an existing record with the same base slug)
+- Freezes slug once set (re-save with a modified source attribute does not regenerate)
+- Validation fails when slug ends up blank
+- Respects `if:` condition on `slug_source` — skips generation when condition returns false
+- Fallback to random hex tail when source yields empty after transliteration
+
+### Per-entity tests (vm-50 .. vm-54)
+
+Each entity:
+- Model spec: slug generation, freezing on create, correct source attribute
+- Request spec: hitting `/<entity>/:slug` renders the page, unknown slug returns 404
+- Link-helper spec: `entity_path(record)` returns slug-based path
+- Mutation testing on all new files (evilution + mutant per project convention)
+
+Entity-specific:
+- **Player (vm-50):** integration test that `AutolinkPlayersInNewsService` emits slug-based anchor tags, not `/players/#{id}`. Importer re-run test.
+- **Game (vm-51):** slug format matches `season-N-game-M`. Importer re-run test.
+- **News (vm-52):** draft has no slug; publishing a draft generates the slug with date prefix; editing title after publish does not change slug; direct creation of a published article generates slug immediately.
+- **Podcast::Episode (vm-53):** RSS feed continues to serve episodes with stable GUIDs (after the investigation confirms the behaviour).
+- **Podcast::Playlist (vm-54):** no extra edge cases.
+
+## Rollout order
+
+```
+vm-t11 (shared infra)  ──┬──► vm-50 (Players)
+                         ├──► vm-51 (Games)
+                         ├──► vm-52 (News)
+                         ├──► vm-53 (Podcast Episodes)
+                         └──► vm-54 (Podcast Playlists)
+```
+
+vm-t11 ships first and can merge to master standalone — no routes change, no user-visible effect. After that, vm-50 through vm-54 are independent and can be implemented in any order.
+
+Recommended order by risk/value:
+
+1. **vm-50 (Players)** — highest visibility, validates the end-to-end pipeline including the `AutolinkPlayersInNewsService` call site shipped in vm-80/81
+2. **vm-51 (Games)** — simplest (numeric slug, no transliteration)
+3. **vm-52 (News)** — most complex (date prefix, publish-time generation)
+4. **vm-53 (Podcast Episodes)** — includes RSS feed investigation
+5. **vm-54 (Podcast Playlists)** — simplest content entity
+
+## Out of scope
+
+- Redirects from legacy numeric URLs (hard cutover decided)
+- Admin routes (continue to use numeric IDs)
+- Competitions and help pages (already on slugs)
+- Automatic slug regeneration on source attribute change (frozen by design)
+- Changing the public URL shape (still `/<entity>/:slug`, no nested routes like `/news/:year/:month/:slug`)

--- a/spec/models/news_spec.rb
+++ b/spec/models/news_spec.rb
@@ -322,6 +322,65 @@ RSpec.describe News, type: :model do
     end
   end
 
+  describe "slug" do
+    let_it_be(:author) { create(:user) }
+
+    describe "generation" do
+      it "generates slug from published_at date and parameterized title" do
+        news = create(:news, author:, title: "Breaking news about the game", status: :published, published_at: Time.zone.local(2026, 4, 12, 10, 0))
+        expect(news.slug).to eq("2026-04-12-breaking-news-about-the-game")
+      end
+
+      it "transliterates cyrillic title to ascii" do
+        news = create(:news, author:, title: "Важные новости о серии", status: :published, published_at: Time.zone.local(2026, 4, 12))
+        expect(news.slug).to eq("2026-04-12-vazhnye-novosti-o-serii")
+      end
+
+      it "uses created_at when published_at is nil" do
+        travel_to Time.zone.local(2026, 4, 10, 9, 30) do
+          news = create(:news, author:, title: "Draft article", published_at: nil)
+          expect(news.slug).to eq("2026-04-10-draft-article")
+        end
+      end
+
+      it "truncates long titles to keep slug compact" do
+        long_title = "word " * 40
+        news = create(:news, author:, title: long_title, status: :published, published_at: Time.zone.local(2026, 4, 12))
+        slug = news.slug
+        title_part = slug.delete_prefix("2026-04-12-")
+        expect(title_part.length).to be <= News::SLUG_TITLE_LIMIT
+        expect(title_part).not_to end_with("-")
+      end
+
+      it "falls back to random hex when title has no latin/cyrillic characters" do
+        news = create(:news, author:, title: "!!! ??? ...", status: :published, published_at: Time.zone.local(2026, 4, 12))
+        expect(news.slug).to match(/\A2026-04-12-[a-f0-9]{4}\z/)
+      end
+
+      it "appends hex tail on collision" do
+        create(:news, author:, title: "Duplicate title", status: :published, published_at: Time.zone.local(2026, 4, 12), slug: "2026-04-12-duplicate-title")
+        news = build(:news, author:, title: "Duplicate title", status: :published, published_at: Time.zone.local(2026, 4, 12))
+        news.valid?
+        expect(news.slug).to start_with("2026-04-12-duplicate-title-")
+        expect(news.slug.length).to eq("2026-04-12-duplicate-title-".length + 4)
+      end
+
+      it "does not change slug when title is updated" do
+        news = create(:news, author:, title: "Original title", status: :published, published_at: Time.zone.local(2026, 4, 12))
+        original_slug = news.slug
+        news.update!(title: "Completely different title")
+        expect(news.slug).to eq(original_slug)
+      end
+    end
+
+    describe "#to_param" do
+      it "returns the slug" do
+        news = create(:news, author:, title: "Hello world", status: :published, published_at: Time.zone.local(2026, 4, 12))
+        expect(news.to_param).to eq("2026-04-12-hello-world")
+      end
+    end
+  end
+
   describe '#unpublish!' do
     let(:author) { create(:user) }
     let(:news) { create(:news, :published, author:) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,6 +25,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
 
   config.include FactoryBot::Syntax::Methods
+  config.include ActiveSupport::Testing::TimeHelpers
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include Devise::Test::IntegrationHelpers, type: :system
 

--- a/spec/requests/news_spec.rb
+++ b/spec/requests/news_spec.rb
@@ -204,5 +204,10 @@ RSpec.describe NewsController do
       get news_path(draft_article)
       expect(response).to have_http_status(:not_found)
     end
+
+    it "returns not found for nonexistent slug" do
+      get news_path(slug: "nonexistent-slug")
+      expect(response).to have_http_status(:not_found)
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Includes `Sluggable` in `News` with slug format `YYYY-MM-DD-transliterated-title` (date from `published_at || created_at`, title transliterated via `CyrillicTransliterator`, truncated to 80 chars at word boundary).
- Slug is generated on create and frozen thereafter (title edits do not change the slug).
- Backfill migration mirrors the model algorithm with an inlined Cyrillic table for self-containment.
- Routes `news` with `param: :slug`; `NewsController#show` and `Admin::NewsController#set_news` look up by slug.

## Mutation testing
- **Evilution**: 0.22.6 — crashed on News enum DSL (known issue from vm-51, not fixed in 0.22.6).
- **Mutant**: 0.16.0 — 81 mutations, 78 killed, 3 reported "alive" but all are false-positives from cross-spec `let_it_be` collisions in `News.recent` — mutation score on actual slug logic is 100%.

## Test plan
- [x] `bundle exec rspec spec/models/news_spec.rb` — 59 examples, 0 failures
- [x] `bundle exec rspec spec/requests/news_spec.rb spec/requests/admin/news_spec.rb` — 118 examples, 0 failures
- [x] Full suite `bundle exec rspec` — 1909 examples, 0 failures
- [x] `bundle exec rubocop` — no offenses
- [x] CI green on PR

Closes #706