### PR TITLE
vm-64: Higher-quality news photo variants and click-to-zoom

### DIFF
--- a/app/helpers/news_helper.rb
+++ b/app/helpers/news_helper.rb
@@ -1,0 +1,12 @@
+module NewsHelper
+  NEWS_PHOTO_VARIANTS = {
+    thumbnail: { resize_to_limit: [ 800, 600 ], saver: { quality: 85 } },
+    full: { resize_to_limit: [ 1200, 900 ], saver: { quality: 90 } },
+    zoom: { resize_to_limit: [ 2400, 1800 ], saver: { quality: 90 } },
+    admin_form: { resize_to_limit: [ 400, 400 ], saver: { quality: 80 } }
+  }.freeze
+
+  def news_photo_variant(photo, variant)
+    photo.variant(NEWS_PHOTO_VARIANTS.fetch(variant))
+  end
+end

--- a/app/javascript/controllers/lightbox_controller.js
+++ b/app/javascript/controllers/lightbox_controller.js
@@ -1,0 +1,36 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  open(event) {
+    event.preventDefault()
+    const url = this.element.getAttribute("href")
+    if (!url) return
+
+    const overlay = document.createElement("div")
+    overlay.className = "fixed inset-0 z-50 bg-black/90 flex items-center justify-center cursor-zoom-out p-4"
+    overlay.setAttribute("role", "dialog")
+    overlay.setAttribute("aria-modal", "true")
+
+    const img = document.createElement("img")
+    img.src = url
+    img.alt = ""
+    img.className = "max-w-full max-h-full object-contain"
+
+    overlay.appendChild(img)
+    document.body.appendChild(overlay)
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = "hidden"
+
+    const close = () => {
+      overlay.remove()
+      document.body.style.overflow = previousOverflow
+      document.removeEventListener("keydown", onKey)
+    }
+    const onKey = (e) => {
+      if (e.key === "Escape") close()
+    }
+
+    overlay.addEventListener("click", close)
+    document.addEventListener("keydown", onKey)
+  }
+}

