### PR TITLE
Fix News show page showing "Content missing" with infinite scroll

### DIFF
--- a/app/views/news/index.html.erb
+++ b/app/views/news/index.html.erb
@@ -3,7 +3,7 @@
 <% if @news.any? %>
   <% if @pagination_mode == :infinite %>
     <div data-controller="infinite-scroll">
-      <turbo-frame id="news-list" class="space-y-8">
+      <turbo-frame id="news-list" target="_top" class="space-y-8">
         <%= render partial: "news/article", collection: @news, as: :article %>
       </turbo-frame>
 

--- a/spec/requests/news_spec.rb
+++ b/spec/requests/news_spec.rb
@@ -127,6 +127,11 @@ RSpec.describe NewsController do
         assert_select "turbo-frame#news-list"
       end
 
+      it "targets _top on the turbo frame so article links escape it" do
+        get news_index_path
+        assert_select "turbo-frame#news-list[target='_top']"
+      end
+
       it "renders a sentinel for loading more" do
         create_list(:news, 25, :published, author: author)
         get news_index_path


### PR DESCRIPTION
## Summary

When `news_infinite_scroll` feature toggle is enabled, articles on the news index are wrapped in `<turbo-frame id="news-list">`. Links inside a Turbo frame target that frame by default, so clicking an article title or "Read more" made Turbo fetch the show page and look for a `news-list` frame inside it. Since the show page has no such frame, Turbo rendered its default mismatch message — "Content missing, response does not contain a matching <turbo-frame id='news-list'>" — instead of the article body.

## Fix

Add `target="_top"` to the `<turbo-frame id="news-list">` element. Descendant links then navigate the whole page by default, while the sentinel's Turbo Stream appends continue to work (they target by DOM id, not frame).

## Test Plan

- [x] Added failing request spec asserting `turbo-frame#news-list[target='_top']` when infinite scroll is enabled
- [x] Full suite passes (1910 examples, 0 failures)
- [ ] Manual smoke test: enable `news_infinite_scroll`, click a news article → shows full content instead of "Content missing"

Closes #722