### PR TITLE
vm-z1y: Enable Devise :lockable for account lockout

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable,
-         :omniauthable, omniauth_providers: [ :google_oauth2 ]
+         :lockable, :omniauthable, omniauth_providers: [ :google_oauth2 ]
 
   belongs_to :player, optional: true
   has_many :player_claims, dependent: :destroy

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -194,27 +194,11 @@ Devise.setup do |config|
   # config.timeout_in = 30.minutes
 
   # ==> Configuration for :lockable
-  # Defines which strategy will be used to lock an account.
-  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
-  # :none            = No lock strategy. You should handle locking by yourself.
-  # config.lock_strategy = :failed_attempts
-
-  # Defines which key will be used when locking and unlocking an account
-  # config.unlock_keys = [:email]
-
-  # Defines which strategy will be used to unlock an account.
-  # :email = Sends an unlock link to the user email
-  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
-  # :both  = Enables both strategies
-  # :none  = No unlock strategy. You should handle unlocking by yourself.
-  # config.unlock_strategy = :both
-
-  # Number of authentication tries before locking an account if lock_strategy
-  # is failed attempts.
-  # config.maximum_attempts = 20
-
-  # Time interval to unlock the account if :time is enabled as unlock_strategy.
-  # config.unlock_in = 1.hour
+  config.lock_strategy = :failed_attempts
+  config.unlock_keys = [ :email ]
+  config.unlock_strategy = :both
+  config.maximum_attempts = 5
+  config.unlock_in = 15.minutes
 
   # Warn on the last attempt before the account is locked.
   # config.last_attempt_warning = true

--- a/config/locales/devise.ru.yml
+++ b/config/locales/devise.ru.yml
@@ -69,6 +69,12 @@ ru:
       not_found_in_database: "Неверный %{authentication_keys} или пароль."
       timeout: "Сессия истекла. Войдите снова."
       unauthenticated: "Необходимо войти в систему."
+      locked: "Ваш аккаунт заблокирован."
+      last_attempt: "У вас остаётся одна попытка до блокировки аккаунта."
+    unlocks:
+      send_instructions: "Через несколько минут вы получите письмо с инструкциями по разблокировке аккаунта."
+      send_paranoid_instructions: "Если ваш аккаунт существует, через несколько минут вы получите письмо с инструкциями по разблокировке."
+      unlocked: "Аккаунт успешно разблокирован. Войдите, чтобы продолжить."
     shared:
       links:
         sign_in: "Войти"
@@ -80,6 +86,8 @@ ru:
     mailer:
       reset_password_instructions:
         subject: "Инструкции по сбросу пароля"
+      unlock_instructions:
+        subject: "Инструкции по разблокировке аккаунта"
   errors:
     messages:
       not_saved:

--- a/db/migrate/20260418123038_add_lockable_to_users.rb
+++ b/db/migrate/20260418123038_add_lockable_to_users.rb
@@ -1,0 +1,11 @@
+class AddLockableToUsers < ActiveRecord::Migration[8.1]
+  def change
+    change_table :users, bulk: true do |t|
+      t.integer :failed_attempts, default: 0, null: false
+      t.string :unlock_token
+      t.datetime :locked_at
+    end
+
+    add_index :users, :unlock_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_18_023325) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_18_123038) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -330,7 +330,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_18_023325) do
     t.string "datetime_format", default: "european_24h", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
+    t.integer "failed_attempts", default: 0, null: false
     t.string "locale", default: "ru", null: false
+    t.datetime "locked_at"
     t.boolean "notify_on_news_draft", default: true, null: false
     t.integer "player_id"
     t.string "provider"
@@ -338,11 +340,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_18_023325) do
     t.datetime "reset_password_sent_at"
     t.string "reset_password_token"
     t.string "uid"
+    t.string "unlock_token"
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["player_id"], name: "index_users_on_player_id", unique: true
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,12 +16,51 @@ RSpec.describe User, type: :model do
     it "configures google_oauth2 as omniauth provider" do
       expect(User.omniauth_providers).to include(:google_oauth2)
     end
+
+    it "includes lockable" do
+      expect(User.devise_modules).to include(:lockable)
+    end
   end
 
   describe "database columns" do
     it { is_expected.to have_db_column(:provider).of_type(:string) }
     it { is_expected.to have_db_column(:uid).of_type(:string) }
     it { is_expected.to have_db_index(%i[provider uid]).unique }
