### PR TITLE
vm-56: Show linked news on root competition page

### DIFF
--- a/app/controllers/competitions_controller.rb
+++ b/app/controllers/competitions_controller.rb
@@ -3,6 +3,7 @@ class CompetitionsController < ApplicationController
     @competition = Competition.find_by!(slug: params[:slug])
     result = CompetitionOverviewService.call(competition: @competition)
     @parent_view = result.parent_view
+    @news = result.news
 
     if @parent_view
       @games_by_child = result.games_by_child
@@ -11,7 +12,6 @@ class CompetitionsController < ApplicationController
       @games = result.games
       @participations_by_player = result.participations_by_player
       @players_sorted = result.players_sorted
-      @news = result.news
     end
   end
 end

--- a/app/services/competition_overview_service.rb
+++ b/app/services/competition_overview_service.rb
@@ -32,7 +32,7 @@ class CompetitionOverviewService
       games: Game.none,
       participations_by_player: {},
       players_sorted: [],
-      news: []
+      news: news_for_competition
     )
   end
 
@@ -48,7 +48,11 @@ class CompetitionOverviewService
       games: games,
       participations_by_player: participations_by_player,
       players_sorted: players_sorted,
-      news: News.visible.for_competition(@competition).includes({ author: :player }, :tags, :rich_text_content, photos_attachments: :blob).recent
+      news: news_for_competition
     )
+  end
+
+  def news_for_competition
+    News.visible.for_competition(@competition).includes({ author: :player }, :tags, :rich_text_content, photos_attachments: :blob).recent
   end
 end

--- a/app/views/competitions/show.html.erb
+++ b/app/views/competitions/show.html.erb
@@ -86,35 +86,35 @@
       </tbody>
     </table>
   </div>
+<% end %>
 
-  <% if @news.any? %>
-    <section class="mt-10">
-      <h2 class="text-2xl font-bold text-maroon mb-4"><%= t(".news") %></h2>
-      <div class="space-y-6">
-        <% @news.each do |article| %>
-          <article class="border-b border-neutral-200 pb-4">
-            <h3 class="text-lg font-bold mb-1"><%= article.title %></h3>
-            <div class="text-sm text-neutral-500 mb-2">
-              <% if article.published_at.present? %>
-                <%= l(article.published_at, format: :short) %>
-              <% end %>
-              <% if article.author.claimed_player? %>
-                · <%= article.author.player.name %>
-              <% end %>
-            </div>
-            <%= render "news/photos", photos: article.photos, alt: article.title, size: :thumbnail %>
-            <div class="prose max-w-none text-neutral-700">
-              <%= article.content %>
-            </div>
-            <% if user_signed_in? && current_user.can_manage_news? %>
-              <div class="mt-2">
-                <%= link_to t("news.index.edit"), edit_admin_news_path(article),
-                      class: "text-sm text-blue-600 hover:underline" %>
-              </div>
+<% if @news.any? %>
+  <section class="mt-10">
+    <h2 class="text-2xl font-bold text-maroon mb-4"><%= t(".news") %></h2>
+    <div class="space-y-6">
+      <% @news.each do |article| %>
+        <article class="border-b border-neutral-200 pb-4">
+          <h3 class="text-lg font-bold mb-1"><%= article.title %></h3>
+          <div class="text-sm text-neutral-500 mb-2">
+            <% if article.published_at.present? %>
+              <%= l(article.published_at, format: :short) %>
             <% end %>
-          </article>
-        <% end %>
-      </div>
-    </section>
-  <% end %>
+            <% if article.author.claimed_player? %>
+              · <%= article.author.player.name %>
+            <% end %>
+          </div>
+          <%= render "news/photos", photos: article.photos, alt: article.title, size: :thumbnail %>
+          <div class="prose max-w-none text-neutral-700">
+            <%= article.content %>
+          </div>
+          <% if user_signed_in? && current_user.can_manage_news? %>
+            <div class="mt-2">
+              <%= link_to t("news.index.edit"), edit_admin_news_path(article),
+                    class: "text-sm text-blue-600 hover:underline" %>
+            </div>
+          <% end %>
+        </article>
+      <% end %>
+    </div>
+  </section>
 <% end %>

