### PR TITLE
vm-78: Ship logs to Better Stack + structured JSON for Telegram scoring

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,8 @@ jobs:
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
       GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+      BETTER_STACK_SOURCE_TOKEN: ${{ secrets.BETTER_STACK_SOURCE_TOKEN }}
+      BETTER_STACK_INGESTING_HOST: ${{ secrets.BETTER_STACK_INGESTING_HOST }}
 
     steps:
       - name: Checkout code

--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -26,3 +26,7 @@ SENTRY_DSN=$(printenv SENTRY_DSN)
 # Google OAuth credentials for Sign in with Google
 GOOGLE_CLIENT_ID=$(printenv GOOGLE_CLIENT_ID)
 GOOGLE_CLIENT_SECRET=$(printenv GOOGLE_CLIENT_SECRET)
+
+# Better Stack (Logtail) log shipping — leave unset to disable
+BETTER_STACK_SOURCE_TOKEN=$(printenv BETTER_STACK_SOURCE_TOKEN)
+BETTER_STACK_INGESTING_HOST=$(printenv BETTER_STACK_INGESTING_HOST)

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,9 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 
 gem "sentry-rails"
 
+# Ship logs to Better Stack (Logtail) when BETTER_STACK_SOURCE_TOKEN is set.
+gem "logtail-rails"
+
 
 # Use the database-backed adapters for Rails.cache, Active Job, and Action Cable
 gem "solid_cache"

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,8 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 
 gem "sentry-rails"
 
-# Ship logs to Better Stack (Logtail) when BETTER_STACK_SOURCE_TOKEN is set.
+# Ship logs to Better Stack (Logtail) in production when both
+# BETTER_STACK_SOURCE_TOKEN and BETTER_STACK_INGESTING_HOST are set.
 gem "logtail-rails"
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,6 +287,17 @@ GEM
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
+    logtail (0.1.17)
+      msgpack (~> 1.0)
+    logtail-rack (0.2.6)
+      logtail (~> 0.1)
+      rack (>= 1.2, < 4.0)
+    logtail-rails (0.2.12)
+      actionpack (>= 5.0.0)
+      activerecord (>= 5.0.0)
+      logtail (~> 0.1, >= 0.1.14)
+      logtail-rack (~> 0.1)
+      railties (>= 5.0.0)
     loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -663,6 +674,7 @@ DEPENDENCIES
   image_processing (~> 1.2)
   importmap-rails
   kamal
+  logtail-rails
   mutant-rspec
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
@@ -784,6 +796,9 @@ CHECKSUMS
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  logtail (0.1.17) sha256=866d05690453b3d0c4088e236054a0497ae07380690f565d0c6132eb2d523a48
+  logtail-rack (0.2.6) sha256=a7959441efd43cf7fe198516bbb358be806e4686de9492d51f7b8ed87617808d
+  logtail-rails (0.2.12) sha256=2685b10779a1d733cde9e35da6fb123ae275e754741036c206dd58a73e3a8955
   loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
   marcel (1.1.0) sha256=fdcfcfa33cc52e93c4308d40e4090a5d4ea279e160a7f6af988260fa970e0bee

--- a/app/jobs/process_telegram_webhook_job.rb
+++ b/app/jobs/process_telegram_webhook_job.rb
@@ -36,11 +36,13 @@ class ProcessTelegramWebhookJob < ApplicationJob
 
     threshold = FeatureToggle.value_for(SCORE_THRESHOLD_SETTING, default: DEFAULT_SCORE_THRESHOLD).to_i
     score = Telegram::NewsScorer.call(parsed)
-    if score < threshold
-      Rails.logger.debug("[TelegramWebhook] rejected: score=#{score} threshold=#{threshold} from_id=#{parsed.from_id}")
+    decision = score < threshold ? :rejected : :accepted
+    payload = { event: "telegram_webhook.#{decision}", score: score, threshold: threshold, from_id: parsed.from_id }.to_json
+    if decision == :rejected
+      Rails.logger.debug(payload)
       true
     else
-      Rails.logger.info("[TelegramWebhook] accepted: score=#{score} threshold=#{threshold} from_id=#{parsed.from_id}")
+      Rails.logger.info(payload)
       false
     end
   end

