### PR TITLE
vm-4bk: Enable Devise :timeoutable for session timeout

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable,
-         :lockable, :omniauthable, omniauth_providers: [ :google_oauth2 ]
+         :lockable, :timeoutable, :omniauthable, omniauth_providers: [ :google_oauth2 ]
 
   belongs_to :player, optional: true
   has_many :player_claims, dependent: :destroy

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -191,7 +191,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 2.weeks
 
   # ==> Configuration for :lockable
   config.lock_strategy = :failed_attempts

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe User, type: :model do
     it "includes lockable" do
       expect(User.devise_modules).to include(:lockable)
     end
+
+    it "includes timeoutable" do
+      expect(User.devise_modules).to include(:timeoutable)
+    end
+
+    it "configures timeout_in to 2 weeks" do
+      expect(Devise.timeout_in).to eq(2.weeks)
+    end
   end
 
   describe "database columns" do
@@ -436,6 +444,16 @@ RSpec.describe User, type: :model do
 
     context "when user has only non-pending dispute claims" do
       before { create(:player_claim, :dispute, user: user, player: player, status: "rejected") }
+
+      it "returns false" do
+        expect(user.pending_dispute?).to be false
+      end
+    end
+
+    context "when user has a pending non-dispute claim" do
+      let(:other_player) { create(:player) }
+
+      before { create(:player_claim, user: user, player: other_player, status: "pending") }
 
       it "returns false" do
         expect(user.pending_dispute?).to be false


### PR DESCRIPTION
## Summary
- Add `:timeoutable` to User model + `config.timeout_in = 2.weeks` in Devise initializer (security audit M1).
- Matches Devise's default `remember_for` so `:rememberable` flow is unaffected.
- Tighten `User#pending_dispute?` spec coverage — add pending-non-dispute case (kills mutant survivor).

Closes #807

## Mutation testing
- Evilution: 100% (120/120 mutants killed)
- Mutant: 100% (163/163 mutants killed)

## Test plan
- [x] `bundle exec rspec spec/models/user_spec.rb` → 68 examples, 0 failures
- [x] `bundle exec mutant run -- 'User'` → 163/163 killed
- [x] `bundle exec evilution run app/models/user.rb` → 120/120 killed
- [x] `bundle exec rubocop app/models/user.rb config/initializers/devise.rb spec/models/user_spec.rb` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)