### PR TITLE
vm-mqs: Refactor OBS overlay to horizontal row of 10 player cards

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -18,8 +18,8 @@ class GamesController < ApplicationController
     config[:font_size] = clamp_font_size(params[:font_size])
     config[:color] = sanitize_hex_color(params[:color])
     config[:hide_roles] = params[:hide_roles] == "1"
-    config[:hide_best_move] = params[:hide_best_move] == "1"
     config[:hide_seats] = params[:hide_seats] == "1"
+    config[:hide_status] = params[:hide_status] == "1"
     config
   end
 

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -1,8 +1,26 @@
 module GamesHelper
+  OVERLAY_STATUS_CLASSES = {
+    alive: "bg-green-700/70 text-green-100",
+    killed_by_mafia: "bg-red-700/70 text-red-100",
+    voted_out: "bg-orange-700/70 text-orange-100",
+    banned: "bg-gray-700/70 text-gray-100"
+  }.freeze
+
   def overlay_custom_style(config)
     parts = []
     parts << "font-size: #{config[:font_size]}px" if config[:font_size]
     parts << "color: ##{config[:color]}" if config[:color]
     parts.join("; ")
+  end
+
+  # Stubbed pending real status tracking — see vm-e4b / GH #812.
+  def overlay_player_status(participation)
+    return nil unless participation
+
+    :alive
+  end
+
+  def overlay_status_class(status)
+    OVERLAY_STATUS_CLASSES.fetch(status, "")
   end
 end