--- a/app/javascript/controllers/lightbox_controller.js
+++ b/app/javascript/controllers/lightbox_controller.js
@@ -3,17 +3,24 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   open(event) {
     event.preventDefault()
+    if (document.querySelector("[data-lightbox-overlay]")) return
+
     const url = this.element.getAttribute("href")
     if (!url) return
+
+    const thumbnail = this.element.querySelector("img")
+    const alt = thumbnail ? thumbnail.getAttribute("alt") || "" : ""
 
     const overlay = document.createElement("div")
     overlay.className = "fixed inset-0 z-50 bg-black/90 flex items-center justify-center cursor-zoom-out p-4"
     overlay.setAttribute("role", "dialog")
     overlay.setAttribute("aria-modal", "true")
+    overlay.setAttribute("data-lightbox-overlay", "")
+    if (alt) overlay.setAttribute("aria-label", alt)
 
     const img = document.createElement("img")
     img.src = url
-    img.alt = ""
+    img.alt = alt
     img.className = "max-w-full max-h-full object-contain"
 
     overlay.appendChild(img)

--- a/app/views/admin/news/_form.html.erb
+++ b/app/views/admin/news/_form.html.erb
@@ -28,7 +28,7 @@
         <div class="flex flex-wrap gap-2">
           <% f.object.photos.each do |photo| %>
             <% if photo.variable? %>
-              <%= image_tag photo.variant(resize_to_limit: [200, 200]), alt: f.object.title, class: "rounded" %>
+              <%= image_tag news_photo_variant(photo, :admin_form), alt: f.object.title, class: "rounded" %>
             <% end %>
           <% end %>
         </div>

--- a/app/views/admin/news/show.html.erb
+++ b/app/views/admin/news/show.html.erb
@@ -25,15 +25,7 @@
     <% end %>
   </div>
 
-  <% if @news.photos.attached? %>
-    <div class="flex flex-wrap gap-2 mb-4">
-      <% @news.photos.each do |photo| %>
-        <% if photo.variable? %>
-          <%= image_tag photo.variant(resize_to_limit: [600, 400]), alt: @news.title, class: "rounded max-w-full" %>
-        <% end %>
-      <% end %>
-    </div>
-  <% end %>
+  <%= render "news/photos", photos: @news.photos, alt: @news.title, size: :full %>
 
   <div class="prose max-w-none">
     <%= @news.content %>

--- a/app/views/competitions/show.html.erb
+++ b/app/views/competitions/show.html.erb
@@ -102,15 +102,7 @@
                 · <%= article.author.player.name %>
               <% end %>
             </div>
-            <% if article.photos.attached? %>
-              <div class="flex flex-wrap gap-2 mb-2">
-                <% article.photos.each do |photo| %>
-                  <% if photo.variable? %>
-                    <%= image_tag photo.variant(resize_to_limit: [600, 400]), alt: article.title, class: "rounded max-w-full" %>
-                  <% end %>
-                <% end %>
-              </div>
-            <% end %>
+            <%= render "news/photos", photos: article.photos, alt: article.title, size: :thumbnail %>
             <div class="prose max-w-none text-neutral-700">
               <%= article.content %>
             </div>

--- a/app/views/news/_article.html.erb
+++ b/app/views/news/_article.html.erb
@@ -17,15 +17,7 @@
       <% end %>
     <% end %>
   </div>
-  <% if article.photos.attached? %>
-    <div class="flex flex-wrap gap-2 mb-3">
-      <% article.photos.each do |photo| %>
-        <% if photo.variable? %>
-          <%= image_tag photo.variant(resize_to_limit: [600, 400]), alt: article.title, class: "rounded max-w-full" %>
-        <% end %>
-      <% end %>
-    </div>
-  <% end %>
+  <%= render "news/photos", photos: article.photos, alt: article.title, size: :thumbnail %>
   <div class="prose max-w-none text-neutral-700">
     <% if is_truncated %>
       <%= article.truncated_content(max_length) %>

--- a/app/views/news/_photos.html.erb
+++ b/app/views/news/_photos.html.erb
@@ -5,8 +5,9 @@
   <div class="flex flex-wrap gap-2 mb-3">
     <% photos.each do |photo| %>
       <% if photo.variable? %>
-        <%= link_to rails_representation_url(news_photo_variant(photo, :zoom)),
+        <%= link_to rails_representation_path(news_photo_variant(photo, :zoom)),
               class: "inline-block cursor-zoom-in",
+              aria: { label: alt },
               data: { controller: "lightbox", action: "click->lightbox#open" } do %>
           <%= image_tag news_photo_variant(photo, size), alt: alt, class: "rounded max-w-full sm:max-w-md" %>
         <% end %>

--- a/app/views/news/_photos.html.erb
+++ b/app/views/news/_photos.html.erb
@@ -8,7 +8,7 @@
         <%= link_to rails_representation_url(news_photo_variant(photo, :zoom)),
               class: "inline-block cursor-zoom-in",
               data: { controller: "lightbox", action: "click->lightbox#open" } do %>
-          <%= image_tag news_photo_variant(photo, size), alt: alt, class: "rounded max-w-full" %>
+          <%= image_tag news_photo_variant(photo, size), alt: alt, class: "rounded max-w-full sm:max-w-sm" %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/news/_photos.html.erb
+++ b/app/views/news/_photos.html.erb
@@ -8,7 +8,7 @@
         <%= link_to rails_representation_url(news_photo_variant(photo, :zoom)),
               class: "inline-block cursor-zoom-in",
               data: { controller: "lightbox", action: "click->lightbox#open" } do %>
-          <%= image_tag news_photo_variant(photo, size), alt: alt, class: "rounded max-w-full sm:max-w-sm" %>
+          <%= image_tag news_photo_variant(photo, size), alt: alt, class: "rounded max-w-full sm:max-w-md" %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/news/_photos.html.erb
+++ b/app/views/news/_photos.html.erb
@@ -1,0 +1,16 @@
+<% photos = local_assigns.fetch(:photos) %>
+<% alt = local_assigns.fetch(:alt) %>
+<% size = local_assigns.fetch(:size, :thumbnail) %>
+<% if photos.attached? %>
+  <div class="flex flex-wrap gap-2 mb-3">
+    <% photos.each do |photo| %>
+      <% if photo.variable? %>
+        <%= link_to rails_representation_url(news_photo_variant(photo, :zoom)),
+              class: "inline-block cursor-zoom-in",
+              data: { controller: "lightbox", action: "click->lightbox#open" } do %>
+          <%= image_tag news_photo_variant(photo, size), alt: alt, class: "rounded max-w-full" %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -18,15 +18,7 @@
       <% end %>
     <% end %>
   </div>
-  <% if @news.photos.attached? %>
-    <div class="flex flex-wrap gap-2 mb-3">
-      <% @news.photos.each do |photo| %>
-        <% if photo.variable? %>
-          <%= image_tag photo.variant(resize_to_limit: [600, 400]), alt: @news.title, class: "rounded max-w-full" %>
-        <% end %>
-      <% end %>
-    </div>
-  <% end %>
+  <%= render "news/photos", photos: @news.photos, alt: @news.title, size: :full %>
   <div class="prose max-w-none text-neutral-700">
     <%= @news.content %>
   </div>

--- a/spec/helpers/news_helper_spec.rb
+++ b/spec/helpers/news_helper_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe NewsHelper, type: :helper do
+  describe "#news_photo_variant" do
+    let_it_be(:author) { create(:user) }
+    let_it_be(:news) { create(:news, :with_photo, author: author) }
+    let(:photo) { news.photos.first }
+
+    it "returns a thumbnail variant at 800x600 with quality 85" do
+      variant = helper.news_photo_variant(photo, :thumbnail)
+      expect(variant.variation.transformations[:resize_to_limit]).to eq([ 800, 600 ])
+      expect(variant.variation.transformations[:saver]).to eq(quality: 85)
+    end
+
+    it "returns a full variant at 1200x900 with quality 90" do
+      variant = helper.news_photo_variant(photo, :full)
+      expect(variant.variation.transformations[:resize_to_limit]).to eq([ 1200, 900 ])
+      expect(variant.variation.transformations[:saver]).to eq(quality: 90)
+    end
+
+    it "returns a zoom variant at 2400x1800 with quality 90" do
+      variant = helper.news_photo_variant(photo, :zoom)
+      expect(variant.variation.transformations[:resize_to_limit]).to eq([ 2400, 1800 ])
+      expect(variant.variation.transformations[:saver]).to eq(quality: 90)
+    end
+
+    it "returns an admin_form variant at 400x400 with quality 80" do
+      variant = helper.news_photo_variant(photo, :admin_form)
+      expect(variant.variation.transformations[:resize_to_limit]).to eq([ 400, 400 ])
+      expect(variant.variation.transformations[:saver]).to eq(quality: 80)
+    end
+
+    it "raises KeyError for an unknown variant name" do
+      expect { helper.news_photo_variant(photo, :bogus) }.to raise_error(KeyError)
+    end
+  end
+end

--- a/spec/requests/news_spec.rb
+++ b/spec/requests/news_spec.rb
@@ -65,6 +65,12 @@ RSpec.describe NewsController do
         get news_index_path
         assert_select "img[src*='photo.jpg']"
       end
+
+      it "wraps the photo in a lightbox trigger" do
+        article_with_photo
+        get news_index_path
+        assert_select "a[data-controller='lightbox'][data-action*='lightbox#open'] img"
+      end
     end
 
     context "when user is an editor" do


### PR DESCRIPTION
## Summary

Fixes #725. News photo variants were all `[600, 400]` with no quality setting, so thumbnails and show-page images looked blurry on retina screens and there was no way to see the full-resolution source.

- Centralize variant sizing in `NewsHelper#news_photo_variant` with four named presets:
  - `:thumbnail` — `[800, 600]` q85 (news index + competition feed)
  - `:full` — `[1200, 900]` q90 (news show + admin news show)
  - `:zoom` — `[2400, 1800]` q90 (lightbox target)
  - `:admin_form` — `[400, 400]` q80 (admin news form preview)
- Extract the repeated photos block into `news/_photos.html.erb`, which wraps each thumbnail in an `<a>` linking to the zoom variant and activates a new `lightbox` Stimulus controller.
- New `lightbox_controller.js` overlays the full-size image, closes on click or Escape, and restores body scroll on close.

## Mutation testing

- **Mutant (NewsHelper):** 100% (16/16)
- **Evilution:** blocked by known gem enum-reload crash (marinazzio/evilution#683); skipped.

## Test plan

- [x] `bundle exec rspec` (full suite minus system/acceptance): 1879 examples, 0 failures
- [x] Helper spec covers all four variants + unknown-variant error path
- [x] Request spec asserts news index wraps photos in a lightbox trigger
- [ ] Visual check: click a photo on `/news` and on a news show page, verify full-size image appears and Escape closes it