### PR TITLE
vm-76: Add published_at field to admin news form

### DIFF
--- a/app/controllers/admin/news_controller.rb
+++ b/app/controllers/admin/news_controller.rb
@@ -100,7 +100,7 @@ class Admin::NewsController < ApplicationController
   end
 
   def news_params
-    permitted = params.require(:news).permit(:title, :content, :competition_id, photos: [])
+    permitted = params.require(:news).permit(:title, :content, :competition_id, :published_at, photos: [])
     if permitted[:photos]
       permitted[:photos].reject!(&:blank?)
       permitted.delete(:photos) if permitted[:photos].empty?

--- a/app/views/admin/news/_form.html.erb
+++ b/app/views/admin/news/_form.html.erb
@@ -40,6 +40,11 @@
       <%= f.file_field :photos, multiple: true, class: "text-sm", accept: "image/*" %>
     </div>
 
+    <div class="flex flex-col sm:flex-row items-start px-4 py-3 gap-2">
+      <%= f.label :published_at, t("admin_news.form.published_at"), class: "w-40 font-semibold text-sm text-right pt-2" %>
+      <%= f.datetime_local_field :published_at, class: "w-full border border-gray-300 rounded-md px-3 py-2 text-sm" %>
+    </div>
+
     <% selected_competition = f.object.competition %>
     <% selected_season_id = selected_competition ? (selected_competition.parent_id || selected_competition.id) : nil %>
     <div class="flex flex-col sm:flex-row items-start px-4 py-3 gap-2"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -332,6 +332,7 @@ ru:
       add_photos: "Добавить фото"
       season: "Сезон"
       series: "Серия"
+      published_at: "Дата публикации"
       submit_create: "Создать"
       submit_update: "Сохранить"
       submit_save_and_publish: "Сохранить и опубликовать"

--- a/spec/requests/admin/news_spec.rb
+++ b/spec/requests/admin/news_spec.rb
@@ -503,6 +503,26 @@ RSpec.describe "Admin::News" do
         expect(response).to redirect_to(new_user_session_path)
       end
     end
+
+    context "published_at field" do
+      let(:scheduled_time) { Time.zone.local(2025, 6, 15, 14, 30) }
+      let(:scheduled_article) { create(:news, author: editor, published_at: scheduled_time) }
+
+      before do
+        sign_in editor
+        get edit_admin_news_path(scheduled_article)
+      end
+
+      it "renders a datetime-local input for published_at" do
+        assert_select "input[type='datetime-local'][name='news[published_at]']"
+      end
+
+      it "pre-fills the current published_at value" do
+        assert_select "input[name='news[published_at]']" do |inputs|
+          expect(inputs.first["value"]).to eq("2025-06-15T14:30:00")
+        end
+      end
+    end
   end
 
   describe "PATCH /admin/news/:id" do
@@ -543,6 +563,28 @@ RSpec.describe "Admin::News" do
           end
           patch admin_news_path(article), params: { news: { title: "Updated Title", photos: [ "" ] } }
           expect(article.reload.photos).to be_attached
+        end
+
+        it "updates published_at when provided" do
+          backdated = Time.zone.local(2024, 1, 15, 10, 0)
+          patch admin_news_path(article), params: { news: { published_at: backdated.to_s } }
+          expect(article.reload.published_at).to be_within(1.second).of(backdated)
+        end
+
+        it "clears published_at when submitted blank" do
+          article.update!(published_at: 1.day.ago)
+          patch admin_news_path(article), params: { news: { published_at: "" } }
+          expect(article.reload.published_at).to be_nil
+        end
+      end
+
+      context "with publish param and manual published_at" do
+        it "respects the provided published_at when publishing" do
+          backdated = Time.zone.local(2024, 3, 1, 12, 0)
+          patch admin_news_path(article), params: { news: { published_at: backdated.to_s }, publish: "1" }
+          article.reload
+          expect(article).to be_published
+          expect(article.published_at).to be_within(1.second).of(backdated)
         end
       end
 


### PR DESCRIPTION
## Summary
- Permit `published_at` in `Admin::NewsController#news_params`
- Render a `datetime_local_field` for `published_at` on the admin news form (new + edit)
- Add Russian i18n label "Дата публикации"

Enables admins to backdate imported articles and correct timestamps. `publish!` already preserves a non-blank `published_at`, so submitting the form with the publish button respects the admin-provided value.

## Mutation testing
- Evilution: blocked by known enum-reload crash (marinazzio/evilution#683)
- Mutant: `Admin::NewsController#news_params` 84/85 (1 neutral — flaky acceptance test collision under mutant fork)

## Test plan
- [x] Edit form shows a datetime picker pre-filled with current published_at
- [x] Setting a backdated value persists it
- [x] Clearing the field nullifies published_at
- [x] Clicking "Save and publish" with a manual published_at respects the provided value

Closes #745