--- a/spec/requests/competitions_spec.rb
+++ b/spec/requests/competitions_spec.rb
@@ -51,6 +51,27 @@ RSpec.describe CompetitionsController do
       it "links player names to profiles" do
         expect(response.body).to include(player_path(player1))
       end
+
+      context "with linked news" do
+        let_it_be(:author) { create(:user) }
+        let_it_be(:parent_article) { create(:news, :published, author: author, competition: parent, title: "Parent season news") }
+        let_it_be(:child_article) { create(:news, :published, author: author, competition: child1, title: "Child series news") }
+        let_it_be(:draft_article) { create(:news, author: author, competition: parent, title: "Draft parent news") }
+
+        before { get competition_path(slug: parent.slug) }
+
+        it "shows news linked directly to the parent competition" do
+          expect(response.body).to include("Parent season news")
+        end
+
+        it "does not show news linked only to child competitions" do
+          expect(response.body).not_to include("Child series news")
+        end
+
+        it "does not show draft news" do
+          expect(response.body).not_to include("Draft parent news")
+        end
+      end
     end
 
     context "when competition is a leaf" do

--- a/spec/requests/competitions_spec.rb
+++ b/spec/requests/competitions_spec.rb
@@ -58,8 +58,6 @@ RSpec.describe CompetitionsController do
         let_it_be(:child_article) { create(:news, :published, author: author, competition: child1, title: "Child series news") }
         let_it_be(:draft_article) { create(:news, author: author, competition: parent, title: "Draft parent news") }
 
-        before { get competition_path(slug: parent.slug) }
-
         it "shows news linked directly to the parent competition" do
           expect(response.body).to include("Parent season news")
         end

--- a/spec/services/competition_overview_service_spec.rb
+++ b/spec/services/competition_overview_service_spec.rb
@@ -66,6 +66,30 @@ RSpec.describe CompetitionOverviewService do
       it "reports as parent" do
         expect(result.parent_view).to be true
       end
+
+      describe "news" do
+        let_it_be(:author) { create(:user) }
+        let_it_be(:parent_news) { create(:news, :published, author: author, competition: parent) }
+        let_it_be(:child_news) { create(:news, :published, author: author, competition: child1) }
+        let_it_be(:draft_parent_news) { create(:news, author: author, competition: parent) }
+        let_it_be(:other_news) { create(:news, :published, author: author, competition: other_comp) }
+
+        it "includes published news linked directly to the parent competition" do
+          expect(result.news).to include(parent_news)
+        end
+
+        it "excludes news linked to child competitions" do
+          expect(result.news).not_to include(child_news)
+        end
+
+        it "excludes draft news" do
+          expect(result.news).not_to include(draft_parent_news)
+        end
+
+        it "excludes news linked to unrelated competitions" do
+          expect(result.news).not_to include(other_news)
+        end
+      end
     end
 
     context "when competition is a leaf (no children)" do


### PR DESCRIPTION
## Summary
- Load linked published news for both parent (season) and leaf (series) competitions
- Root season pages now render their directly-linked news articles (exact `competition_id` match — not subtree)
- Controller assigns `@news` uniformly; view moves the news section outside the parent/leaf branch

## Mutation testing
- Evilution: blocked by known enum-reload crash (marinazzio/evilution#683)
- Mutant: `CompetitionOverviewService#news_for_competition` 32/33 (1 neutral — flaky `let_it_be` slug collision on fork reload); `#parent_result` 80/81 (same neutral cause)

## Test plan
- [x] Root season page displays news linked directly to the season
- [x] News linked only to child competitions is not shown
- [x] Draft news is not shown

Closes #711