--- a/app/javascript/controllers/game_overlay_controller.js
+++ b/app/javascript/controllers/game_overlay_controller.js
@@ -3,7 +3,7 @@ import { createConsumer } from "@rails/actioncable"
 
 export default class extends Controller {
   static values = { gameId: Number, roleIconTemplate: String }
-  static targets = ["playerName", "roleCode", "bestMove"]
+  static targets = ["playerName", "roleCode", "status"]
 
   connect() {
     this.subscription = createConsumer().subscriptions.create(
@@ -49,9 +49,9 @@ export default class extends Controller {
       this.updateRoleDisplay(roleTarget, null)
     }
 
-    const bestMoveTarget = this.findTarget("best_move", seat)
-    if (bestMoveTarget) {
-      bestMoveTarget.textContent = ""
+    const statusTarget = this.findTarget("status", seat)
+    if (statusTarget) {
+      statusTarget.textContent = ""
     }
   }
 
@@ -67,7 +67,7 @@ export default class extends Controller {
     const mapping = {
       player_name: "playerName",
       role_code: "roleCode",
-      best_move: "bestMove"
+      status: "status"
     }
     return mapping[field]
   }
@@ -81,7 +81,7 @@ export default class extends Controller {
       img.src = src
       img.alt = roleCode
       img.title = roleCode
-      img.className = "inline-block h-5 w-5"
+      img.className = "inline-block h-4 w-4"
       target.appendChild(img)
     }
   }

--- a/app/views/games/overlay.html.erb
+++ b/app/views/games/overlay.html.erb
@@ -4,45 +4,57 @@
      data-controller="game-overlay"
      data-game-overlay-game-id-value="<%= @game.id %>"
      data-game-overlay-role-icon-template-value="<%= asset_path('roles/peace.png').sub('peace', '%ROLE_CODE%') %>"
+     class="flex gap-2 px-2 text-white"
      <% if custom_style.present? %>style="<%= custom_style %>"<% end %>>
-  <table class="w-full text-white text-sm">
-    <thead>
-      <tr class="text-left text-gray-400 border-b border-gray-700">
-        <% unless @overlay_config[:hide_seats] %>
-          <th class="px-2 py-1"><%= t(".seat") %></th>
-        <% end %>
-        <th class="px-2 py-1"><%= t(".player") %></th>
-        <% unless @overlay_config[:hide_roles] %>
-          <th class="px-2 py-1"><%= t(".role") %></th>
-        <% end %>
-        <% unless @overlay_config[:hide_best_move] %>
-          <th class="px-2 py-1"><%= t(".best_move") %></th>
-        <% end %>
-      </tr>
-    </thead>
-    <tbody>
-      <% (1..10).each do |seat| %>
-        <% participation = @participations_by_seat[seat] %>
-        <tr id="seat-<%= seat %>" class="border-b border-gray-800">
-          <% unless @overlay_config[:hide_seats] %>
-            <td class="px-2 py-1"><%= seat %></td>
-          <% end %>
-          <td class="px-2 py-1" data-game-overlay-target="playerName" data-seat="<%= seat %>"><%= participation&.player&.name %></td>
-          <% unless @overlay_config[:hide_roles] %>
-            <td class="px-2 py-1" data-game-overlay-target="roleCode" data-seat="<%= seat %>">
-              <% if participation&.role_code.present? %>
-                <%= image_tag "roles/#{participation.role_code}.png",
-                      alt: participation.role&.name.presence || participation.role_code,
-                      class: "inline-block h-5 w-5",
-                      title: participation.role&.name.presence || participation.role_code %>
-              <% end %>
-            </td>
-          <% end %>
-          <% unless @overlay_config[:hide_best_move] %>
-            <td class="px-2 py-1" data-game-overlay-target="bestMove" data-seat="<%= seat %>"><%= participation&.best_move %></td>
-          <% end %>
-        </tr>
+  <% (1..10).each do |seat| %>
+    <% participation = @participations_by_seat[seat] %>
+    <% player = participation ? participation.player : nil %>
+    <% role = participation ? participation.role : nil %>
+    <% status = overlay_player_status(participation) %>
+    <div id="seat-<%= seat %>" class="flex-1 min-w-0 flex flex-col items-center gap-1 rounded bg-black/40 p-2">
+      <% unless @overlay_config[:hide_seats] %>
+        <div class="self-start text-xs text-gray-400">#<%= seat %></div>
       <% end %>
-    </tbody>
-  </table>
+
+      <div class="w-full aspect-square overflow-hidden rounded">
+        <% if player && player.photo.attached? %>
+          <%= image_tag player.photo.variant(resize_to_fill: [ 200, 200 ]),
+                        alt: player.name,
+                        class: "w-full h-full object-cover" %>
+        <% else %>
+          <%= image_tag Player::DEFAULT_PHOTO_PATH,
+                        alt: player ? player.name : "",
+                        class: "w-full h-full object-cover" %>
+        <% end %>
+      </div>
+
+      <div class="w-full text-center font-semibold truncate"
+           data-game-overlay-target="playerName"
+           data-seat="<%= seat %>">
+        <%= player ? player.name : "" %>
+      </div>
+
+      <% unless @overlay_config[:hide_roles] %>
+        <div class="flex items-center gap-1 text-xs"
+             data-game-overlay-target="roleCode"
+             data-seat="<%= seat %>">
+          <% if participation && participation.role_code.present? %>
+            <%= image_tag "roles/#{participation.role_code}.png",
+                          alt: role && role.name.present? ? role.name : participation.role_code,
+                          class: "inline-block h-4 w-4",
+                          title: role && role.name.present? ? role.name : participation.role_code %>
+            <span><%= role && role.name.present? ? role.name : participation.role_code %></span>
+          <% end %>
+        </div>
+      <% end %>
+
+      <% unless @overlay_config[:hide_status] %>
+        <div class="text-xs px-2 py-0.5 rounded <%= overlay_status_class(status) %>"
+             data-game-overlay-target="status"
+             data-seat="<%= seat %>">
+          <%= status ? t("games.overlay.status.#{status}") : "" %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/help/pages/_obs-overlay.html.erb
+++ b/app/views/help/pages/_obs-overlay.html.erb
@@ -67,9 +67,9 @@
       <td><%= t(".param_hide_roles") %></td>
     </tr>
     <tr>
-      <td><code>hide_best_move</code></td>
-      <td><code>hide_best_move=1</code></td>
-      <td><%= t(".param_hide_best_move") %></td>
+      <td><code>hide_status</code></td>
+      <td><code>hide_status=1</code></td>
+      <td><%= t(".param_hide_status") %></td>
     </tr>
   </tbody>
 </table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -330,9 +330,9 @@ en:
         param_description: "Description"
         param_font_size: "Font size in pixels (8–72). Default is determined by the browser."
         param_color: "Text color as a hex code without #. For example, ffffff for white."
-        param_hide_seats: "Hide the seat number column."
-        param_hide_roles: "Hide the role column."
-        param_hide_best_move: "Hide the best move column."
+        param_hide_seats: "Hide seat numbers."
+        param_hide_roles: "Hide the role display."
+        param_hide_status: "Hide the player status pill."
         params_example_full: "Full example with all parameters:"
         params_example_url: "https://vanilla-mafia.ru/games/123/overlay?font_size=20&color=ffffff&hide_seats=1"
         judge_title: "Guide for Judges"
@@ -382,10 +382,11 @@ en:
         peace_victory: "City wins"
         mafia_victory: "Mafia wins"
     overlay:
-      seat: "Seat"
-      player: "Player"
-      role: "Role"
-      best_move: "Best move"
+      status:
+        alive: "Alive"
+        killed_by_mafia: "Killed"
+        voted_out: "Voted out"
+        banned: "Banned"
   series:
     show:
       player: "Player"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -156,9 +156,9 @@ ru:
         param_description: "Описание"
         param_font_size: "Размер шрифта в пикселях (8–72). По умолчанию определяется браузером."
         param_color: "Цвет текста в формате hex без #. Например, ffffff для белого."
-        param_hide_seats: "Скрыть колонку с номером места."
-        param_hide_roles: "Скрыть колонку с ролью."
-        param_hide_best_move: "Скрыть колонку лучшего хода."
+        param_hide_seats: "Скрыть номера мест."
+        param_hide_roles: "Скрыть отображение роли."
+        param_hide_status: "Скрыть плашку статуса игрока."
         params_example_full: "Полный пример со всеми параметрами:"
         params_example_url: "https://vanilla-mafia.ru/games/123/overlay?font_size=20&color=ffffff&hide_seats=1"
         judge_title: "Руководство для ведущего"
@@ -208,10 +208,11 @@ ru:
         peace_victory: "Победа мирных"
         mafia_victory: "Победа мафии"
     overlay:
-      seat: "Место"
-      player: "Игрок"
-      role: "Роль"
-      best_move: "Лучший ход"
+      status:
+        alive: "Жив"
+        killed_by_mafia: "Убит"
+        voted_out: "Повешен"
+        banned: "ППК"
   player_claims:
     create:
       pending: "Заявка отправлена и ожидает подтверждения."

--- a/spec/helpers/games_helper_spec.rb
+++ b/spec/helpers/games_helper_spec.rb
@@ -26,4 +26,38 @@ RSpec.describe GamesHelper do
       expect(helper.overlay_custom_style(config)).to eq("font-size: 16px; color: #00ff00")
     end
   end
+
+  describe "#overlay_player_status" do
+    it "returns nil when no participation is given" do
+      expect(helper.overlay_player_status(nil)).to be_nil
+    end
+
+    it "returns :alive for an existing participation (stubbed pending vm-e4b)" do
+      participation = instance_double(GameParticipation)
+
+      expect(helper.overlay_player_status(participation)).to eq(:alive)
+    end
+  end
+
+  describe "#overlay_status_class" do
+    it "returns a non-empty class string for alive" do
+      expect(helper.overlay_status_class(:alive)).to include("green")
+    end
+
+    it "returns a non-empty class string for killed_by_mafia" do
+      expect(helper.overlay_status_class(:killed_by_mafia)).to include("red")
+    end
+
+    it "returns a non-empty class string for voted_out" do
+      expect(helper.overlay_status_class(:voted_out)).to include("orange")
+    end
+
+    it "returns a non-empty class string for banned" do
+      expect(helper.overlay_status_class(:banned)).to include("gray")
+    end
+
+    it "returns an empty string for unknown status" do
+      expect(helper.overlay_status_class(:unknown)).to eq("")
+    end
+  end
 end

--- a/spec/requests/games_overlay_spec.rb
+++ b/spec/requests/games_overlay_spec.rb
@@ -33,7 +33,15 @@ RSpec.describe "Games#overlay" do
       expect(response.body).to include("game-overlay")
     end
 
-    it "displays player names with seat numbers" do
+    it "renders a card per seat (10 cards)" do
+      get overlay_game_path(game)
+
+      (1..10).each do |seat|
+        expect(response.body).to include(%(id="seat-#{seat}"))
+      end
+    end
+
+    it "displays player names inside their cards" do
       get overlay_game_path(game)
 
       expect(response.body).to include("Алексей")
@@ -45,6 +53,18 @@ RSpec.describe "Games#overlay" do
 
       expect(response.body).to include("sheriff")
       expect(response.body).to include("don")
+    end
+
+    it "renders a default photo placeholder for players without an attached photo" do
+      get overlay_game_path(game)
+
+      expect(response.body).to include(Player::DEFAULT_PHOTO_PATH)
+    end
+
+    it "renders a status pill with the default :alive status for every taken seat" do
+      get overlay_game_path(game)
+
+      expect(response.body.scan(I18n.t("games.overlay.status.alive")).size).to be >= 2
     end
 
     it "includes ActionCable subscription data for the game" do
@@ -116,22 +136,22 @@ RSpec.describe "Games#overlay" do
         expect(response.body).not_to include("color:")
       end
 
-      it "hides roles column when hide_roles param is set" do
+      it "hides role display when hide_roles param is set" do
         get overlay_game_path(game, hide_roles: "1")
 
         expect(response.body).not_to include("sheriff")
       end
 
-      it "hides best_move column when hide_best_move param is set" do
-        get overlay_game_path(game, hide_best_move: "1")
-
-        expect(response.body).not_to include(I18n.t("games.overlay.best_move"))
-      end
-
       it "hides seat numbers when hide_seats param is set" do
         get overlay_game_path(game, hide_seats: "1")
 
-        expect(response.body).not_to include(I18n.t("games.overlay.seat"))
+        expect(response.body).not_to include("#1")
+      end
+
+      it "hides status pill when hide_status param is set" do
+        get overlay_game_path(game, hide_status: "1")
+
+        expect(response.body).not_to include(I18n.t("games.overlay.status.alive"))
       end
     end
   end


### PR DESCRIPTION
## Summary

- Replaces the OBS overlay table with a flex row of 10 player cards. Each card shows photo · nickname · role icon+name · status pill.
- Status is stubbed to `:alive` for all taken seats. Real status tracking lands in the follow-up GH #812 / vm-e4b (driven by the game protocol).
- New URL param `hide_status=1`. `hide_best_move` was removed (the overlay no longer shows best move).
- Stimulus controller exposes a `status` target so the follow-up wires live updates without touching the view again.

## Mutation testing (GamesHelper)

- **Evilution 0.24.0**: 78/83 killed, 0 survived (score 1.0)
- **Mutant** (new methods `overlay_player_status`, `overlay_status_class`): 28/28 killed (100%). The 4 pre-existing survivors in `overlay_custom_style` are `[]` vs `.fetch` equivalent mutants, not introduced by this PR.

## Test plan

- [x] Open `/games/:slug/overlay` on an active game — expect 10 evenly-spaced cards in a single horizontal row
- [x] Verify each taken seat renders photo (or placeholder), nickname, role icon + name, and a green "Жив" pill
- [ ] Verify empty seats render a blank card with default photo placeholder
- [ ] Test URL params individually: `font_size=24`, `color=ff0000`, `hide_seats=1`, `hide_roles=1`, `hide_status=1`
- [ ] Confirm OBS background is still transparent (`body { background-color: rgba(0,0,0,0); }`)
- [ ] Trigger a judge-protocol save; verify the overlay updates player name and role live without refresh

Closes #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)