### PR TITLE
vm-57: upload Brakeman SARIF to GitHub Security tab

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   scan_ruby:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
 
     steps:
       - name: Checkout code
@@ -20,11 +22,18 @@ jobs:
           bundler-cache: true
 
       - name: Scan for common Rails security vulnerabilities using static analysis
-        run: bin/brakeman --no-pager
-      
+        run: bin/brakeman --no-pager --format sarif --output brakeman.sarif
+
+      - name: Upload Brakeman SARIF to GitHub Security
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: brakeman.sarif
+          category: brakeman
+
       - name: Scan for known security vulnerabilities in gems used
         run: bin/bundler-audit
-      
+
   scan_js:
     runs-on: ubuntu-latest
 

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ coverage/*
 
 .claude/projects/
 .mutant/
+
+# Brakeman SARIF output (generated in CI)
+/brakeman.sarif


### PR DESCRIPTION
## Summary
Brakeman was already wired into CI (`scan_ruby` job) and the codebase has zero findings. This PR switches Brakeman to SARIF output and uploads the report via `github/codeql-action/upload-sarif` so future findings appear as code scanning alerts in the Security tab instead of living only in CI log lines.

- Add `security-events: write` permission to `scan_ruby` job
- Run brakeman with `--format sarif --output brakeman.sarif` (still exits non-zero on findings → build still fails)
- Upload SARIF with `if: always()` so findings are visible even when brakeman fails the build
- Gitignore the generated `brakeman.sarif`

Note: Gem install and CI step already existed before this PR, and the scan is clean (43 controllers, 26 models, 62 templates, 0 security warnings).

## Test plan
- [x] `bin/brakeman --no-pager --format sarif --output brakeman.sarif` — 0 warnings, valid SARIF produced locally
- [x] YAML parses
- [x] CI green on PR, Brakeman SARIF appears under repo Security → Code scanning

Closes #717