### PR TITLE
vm-ct5: Address PR review comments for datetime formatting

### DIFF
--- a/app/controllers/datetime_formats_controller.rb
+++ b/app/controllers/datetime_formats_controller.rb
@@ -1,17 +1,17 @@
 class DatetimeFormatsController < ApplicationController
   def update
-    format = params[:datetime_format]
-    return redirect_back(fallback_location: root_path) unless valid_format?(format)
+    fmt = params[:datetime_format]
+    return redirect_back(fallback_location: root_path) unless valid_format?(fmt)
 
-    cookies[:datetime_format] = { value: format, expires: 1.year.from_now }
-    current_user.update!(datetime_format: format) if user_signed_in?
+    cookies[:datetime_format] = { value: fmt, expires: 1.year.from_now }
+    current_user.update!(datetime_format: fmt) if user_signed_in?
 
     redirect_back(fallback_location: root_path)
   end
 
   private
 
-  def valid_format?(format)
-    User.datetime_formats.key?(format.to_s)
+  def valid_format?(fmt)
+    User.datetime_formats.key?(fmt.to_s)
   end
 end

--- a/app/services/datetime_formatter.rb
+++ b/app/services/datetime_formatter.rb
@@ -13,7 +13,7 @@ class DatetimeFormatter
     },
     "us_12h" => {
       date: "%m/%d/%Y",
-      datetime: "%m/%d/%Y %-l:%M %p"
+      datetime: "%m/%d/%Y %-I:%M %p"
     }
   }.freeze
 

--- a/docs/superpowers/specs/2026-04-15-user-datetime-format-design.md
+++ b/docs/superpowers/specs/2026-04-15-user-datetime-format-design.md
@@ -91,15 +91,15 @@ Invalid cookie tz values are dropped silently (no flash, no error) to keep the u
 
 ### `app/services/datetime_formatter.rb` (new)
 
-Pure service. Input: a `Time`/`Date`/`DateTime`/`ActiveSupport::TimeWithZone`/`nil`, a `style` symbol (`:short` or `:long`), and optionally an explicit format key (defaults to `Current.datetime_format`). Output: formatted `String`.
+Pure service. Input: a `Time`/`Date`/`DateTime`/`ActiveSupport::TimeWithZone`/`nil` and a `type` symbol (`:date` or `:datetime`). The format key is resolved from `Current.datetime_format` (falling back to `DEFAULT_FORMAT`). Output: formatted `String`.
 
 Format strings live in a single nested constant:
 
 ```ruby
 FORMATS = {
-  european_24h: { short_date: "%d.%m.%Y", short_datetime: "%d.%m.%Y %H:%M", ... },
-  iso:          { short_date: "%Y-%m-%d", short_datetime: "%Y-%m-%d %H:%M", ... },
-  us_12h:       { short_date: "%m/%d/%Y", short_datetime: "%m/%d/%Y %-I:%M %p", ... }
+  "european_24h" => { date: "%d.%m.%Y", datetime: "%d.%m.%Y %H:%M" },
+  "iso"          => { date: "%Y-%m-%d", datetime: "%Y-%m-%d %H:%M" },
+  "us_12h"       => { date: "%m/%d/%Y", datetime: "%m/%d/%Y %-I:%M %p" }
 }.freeze
 ```
 
@@ -110,12 +110,12 @@ The service does not call `I18n.l`. It converts the input to `Current.time_zone`
 Two thin wrappers for view code:
 
 ```ruby
-def format_datetime(value, style: :short)
-  DatetimeFormatter.call(value, style: style, type: :datetime)
+def format_datetime(value)
+  DatetimeFormatter.call(value, type: :datetime)
 end
 
-def format_date(value, style: :short)
-  DatetimeFormatter.call(value, style: style, type: :date)
+def format_date(value)
+  DatetimeFormatter.call(value, type: :date)
 end
 ```
 


### PR DESCRIPTION
## Summary
- Rename `format` → `fmt` in `DatetimeFormatsController` to avoid shadowing `Kernel#format`
- Use `%-I` instead of `%-l` for 12-hour time directive (more conventional, consistent with design doc)
- Update design doc to match actual implementation API (`type:` param, string keys, `date`/`datetime` sub-keys)

Closes #800 review comments.

## Test plan
- [x] `spec/services/datetime_formatter_spec.rb` — 30 examples, 0 failures
- [x] `spec/requests/datetime_formats_spec.rb` — passes
- [x] Rubocop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)