--- a/app/services/telegram/news_scorer.rb
+++ b/app/services/telegram/news_scorer.rb
@@ -42,8 +42,7 @@ module Telegram
         question: question_penalty
       }
       total = scores.values.sum
-      breakdown = scores.map { |k, v| "#{k}=#{v}" }.join(" ")
-      Rails.logger.debug("[NewsScorer] #{breakdown} total=#{total}")
+      Rails.logger.debug({ event: "news_scorer.scored", total: total, **scores }.to_json)
       total
     end
 

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -41,6 +41,8 @@ env:
     - SENTRY_DSN
     - GOOGLE_CLIENT_ID
     - GOOGLE_CLIENT_SECRET
+    - BETTER_STACK_SOURCE_TOKEN
+    - BETTER_STACK_INGESTING_HOST
   clear:
     # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
     # When you start using multiple servers, you should split out job processing to a dedicated machine.

--- a/config/initializers/logtail.rb
+++ b/config/initializers/logtail.rb
@@ -3,5 +3,10 @@ ingesting_host = ENV["BETTER_STACK_INGESTING_HOST"]
 
 if Rails.env.production? && source_token.present? && ingesting_host.present?
   logtail_logger = Logtail::Logger.create_default_logger(source_token, ingesting_host: ingesting_host)
-  Rails.logger.broadcast_to(logtail_logger)
+
+  if Rails.logger.respond_to?(:broadcast_to)
+    Rails.logger.broadcast_to(logtail_logger)
+  else
+    Rails.logger = ActiveSupport::BroadcastLogger.new(Rails.logger, logtail_logger)
+  end
 end

--- a/config/initializers/logtail.rb
+++ b/config/initializers/logtail.rb
@@ -1,0 +1,7 @@
+source_token = ENV["BETTER_STACK_SOURCE_TOKEN"]
+ingesting_host = ENV["BETTER_STACK_INGESTING_HOST"]
+
+if source_token.present? && ingesting_host.present?
+  logtail_logger = Logtail::Logger.create_default_logger(source_token, ingesting_host: ingesting_host)
+  Rails.logger.broadcast_to(logtail_logger)
+end

--- a/config/initializers/logtail.rb
+++ b/config/initializers/logtail.rb
@@ -1,7 +1,7 @@
 source_token = ENV["BETTER_STACK_SOURCE_TOKEN"]
 ingesting_host = ENV["BETTER_STACK_INGESTING_HOST"]
 
-if source_token.present? && ingesting_host.present?
+if Rails.env.production? && source_token.present? && ingesting_host.present?
   logtail_logger = Logtail::Logger.create_default_logger(source_token, ingesting_host: ingesting_host)
   Rails.logger.broadcast_to(logtail_logger)
 end

--- a/spec/jobs/process_telegram_webhook_job_spec.rb
+++ b/spec/jobs/process_telegram_webhook_job_spec.rb
@@ -350,10 +350,12 @@ RSpec.describe ProcessTelegramWebhookJob do
         expect { described_class.new.perform(payload) }.not_to change(News, :count)
       end
 
-      it "logs the rejection at debug level" do
+      it "logs the rejection as structured JSON at debug level" do
         allow(Rails.logger).to receive(:debug)
         described_class.new.perform(payload)
-        expect(Rails.logger).to have_received(:debug).with(/rejected.*score=0.*threshold=10.*from_id=12345/)
+        expect(Rails.logger).to have_received(:debug).with(
+          a_string_matching(/"event":"telegram_webhook\.rejected".*"score":0.*"threshold":10.*"from_id":12345[,}]/)
+        )
       end
     end
 
@@ -376,10 +378,12 @@ RSpec.describe ProcessTelegramWebhookJob do
         expect(Telegram::NewsScorer).to have_received(:call).with(an_instance_of(Telegram::MessageParser::Result))
       end
 
-      it "logs the acceptance at info level" do
+      it "logs the acceptance as structured JSON at info level" do
         allow(Rails.logger).to receive(:info)
         described_class.new.perform(payload)