+    it { is_expected.to have_db_column(:failed_attempts).of_type(:integer).with_options(default: 0, null: false) }
+    it { is_expected.to have_db_column(:unlock_token).of_type(:string) }
+    it { is_expected.to have_db_column(:locked_at).of_type(:datetime) }
+    it { is_expected.to have_db_index(:unlock_token).unique }
+  end
+
+  describe "lockable behavior" do
+    let(:user) { create(:user) }
+
+    it "locks the account after 5 failed attempts" do
+      5.times { user.valid_for_authentication? { false } }
+      expect(user.reload.access_locked?).to be true
+    end
+
+    it "does not lock after 4 failed attempts" do
+      4.times { user.valid_for_authentication? { false } }
+      expect(user.reload.access_locked?).to be false
+    end
+
+    it "auto-unlocks after the configured unlock_in window has passed" do
+      5.times { user.valid_for_authentication? { false } }
+      user.update!(locked_at: 16.minutes.ago)
+      expect(user.access_locked?).to be false
+    end
+
+    it "stays locked while still inside the unlock_in window" do
+      5.times { user.valid_for_authentication? { false } }
+      user.update!(locked_at: 14.minutes.ago)
+      expect(user.access_locked?).to be true
+    end
+
+    it "generates an unlock token when locking via :both unlock strategy" do
+      5.times { user.valid_for_authentication? { false } }
+      expect(user.reload.unlock_token).to be_present
+    end
   end
 
   describe "validations" do

--- a/spec/requests/devise/unlocks_spec.rb
+++ b/spec/requests/devise/unlocks_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe "Devise::Unlocks" do
+  let(:password) { "Str0ng!pass" }
+  let(:user) { create(:user, password: password) }
+
+  describe "POST /users/sign_in with bad password" do
+    it "locks the account after the configured maximum_attempts" do
+      Devise.maximum_attempts.times do
+        post user_session_path, params: { user: { email: user.email, password: "wrong" } }
+      end
+
+      expect(user.reload.access_locked?).to be true
+    end
+
+    it "rejects sign-in for a locked account even with the correct password" do
+      user.lock_access!
+      post user_session_path, params: { user: { email: user.email, password: password } }
+
+      expect(response.body).to include(I18n.t("devise.failure.locked"))
+    end
+  end
+
+  describe "GET /users/unlock" do
+    let(:locked_user) { create(:user, password: password) }
+
+    it "unlocks the account when given a valid token" do
+      raw_token, encrypted_token = Devise.token_generator.generate(User, :unlock_token)
+      locked_user.update_columns(unlock_token: encrypted_token, locked_at: Time.current, failed_attempts: Devise.maximum_attempts)
+
+      get user_unlock_path, params: { unlock_token: raw_token }
+
+      expect(locked_user.reload.access_locked?).to be false
+    end
+
+    it "leaves the account locked for an invalid token" do
+      locked_user.lock_access!
+
+      get user_unlock_path, params: { unlock_token: "bogus" }
+
+      expect(locked_user.reload.access_locked?).to be true
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Addresses finding **H2** of the 2026-04-16 security audit: there was no per-account lockout, so brute-force attempts were only bounded by the per-IP rack-attack throttle (vm-jai). This PR enables Devise's `:lockable` module with a 5-attempt threshold and a 15-minute auto-unlock.

## Changes
- **Migration** `20260418123038_add_lockable_to_users.rb` — bulk add `failed_attempts (int default 0 not null)`, `unlock_token (string)`, `locked_at (datetime)` and a unique index on `unlock_token`.
- **`User`** — adds `:lockable` to the devise modules list.
- **`config/initializers/devise.rb`** — uncomments and sets:
  - `lock_strategy = :failed_attempts`
  - `unlock_keys = [:email]`
  - `unlock_strategy = :both`
  - `maximum_attempts = 5`
  - `unlock_in = 15.minutes`
- **`config/locales/devise.ru.yml`** — adds missing translations for `failure.locked`, `failure.last_attempt`, `unlocks.*`, and `mailer.unlock_instructions.subject` (the en file already had them; ru did not).

## Tests
- `spec/models/user_spec.rb`: includes-`:lockable` assertion, the three new db columns, the unique unlock_token index, and lockable behavior (locks at 5 attempts, not at 4, auto-unlocks after 15 min, stays locked inside the window, generates an unlock_token).
- `spec/requests/devise/unlocks_spec.rb`: end-to-end — exhausting attempts at `POST /users/sign_in` locks the account, a locked account is rejected even with the correct password, `GET /users/unlock?unlock_token=` with a valid token unlocks, with an invalid token does not.

## Test plan
- [x] `bundle exec rspec spec/` — 2018/2018 pass
- [x] `bundle exec rubocop` — clean on changed files
- [x] `bundle exec brakeman` — 0 security warnings
- [x] Mutation testing on `User`:
  - Evilution: 100.00% (120/120 mutants killed)
  - Mutant: 99.38% (162/163; the one survivor is pre-existing `pending_dispute?`, not introduced by this PR)
- [ ] Manual: with the migration applied locally, attempt 5 bad logins → 6th login (even with correct password) is blocked with the locked message; wait 15 min → can sign in again.

Closes #803