### PR TITLE
vm-vp2: Enable Devise paranoid mode and change notifications

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -90,7 +90,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # particular strategies by setting this option.
@@ -129,10 +129,10 @@ Devise.setup do |config|
   # config.pepper = 'faa0841ba51b989c30a8b5090885d6487dd2c016c64633204b8ae627c5f37eb34530c03958e9d6703b87cef6748ad215666300b69fd2065d8e28639c4bf2d643'
 
   # Send a notification to the original email when the user's email is changed.
-  # config.send_email_changed_notification = false
+  config.send_email_changed_notification = true
 
   # Send a notification email when the user's password is changed.
-  # config.send_password_change_notification = false
+  config.send_password_change_notification = true
 
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without

--- a/config/locales/devise.ru.yml
+++ b/config/locales/devise.ru.yml
@@ -88,6 +88,10 @@ ru:
         subject: "Инструкции по сбросу пароля"
       unlock_instructions:
         subject: "Инструкции по разблокировке аккаунта"
+      email_changed:
+        subject: "Email был изменён"
+      password_change:
+        subject: "Пароль был изменён"
   errors:
     messages:
       not_saved:

--- a/spec/models/user_notifications_spec.rb
+++ b/spec/models/user_notifications_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe User, type: :model do
+  describe "account change notifications" do
+    let(:user) { create(:user) }
+
+    before { ActionMailer::Base.deliveries.clear }
+
+    describe "email change" do
+      it "sends an email_changed notification to the original email" do
+        original_email = user.email
+        new_email = "new-#{SecureRandom.hex(4)}@example.com"
+
+        user.update!(email: new_email)
+
+        mail = ActionMailer::Base.deliveries.last
+        expect(mail.subject).to eq(I18n.t("devise.mailer.email_changed.subject"))
+        expect(mail.to).to eq([ original_email ])
+      end
+
+      it "does not send a notification when email is unchanged" do
+        user
+
+        expect {
+          user.update!(notify_on_news_draft: false)
+        }.not_to(change { ActionMailer::Base.deliveries.size })
+      end
+    end
+
+    describe "password change" do
+      it "sends a password_change notification to the current email" do
+        user.update!(password: "NewStr0ng!pass23", password_confirmation: "NewStr0ng!pass23")
+
+        mail = ActionMailer::Base.deliveries.last
+        expect(mail.subject).to eq(I18n.t("devise.mailer.password_change.subject"))
+        expect(mail.to).to eq([ user.email ])
+      end
+
+      it "does not send a notification when password is unchanged" do
+        user
+
+        expect {
+          user.update!(notify_on_news_draft: false)
+        }.not_to(change { ActionMailer::Base.deliveries.size })
+      end
+    end
+  end
+end

--- a/spec/requests/devise/passwords_spec.rb
+++ b/spec/requests/devise/passwords_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Devise::Passwords" do
+  describe "POST /users/password (paranoid mode)" do
+    let(:existing_user) { create(:user) }
+
+    it "shows the generic paranoid flash for an unknown email" do
+      post user_password_path, params: { user: { email: "no-such-user@example.com" } }
+
+      expect(flash[:notice]).to eq(I18n.t("devise.passwords.send_paranoid_instructions"))
+    end
+
+    it "shows the generic paranoid flash for a known email" do
+      post user_password_path, params: { user: { email: existing_user.email } }
+
+      expect(flash[:notice]).to eq(I18n.t("devise.passwords.send_paranoid_instructions"))
+    end
+
+    it "redirects to sign_in in both cases so outcome is indistinguishable" do
+      post user_password_path, params: { user: { email: "no-such-user@example.com" } }
+      expect(response).to redirect_to(new_user_session_path)
+
+      post user_password_path, params: { user: { email: existing_user.email } }
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+end

--- a/spec/requests/devise/unlocks_spec.rb
+++ b/spec/requests/devise/unlocks_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe "Devise::Unlocks" do
       user.lock_access!
       post user_session_path, params: { user: { email: user.email, password: password } }
 
-      expect(response.body).to include(I18n.t("devise.failure.locked"))
+      expect(controller.warden.user).to be_nil
+      expect(response).not_to redirect_to(root_path)
     end
   end
 


### PR DESCRIPTION
## Summary
- `config.paranoid = true` — password reset, unlock, and locked-account sign-in all return the same generic message (security audit M2 — user enumeration).
- `config.send_email_changed_notification = true` — notify old email on email change.
- `config.send_password_change_notification = true` — notify current email on password change (security audit M3).
- Added RU subjects for `devise.mailer.email_changed` / `password_change`.
- Updated lockable spec: paranoid mode suppresses the "locked" flash, so assert `warden.user.nil?` instead.

Devise 5.x provides `send_email_changed_notification` from `:database_authenticatable`, so `:confirmable` isn't required.

Closes #808

## Mutation testing (User)
- Evilution: 100% (120/120 mutants killed)
- Mutant: 100% (163/163 mutants killed)

## Test plan
- [x] `bundle exec rspec spec` → 2065 examples, 0 failures
- [x] `bundle exec mutant run -- 'User'` → 163/163 killed
- [x] `bundle exec evilution run app/models/user.rb` → 120/120 killed
- [x] `bundle exec rubocop ...` → clean
- [x] New: `spec/requests/devise/passwords_spec.rb` (paranoid mode)
- [x] New: `spec/models/user_notifications_spec.rb` (email/password change notifications)

🤖 Generated with [Claude Code](https://claude.com/claude-code)