-        expect(Rails.logger).to have_received(:info).with(/accepted.*score=10.*threshold=10.*from_id=12345/)
+        expect(Rails.logger).to have_received(:info).with(
+          a_string_matching(/"event":"telegram_webhook\.accepted".*"score":10.*"threshold":10.*"from_id":12345[,}]/)
+        )
       end
     end
 

--- a/spec/services/telegram/news_scorer_spec.rb
+++ b/spec/services/telegram/news_scorer_spec.rb
@@ -420,11 +420,11 @@ RSpec.describe Telegram::NewsScorer do
         [ { "type" => "bold", "offset" => 0, "length" => 12 } ]
       end
 
-      it "logs the score breakdown at debug level" do
+      it "logs the score breakdown as structured JSON at debug level" do
         allow(Rails.logger).to receive(:debug)
         described_class.call(parsed_result)
         expect(Rails.logger).to have_received(:debug).with(
-          /NewsScorer.*formatting=2.*paragraph=3.*link=0.*photo=0.*keyword=0.*first_person=0.*question=0.*total=5/
+          a_string_matching(/"event":"news_scorer\.scored".*"total":5.*"formatting":2.*"paragraph":3.*"link":0.*"photo":0.*"keyword":0.*"first_person":0.*"question":0/)
         )
       end
     end


### PR DESCRIPTION
## Summary
- Add `logtail-rails` gem and `config/initializers/logtail.rb` that broadcasts a `Logtail::Logger` onto `Rails.logger` when both `BETTER_STACK_SOURCE_TOKEN` and `BETTER_STACK_INGESTING_HOST` are present (STDOUT / Kamal logs keep working).
- Wire the two env vars through `.kamal/secrets` and `config/deploy.yml` so Kamal injects them on deploy; leave them unset to disable shipping.
- Convert three hot log call sites in the Telegram intake pipeline to structured JSON so the events are queryable in Better Stack:
  - `Telegram::NewsScorer` → `news_scorer.scored` with the full score breakdown (debug)
  - `ProcessTelegramWebhookJob#below_score_threshold?` → `telegram_webhook.rejected` (debug) / `telegram_webhook.accepted` (info), each with `score`, `threshold`, `from_id`.

## Mutation testing
`Telegram::NewsScorer#call` + `ProcessTelegramWebhookJob#below_score_threshold?`:

- **Mutant**: 166/171 killed — 97.07% coverage. The 5 surviving mutants are all on `below_score_threshold?` and are pre-existing / equivalent / flaky:
  - `eba97` — `.to_i` → `Integer(...)` on threshold parsing. Pre-existing (not introduced by this PR); equivalent for well-formed integer strings.
  - `45739`, `a5cb9` — `Rails.logger.debug/info` → `self.logger.debug/info`. Equivalent: ActiveJob's `#logger` delegates to `Rails.logger`.
  - `a817e` — removes the explicit `true` return in the rejected branch. Flaky-neutral under fork isolation (same `let_it_be` factory slug-collision pattern seen in recent PRs).
  - `79d38` — `from_id: parsed.from_id` → `from_id: parsed`. Originally a real gap because the structured-JSON regex match was too loose; tightened the test regex with a trailing `[,}]` boundary to anchor on the numeric value.
- **Evilution**: not run — blocked by upstream [evilution#683](https://github.com/marinazzio/evilution/issues/683) (enum-reload crash during session setup). Mutant coverage stands alone for this PR.

## Test plan
- [ ] `bundle exec rspec spec/jobs/process_telegram_webhook_job_spec.rb spec/services/telegram/news_scorer_spec.rb` — green locally (34 + 39 examples).
- [ ] Full suite `bundle exec rspec` — 1935/1935 green.
- [ ] `bundle exec rubocop` on changed files — clean.
- [ ] Post-deploy: set `BETTER_STACK_SOURCE_TOKEN` and `BETTER_STACK_INGESTING_HOST` on the production host env, redeploy with `bin/kamal deploy`, then post a Telegram test message and confirm `news_scorer.scored` + `telegram_webhook.accepted` events land in the Better Stack source dashboard. Leaving both vars unset must keep STDOUT logging untouched.

Closes #752