### PR TITLE
vm-jai: Add rack-attack rate limiting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,9 @@ gem "thruster", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 1.2"
 
+# Rate limiting and request throttling [https://github.com/rack/rack-attack]
+gem "rack-attack"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -422,6 +422,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-protection (4.2.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
@@ -682,6 +684,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   pundit
+  rack-attack
   rails (~> 8.1.2)
   rails-i18n
   rspec-rails
@@ -854,6 +857,7 @@ CHECKSUMS
   raabro (1.4.0) sha256=d4fa9ff5172391edb92b242eed8be802d1934b1464061ae5e70d80962c5da882
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
+  rack-attack (6.8.0) sha256=f2499fdebf85bcc05573a22dff57d24305ac14ec2e4156cd3c28d47cafeeecf2
   rack-protection (4.2.1) sha256=cf6e2842df8c55f5e4d1a4be015e603e19e9bc3a7178bae58949ccbb58558bac
   rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,38 +1,51 @@
 # frozen_string_literal: true
 
+module RackAttackConfig
+  module_function
+
+  def client_ip(req)
+    ActionDispatch::Request.new(req.env).remote_ip
+  end
+
+  def install_throttles!
+    Rack::Attack.throttle("req/ip", limit: 500, period: 5.minutes) do |req|
+      client_ip(req)
+    end
+
+    Rack::Attack.throttle("logins/ip", limit: 5, period: 1.minute) do |req|
+      client_ip(req) if req.path == "/users/sign_in" && req.post?
+    end
+
+    Rack::Attack.throttle("password_resets/email", limit: 3, period: 1.hour) do |req|
+      next unless req.path == "/users/password" && req.post?
+
+      email = req.params.dig("user", "email").to_s.downcase.strip
+      email.presence
+    end
+
+    Rack::Attack.throttle("password_resets/ip", limit: 10, period: 1.hour) do |req|
+      client_ip(req) if req.path == "/users/password" && req.post?
+    end
+
+    Rack::Attack.throttle("registrations/ip", limit: 5, period: 1.hour) do |req|
+      client_ip(req) if req.path == "/users" && req.post?
+    end
+  end
+
+  def subscribe_to_notifications!
+    ActiveSupport::Notifications.subscribe("throttle.rack_attack") do |_name, _start, _finish, _id, payload|
+      req = payload[:request]
+      Rails.logger.warn(
+        "[rack-attack] throttled #{req.env["rack.attack.matched"]} " \
+        "ip=#{client_ip(req)} path=#{req.path} method=#{req.request_method}"
+      )
+    end
+  end
+end
+
 return unless Rails.env.production?
 
 Rails.application.config.middleware.use Rack::Attack
-
 Rack::Attack.cache.store = Rails.cache
-
-Rack::Attack.throttle("req/ip", limit: 500, period: 5.minutes) do |req|
-  req.ip
-end
-
-Rack::Attack.throttle("logins/ip", limit: 5, period: 1.minute) do |req|
-  req.ip if req.path == "/users/sign_in" && req.post?
-end
-
-Rack::Attack.throttle("password_resets/email", limit: 3, period: 1.hour) do |req|
-  next unless req.path == "/users/password" && req.post?
-
-  email = req.params.dig("user", "email").to_s.downcase.strip
-  email.presence
-end
-
-Rack::Attack.throttle("password_resets/ip", limit: 10, period: 1.hour) do |req|
-  req.ip if req.path == "/users/password" && req.post?
-end
-
-Rack::Attack.throttle("registrations/ip", limit: 5, period: 1.hour) do |req|
-  req.ip if req.path == "/users" && req.post?
-end
-
-ActiveSupport::Notifications.subscribe("throttle.rack_attack") do |_name, _start, _finish, _id, payload|
-  req = payload[:request]
-  Rails.logger.warn(
-    "[rack-attack] throttled #{req.env["rack.attack.matched"]} " \
-    "ip=#{req.ip} path=#{req.path} method=#{req.request_method}"
-  )
-end
+RackAttackConfig.install_throttles!
+RackAttackConfig.subscribe_to_notifications!

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+return unless Rails.env.production?
+
+Rails.application.config.middleware.use Rack::Attack
+
+Rack::Attack.cache.store = Rails.cache
+
+Rack::Attack.throttle("req/ip", limit: 500, period: 5.minutes) do |req|
+  req.ip
+end
+
+Rack::Attack.throttle("logins/ip", limit: 5, period: 1.minute) do |req|
+  req.ip if req.path == "/users/sign_in" && req.post?
+end
+
+Rack::Attack.throttle("password_resets/email", limit: 3, period: 1.hour) do |req|
+  next unless req.path == "/users/password" && req.post?
+
+  email = req.params.dig("user", "email").to_s.downcase.strip
+  email.presence
+end
+
+Rack::Attack.throttle("password_resets/ip", limit: 10, period: 1.hour) do |req|
+  req.ip if req.path == "/users/password" && req.post?
+end
+
+Rack::Attack.throttle("registrations/ip", limit: 5, period: 1.hour) do |req|
+  req.ip if req.path == "/users" && req.post?
+end
+
+ActiveSupport::Notifications.subscribe("throttle.rack_attack") do |_name, _start, _finish, _id, payload|
+  req = payload[:request]
+  Rails.logger.warn(
+    "[rack-attack] throttled #{req.env["rack.attack.matched"]} " \
+    "ip=#{req.ip} path=#{req.path} method=#{req.request_method}"
+  )
+end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -2,33 +2,22 @@ require "rails_helper"
 
 RSpec.describe "Rack::Attack throttling", type: :request do
   before(:all) do
-    Rails.application.config.middleware.use(Rack::Attack) unless Rails.application.middleware.include?(Rack::Attack)
-    Rails.application.reload_routes!
+    @middleware_was_installed = Rails.application.middleware.include?(Rack::Attack)
+    Rails.application.config.middleware.use(Rack::Attack) unless @middleware_was_installed
+
     @original_store = Rack::Attack.cache.store
     Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
 
+    @original_throttles = Rack::Attack.throttles.dup
     Rack::Attack.throttles.clear
-    Rack::Attack.throttle("req/ip", limit: 500, period: 5.minutes) { |req| req.ip }
-    Rack::Attack.throttle("logins/ip", limit: 5, period: 1.minute) do |req|
-      req.ip if req.path == "/users/sign_in" && req.post?
-    end
-    Rack::Attack.throttle("password_resets/email", limit: 3, period: 1.hour) do |req|
-      next unless req.path == "/users/password" && req.post?
-
-      email = req.params.dig("user", "email").to_s.downcase.strip
-      email.presence
-    end
-    Rack::Attack.throttle("password_resets/ip", limit: 10, period: 1.hour) do |req|
-      req.ip if req.path == "/users/password" && req.post?
-    end
-    Rack::Attack.throttle("registrations/ip", limit: 5, period: 1.hour) do |req|
-      req.ip if req.path == "/users" && req.post?
-    end
+    RackAttackConfig.install_throttles!
   end
 
   after(:all) do
     Rack::Attack.cache.store = @original_store
     Rack::Attack.throttles.clear
+    @original_throttles.each { |name, throttle| Rack::Attack.throttles[name] = throttle }
+    Rails.application.config.middleware.delete(Rack::Attack) unless @middleware_was_installed
   end
 
   before { Rack::Attack.cache.store.clear }
@@ -115,7 +104,7 @@ RSpec.describe "Rack::Attack throttling", type: :request do
   describe "global per-IP throttle (500 / 5 min)" do
     it "eventually blocks on sustained traffic from a single IP" do
       Rack::Attack.throttles.delete("req/ip")
-      Rack::Attack.throttle("req/ip", limit: 3, period: 5.minutes) { |req| req.ip }
+      Rack::Attack.throttle("req/ip", limit: 3, period: 5.minutes) { |req| RackAttackConfig.client_ip(req) }
 
       3.times { get root_path, headers: ip_header("4.4.4.4") }
       get root_path, headers: ip_header("4.4.4.4")
@@ -123,7 +112,7 @@ RSpec.describe "Rack::Attack throttling", type: :request do
       expect(response).to have_http_status(:too_many_requests)
     ensure
       Rack::Attack.throttles.delete("req/ip")
-      Rack::Attack.throttle("req/ip", limit: 500, period: 5.minutes) { |req| req.ip }
+      Rack::Attack.throttle("req/ip", limit: 500, period: 5.minutes) { |req| RackAttackConfig.client_ip(req) }
     end
   end
 end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -1,0 +1,129 @@
+require "rails_helper"
+
+RSpec.describe "Rack::Attack throttling", type: :request do
+  before(:all) do
+    Rails.application.config.middleware.use(Rack::Attack) unless Rails.application.middleware.include?(Rack::Attack)
+    Rails.application.reload_routes!
+    @original_store = Rack::Attack.cache.store
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+
+    Rack::Attack.throttles.clear
+    Rack::Attack.throttle("req/ip", limit: 500, period: 5.minutes) { |req| req.ip }
+    Rack::Attack.throttle("logins/ip", limit: 5, period: 1.minute) do |req|
+      req.ip if req.path == "/users/sign_in" && req.post?
+    end
+    Rack::Attack.throttle("password_resets/email", limit: 3, period: 1.hour) do |req|
+      next unless req.path == "/users/password" && req.post?
+
+      email = req.params.dig("user", "email").to_s.downcase.strip
+      email.presence
+    end
+    Rack::Attack.throttle("password_resets/ip", limit: 10, period: 1.hour) do |req|
+      req.ip if req.path == "/users/password" && req.post?
+    end
+    Rack::Attack.throttle("registrations/ip", limit: 5, period: 1.hour) do |req|
+      req.ip if req.path == "/users" && req.post?
+    end
+  end
+
+  after(:all) do
+    Rack::Attack.cache.store = @original_store
+    Rack::Attack.throttles.clear
+  end
+
+  before { Rack::Attack.cache.store.clear }
+
+  def ip_header(ip)
+    { "REMOTE_ADDR" => ip }
+  end
+
+  describe "login throttle (5/min per IP)" do
+    it "allows 5 login attempts then blocks the 6th" do
+      5.times do
+        post user_session_path, params: { user: { email: "x@example.com", password: "nope" } }, headers: ip_header("1.2.3.4")
+        expect(response).not_to have_http_status(:too_many_requests)
+      end
+
+      post user_session_path, params: { user: { email: "x@example.com", password: "nope" } }, headers: ip_header("1.2.3.4")
+      expect(response).to have_http_status(:too_many_requests)
+    end
+
+    it "isolates counters by IP" do
+      5.times do
+        post user_session_path, params: { user: { email: "x@example.com", password: "nope" } }, headers: ip_header("1.2.3.4")
+      end
+
+      post user_session_path, params: { user: { email: "x@example.com", password: "nope" } }, headers: ip_header("5.6.7.8")
+      expect(response).not_to have_http_status(:too_many_requests)
+    end
+  end
+
+  describe "password reset throttle (3/hour per email)" do
+    it "blocks the 4th request for the same email across IPs" do
+      3.times do |i|
+        post user_password_path, params: { user: { email: "alice@example.com" } }, headers: ip_header("9.9.9.#{i}")
+        expect(response).not_to have_http_status(:too_many_requests)
+      end
+
+      post user_password_path, params: { user: { email: "alice@example.com" } }, headers: ip_header("9.9.9.99")
+      expect(response).to have_http_status(:too_many_requests)
+    end
+
+    it "normalizes email casing and whitespace" do
+      3.times do
+        post user_password_path, params: { user: { email: "Alice@example.com" } }, headers: ip_header("9.9.9.1")
+      end
+
+      post user_password_path, params: { user: { email: "  alice@EXAMPLE.com  " } }, headers: ip_header("9.9.9.2")
+      expect(response).to have_http_status(:too_many_requests)
+    end
+
+    it "tracks different emails separately" do
+      3.times do
+        post user_password_path, params: { user: { email: "alice@example.com" } }, headers: ip_header("9.9.9.1")
+      end
+
+      post user_password_path, params: { user: { email: "bob@example.com" } }, headers: ip_header("9.9.9.1")
+      expect(response).not_to have_http_status(:too_many_requests)
+    end
+  end
+
+  describe "password reset per-IP throttle (10/hour)" do
+    it "blocks the 11th request from the same IP even when emails rotate" do
+      10.times do |i|
+        post user_password_path, params: { user: { email: "user#{i}@example.com" } }, headers: ip_header("7.7.7.7")
+        expect(response).not_to have_http_status(:too_many_requests)
+      end
+
+      post user_password_path, params: { user: { email: "user11@example.com" } }, headers: ip_header("7.7.7.7")
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+
+  describe "registration throttle (5/hour per IP)" do
+    it "blocks the 6th registration attempt from the same IP" do
+      5.times do |i|
+        post user_registration_path, params: { user: { email: "new#{i}@example.com", password: "secret123", password_confirmation: "secret123" } }, headers: ip_header("3.3.3.3")
+        expect(response).not_to have_http_status(:too_many_requests)
+      end
+
+      post user_registration_path, params: { user: { email: "new6@example.com", password: "secret123", password_confirmation: "secret123" } }, headers: ip_header("3.3.3.3")
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+
+  describe "global per-IP throttle (500 / 5 min)" do
+    it "eventually blocks on sustained traffic from a single IP" do
+      Rack::Attack.throttles.delete("req/ip")
+      Rack::Attack.throttle("req/ip", limit: 3, period: 5.minutes) { |req| req.ip }
+
+      3.times { get root_path, headers: ip_header("4.4.4.4") }
+      get root_path, headers: ip_header("4.4.4.4")
+
+      expect(response).to have_http_status(:too_many_requests)
+    ensure
+      Rack::Attack.throttles.delete("req/ip")
+      Rack::Attack.throttle("req/ip", limit: 500, period: 5.minutes) { |req| req.ip }
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Addresses finding **H1** of the 2026-04-16 security audit: the app has no rate limiting. This PR installs [rack-attack](https://github.com/rack/rack-attack) and configures five throttles, all gated on `Rails.env.production?` so dev and test remain untouched.

## Throttles
| Name | Limit | Period | Key |
|---|---|---|---|
| `req/ip` (global) | 500 | 5 min | client IP |
| `logins/ip` | 5 | 1 min | client IP, only on `POST /users/sign_in` |
| `password_resets/email` | 3 | 1 hour | lowercased/stripped `user[email]` on `POST /users/password` |
| `password_resets/ip` | 10 | 1 hour | client IP on `POST /users/password` (caps email rotation) |
| `registrations/ip` | 5 | 1 hour | client IP, only on `POST /users` |

Store: `Rails.cache` (SolidCache). Throttled events are logged via an `ActiveSupport::Notifications` subscriber to `throttle.rack_attack` at `warn` level.

## Test plan
- [x] New `spec/requests/rack_attack_spec.rb` — 8 examples covering each throttle, IP isolation, email case-normalization, and different-email separation (8/8 pass)
- [x] `bundle exec rspec spec/requests/` — 755/755 pass
- [x] `bundle exec rubocop` clean on new files
- [x] `bundle exec brakeman` — 0 security warnings
- [ ] Manual production verification after deploy (hit login 6× from same IP and confirm 429)

## Notes
- Initializer is a no-op outside of production (`return unless Rails.env.production?`) to keep the dev/test experience identical.
- The per-IP password-reset throttle was added on top of the per-email one to prevent the trivial bypass where an attacker rotates emails.

Closes #802