### PR TITLE
vm-63: Tile desktop sidebar background instead of stretching

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -116,7 +116,7 @@
 
     <div class="lg:flex lg:min-h-screen">
       <%# Desktop sidebar %>
-      <aside class="hidden lg:flex lg:flex-col lg:w-56 lg:flex-shrink-0 bg-neutral-900 bg-cover bg-center text-gray-300"
+      <aside class="hidden lg:flex lg:flex-col lg:w-56 lg:flex-shrink-0 bg-neutral-900 bg-repeat bg-top text-gray-300"
              style="background-image: url('/img/back.jpg')">
         <div class="flex flex-col items-center px-4 py-8 bg-neutral-900/80 min-h-screen">
           <%= link_to root_path, class: "mb-8" do %>

--- a/spec/requests/navigation_spec.rb
+++ b/spec/requests/navigation_spec.rb
@@ -78,4 +78,12 @@ RSpec.describe "Navigation" do
       end
     end
   end
+
+  describe "desktop sidebar background" do
+    it "tiles the background image instead of stretching to cover" do
+      get "/news"
+      assert_select "aside[style*='back.jpg'].bg-repeat"
+      assert_select "aside[style*='back.jpg'].bg-cover", false
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes #724. On long pages the desktop sidebar background (`/img/back.jpg`) was scaled up enormously because the aside used Tailwind's `bg-cover`, which resizes the 1920×960 image to cover the element's full height. The result looked blurry/stretched.

**Fix:** Replace `bg-cover bg-center` with `bg-repeat bg-top` so the image tiles vertically at native size regardless of page length.

## Mutation testing

N/A — the change is a single Tailwind class tweak in an `.erb` layout; neither mutant nor evilution mutate view templates.

## Test plan

- [x] `bundle exec rspec spec/requests/navigation_spec.rb` — added regression spec asserting `aside` has `bg-repeat` and not `bg-cover`.
- [x] Visual check: load `/news` on a long page and confirm sidebar background tiles instead of stretching.