### PR TITLE
vm-w9h: Grant reusable ci.yml the permissions it declares

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
 
   deploy:
     needs: ci


### PR DESCRIPTION
## Summary
Fixes the \`startup_failure\` on [v0.32.0 deploy run 24332360013](https://github.com/Port-Royal/vanilla-mafia/actions/runs/24332360013) (zero jobs instantiated).

## Root cause
vm-57 (#783) added \`permissions: security-events: write\` to the \`scan_ruby\` job in \`ci.yml\` so Brakeman could upload a SARIF report. \`deploy.yml\` calls \`ci.yml\` as a reusable workflow via \`uses: ./.github/workflows/ci.yml\`. GitHub Actions requires the **caller** to explicitly grant any permissions the reusable workflow requests — otherwise the run fails at startup before any job can begin.

v0.31.0 did not include #783, which is why that release deployed fine. v0.32.0 is the first tag cut after that merge, and it's the first one to hit this.

## Fix
Declare \`permissions\` on the \`ci\` job in \`deploy.yml\`:
- \`contents: read\` — default for \`actions/checkout\`
- \`security-events: write\` — what \`scan_ruby\` needs to upload SARIF
- \`actions: read\` — required by \`github/codeql-action/upload-sarif\`

## Test plan
- [ ] Merge this PR
- [ ] Cut a new tag (e.g. \`v0.32.1\`) and confirm the deploy workflow starts, runs ci + deploy jobs, and ships the image

Closes #793