### PR TITLE
vm-77: Add table_number to game protocol

### DIFF
--- a/app/controllers/judge/protocols_controller.rb
+++ b/app/controllers/judge/protocols_controller.rb
@@ -102,7 +102,7 @@ class Judge::ProtocolsController < ApplicationController
   end
 
   def game_params
-    params.require(:game).permit(:game_number, :played_on, :name, :result, :judge, :competition_id, :stage_id, :new_stage_name)
+    params.require(:game).permit(:game_number, :played_on, :name, :result, :judge, :table_number, :competition_id, :stage_id, :new_stage_name)
   end
 
   def resolve_competition(gp)

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -18,6 +18,7 @@ class Game < ApplicationRecord
   validates :game_number, presence: true, numericality: { only_integer: true }
   validates :result, presence: true
   validates :game_number, uniqueness: { scope: :competition_id }
+  validates :table_number, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
 
   scope :for_competition, ->(competition) { where(competition: competition) }
   scope :ordered, -> { order(played_on: :asc, game_number: :asc) }

--- a/app/services/autosave_game_protocol_service.rb
+++ b/app/services/autosave_game_protocol_service.rb
@@ -1,7 +1,7 @@
 class AutosaveGameProtocolService
   Result = Data.define(:success, :errors)
 
-  GAME_FIELDS = %w[game_number played_on name result judge competition_id].freeze
+  GAME_FIELDS = %w[game_number played_on name result judge competition_id table_number].freeze
   PARTICIPATION_FIELDS = %w[player_name role_code plus minus best_move first_shoot notes].freeze
 
   def self.call(game:, scope:, field:, value:, seat: nil)

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -14,8 +14,12 @@
 </div>
 
 <p class="text-lg text-gray-600 mb-2"><%= t(".result.#{@game.result}") %></p>
+<% last_meta = @game.table_number.present? ? :table_number : (@game.judge.present? ? :judge : nil) %>
 <% if @game.judge.present? %>
-  <p class="text-sm text-gray-500 mb-6"><%= t(".judge", name: @game.judge) %></p>
+  <p class="text-sm text-gray-500 <%= last_meta == :judge ? 'mb-6' : 'mb-2' %>"><%= t(".judge", name: @game.judge) %></p>
+<% end %>
+<% if @game.table_number.present? %>
+  <p class="text-sm text-gray-500 mb-6"><%= t(".table_number", number: @game.table_number) %></p>
 <% end %>
 
 <div class="scroll-wrapper">

--- a/app/views/judge/protocols/_form.html.erb
+++ b/app/views/judge/protocols/_form.html.erb
@@ -35,6 +35,10 @@
       <input type="number" name="game[game_number]" id="game_game_number" value="<%= @game.game_number %>" class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm" required />
     </div>
     <div class="flex flex-col sm:flex-row items-center px-4 py-3 gap-2">
+      <label class="w-40 font-semibold text-sm text-right" for="game_table_number"><%= Game.human_attribute_name(:table_number) %></label>
+      <input type="number" name="game[table_number]" id="game_table_number" value="<%= @game.table_number %>" min="1" class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm" />
+    </div>
+    <div class="flex flex-col sm:flex-row items-center px-4 py-3 gap-2">
       <label class="w-40 font-semibold text-sm text-right" for="game_played_on"><%= Game.human_attribute_name(:played_on) %></label>
       <input type="date" name="game[played_on]" id="game_played_on" value="<%= @game.played_on %>" class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm" />
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,7 @@ en:
           group: "Group"
           fun_session: "Fun Session"
       game:
+        table_number: "Table number"
         results:
           in_progress: "In progress"
           peace_victory: "Peace victory"
@@ -377,6 +378,7 @@ en:
       best_move: "Best move"
       total: "Total"
       judge: "Judge: %{name}"
+      table_number: "Table: %{number}"
       result:
         in_progress: "In progress"
         peace_victory: "City wins"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -31,6 +31,7 @@ ru:
         name: "Название"
         result: "Результат"
         judge: "Ведущий"
+        table_number: "Номер стола"
         results:
           in_progress: "В процессе"
           peace_victory: "Победа мирных"
@@ -203,6 +204,7 @@ ru:
       best_move: "Лучший ход"
       total: "Итого"
       judge: "Ведущий: %{name}"
+      table_number: "Стол: %{number}"
       result:
         in_progress: "Игра в процессе"
         peace_victory: "Победа мирных"

--- a/db/migrate/20260418023325_add_table_number_to_games.rb
+++ b/db/migrate/20260418023325_add_table_number_to_games.rb
@@ -1,0 +1,5 @@
+class AddTableNumberToGames < ActiveRecord::Migration[8.1]
+  def change
+    add_column :games, :table_number, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_14_171053) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_18_023325) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -145,6 +145,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_14_171053) do
     t.date "played_on"
     t.string "result", default: "in_progress", null: false
     t.string "slug", null: false
+    t.integer "table_number"
     t.datetime "updated_at", null: false
     t.index ["competition_id", "game_number"], name: "index_games_on_competition_id_and_game_number", unique: true
     t.index ["competition_id"], name: "index_games_on_competition_id"

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -14,6 +14,29 @@ RSpec.describe Game, type: :model do
     it { is_expected.to validate_numericality_of(:game_number).only_integer }
     it { is_expected.to validate_uniqueness_of(:game_number).scoped_to(:competition_id) }
     it { is_expected.to define_enum_for(:result).with_values(described_class::RESULTS).backed_by_column_of_type(:string) }
+    it { is_expected.to validate_numericality_of(:table_number).only_integer.is_greater_than(0).allow_nil }
+
+    it "allows nil table_number" do
+      game = build(:game, table_number: nil)
+      expect(game).to be_valid
+    end
+
+    it "accepts positive integer table_number" do
+      game = build(:game, table_number: 3)
+      expect(game).to be_valid
+    end
+
+    it "rejects zero table_number" do
+      game = build(:game, table_number: 0)
+      expect(game).not_to be_valid
+      expect(game.errors[:table_number]).to be_present
+    end
+
+    it "rejects negative table_number" do
+      game = build(:game, table_number: -1)
+      expect(game).not_to be_valid
+      expect(game.errors[:table_number]).to be_present
+    end
 
     it 'rejects invalid result values' do
       game = build(:game)

--- a/spec/requests/judge/protocols_autosave_spec.rb
+++ b/spec/requests/judge/protocols_autosave_spec.rb
@@ -97,6 +97,26 @@ RSpec.describe "Judge::Protocols#autosave" do
           expect(game.reload.game_number).to eq(42)
         end
 
+        it "updates table_number" do
+          patch autosave_judge_protocol_path(game), params: {
+            scope: "game", field: "table_number", value: "5"
+          }, as: :json
+
+          expect(response).to have_http_status(:ok)
+          expect(game.reload.table_number).to eq(5)
+        end
+
+        it "clears table_number when given an empty value" do
+          game.update!(table_number: 2)
+
+          patch autosave_judge_protocol_path(game), params: {
+            scope: "game", field: "table_number", value: ""
+          }, as: :json
+
+          expect(response).to have_http_status(:ok)
+          expect(game.reload.table_number).to be_nil
+        end
+
         it "rejects disallowed fields" do
           patch autosave_judge_protocol_path(game), params: {
             scope: "game", field: "id", value: "999"

--- a/spec/requests/judge/protocols_spec.rb
+++ b/spec/requests/judge/protocols_spec.rb
@@ -229,6 +229,24 @@ RSpec.describe "Judge::Protocols" do
         end
       end
 
+      context "with table_number" do
+        let(:game_params) { { game_number: 88, result: "peace_victory", competition_id: competition.id, table_number: "3" } }
+
+        it "persists the submitted table_number" do
+          post judge_protocols_path, params: { game: game_params, participations: valid_participations_params }
+          expect(Game.last.table_number).to eq(3)
+        end
+      end
+
+      context "with blank table_number" do
+        let(:game_params) { { game_number: 87, result: "peace_victory", competition_id: competition.id, table_number: "" } }
+
+        it "stores nil table_number" do
+          post judge_protocols_path, params: { game: game_params, participations: valid_participations_params }
+          expect(Game.last.table_number).to be_nil
+        end
+      end
+
       context "with in_progress result" do
         let(:game_params) { { game_number: 95, result: "in_progress", competition_id: competition.id } }
 


### PR DESCRIPTION
## Summary

- Judges can record which table a game was played at — useful for tournaments running multiple tables simultaneously.
- Optional nullable `integer` column on `games`. Validated as positive integer when present.
- Input sits next to `game_number` on the protocol form; autosaves via the existing live channel (added to `AutosaveGameProtocolService::GAME_FIELDS`).
- Rendered on `games#show` under the judge line as `Стол: N` / `Table: N`.

## Mutation testing (Game)

- **Evilution 0.24.0**: 55/59 killed, 0 survived (score 1.0)
- **Mutant**: 82/83 killed (98.79%). The single alive mutant is in pre-existing `#slug_base`, not in new code.

## Test plan

- [ ] Open an existing game's protocol form; verify the new `Номер стола` input is present next to `Номер игры`
- [ ] Enter `2` and confirm autosave fires and persists (reload → value stays)
- [ ] Clear the value and confirm it saves as NULL
- [ ] Try submitting `0` or `-1` — should be rejected with a validation error
- [ ] Visit `games#show` for a game with `table_number` set — expect `Стол: 2` line below judge
- [ ] Visit `games#show` for a game without `table_number` — no extra line appears

Closes #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)