### PR TITLE
vm-dn8: Enable host validation and Permissions-Policy header

### DIFF
--- a/app/middleware/permissions_policy_header.rb
+++ b/app/middleware/permissions_policy_header.rb
@@ -1,0 +1,22 @@
+class PermissionsPolicyHeader
+  HEADER_NAME = "Permissions-Policy"
+  HEADER_VALUE = [
+    "camera=()",
+    "microphone=()",
+    "geolocation=()",
+    "gyroscope=()",
+    "usb=()",
+    "payment=()",
+    "fullscreen=(self)"
+  ].join(", ").freeze
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    status, headers, body = @app.call(env)
+    headers[HEADER_NAME] ||= HEADER_VALUE
+    [ status, headers, body ]
+  end
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,11 +76,12 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  #
+  config.hosts = [
+    "vanilla-mafia.ru",
+    /.*\.vanilla-mafia\.ru/
+  ]
+  config.hosts << ENV["APPLICATION_HOST"] if ENV["APPLICATION_HOST"].present?
+
   # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end

--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -1,0 +1,3 @@
+require Rails.root.join("app/middleware/permissions_policy_header")
+
+Rails.application.config.middleware.use PermissionsPolicyHeader

--- a/spec/config/production_environment_spec.rb
+++ b/spec/config/production_environment_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe "config/environments/production.rb host validation" do
+  let(:config) do
+    c = ActiveSupport::OrderedOptions.new
+    c.hosts = []
+    c
+  end
+
+  def evaluate_production_hosts_block
+    source = Rails.root.join("config/environments/production.rb").read
+    match = source.match(/Rails\.application\.configure do\n(.*)\nend\n\z/m)
+    raise "Could not find Rails.application.configure block" unless match
+
+    body = match[1]
+    host_section = body.match(/^  # Enable DNS rebinding protection.*?^  config\.host_authorization = [^\n]+$/m)
+    raise "Could not find host config section" unless host_section
+
+    config_ref = config
+    eval_context = Object.new
+    eval_context.define_singleton_method(:config) { config_ref }
+    eval_context.instance_eval(host_section[0])
+  end
+
+  around do |example|
+    original_host = ENV["APPLICATION_HOST"]
+    ENV["APPLICATION_HOST"] = nil
+    example.run
+  ensure
+    ENV["APPLICATION_HOST"] = original_host
+  end
+
+  it "whitelists the canonical production domain" do
+    evaluate_production_hosts_block
+    expect(config.hosts).to include("vanilla-mafia.ru")
+  end
+
+  it "whitelists subdomains of the production domain" do
+    evaluate_production_hosts_block
+    subdomain_matcher = config.hosts.find { |h| h.is_a?(Regexp) }
+    expect(subdomain_matcher).to match("www.vanilla-mafia.ru")
+    expect(subdomain_matcher).not_to match("evil.example.com")
+  end
+
+  it "appends APPLICATION_HOST when present" do
+    ENV["APPLICATION_HOST"] = "staging.example.com"
+    evaluate_production_hosts_block
+    expect(config.hosts).to include("staging.example.com")
+  end
+
+  it "does not append APPLICATION_HOST when blank" do
+    ENV["APPLICATION_HOST"] = ""
+    evaluate_production_hosts_block
+    expect(config.hosts).not_to include("")
+  end
+
+  it "excludes the /up health check from host authorization" do
+    evaluate_production_hosts_block
+    request = Struct.new(:path).new("/up")
+    expect(config.host_authorization[:exclude].call(request)).to be true
+  end
+
+  it "enforces host authorization for non-health-check paths" do
+    evaluate_production_hosts_block
+    request = Struct.new(:path).new("/admin")
+    expect(config.host_authorization[:exclude].call(request)).to be false
+  end
+end

--- a/spec/middleware/permissions_policy_header_spec.rb
+++ b/spec/middleware/permissions_policy_header_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.describe PermissionsPolicyHeader do
+  let(:downstream_status) { 200 }
+  let(:downstream_headers) { {} }
+  let(:downstream_body) { [ "ok" ] }
+  let(:downstream_response) { [ downstream_status, downstream_headers, downstream_body ] }
+  let(:app) { ->(_env) { downstream_response } }
+  let(:middleware) { described_class.new(app) }
+
+  describe "#call" do
+    it "returns the downstream status unchanged" do
+      status, _, _ = middleware.call({})
+      expect(status).to eq(200)
+    end
+
+    it "returns the downstream body unchanged" do
+      _, _, body = middleware.call({})
+      expect(body).to eq([ "ok" ])
+    end
+
+    it "sets the Permissions-Policy header" do
+      _, headers, _ = middleware.call({})
+      expect(headers["Permissions-Policy"]).to eq(described_class::HEADER_VALUE)
+    end
+
+    it "does not overwrite a pre-existing Permissions-Policy header" do
+      downstream_headers["Permissions-Policy"] = "camera=(self)"
+      _, headers, _ = middleware.call({})
+      expect(headers["Permissions-Policy"]).to eq("camera=(self)")
+    end
+
+    it "passes the rack env unchanged to the downstream app" do
+      captured_env = nil
+      capturing_app = ->(env) { captured_env = env; downstream_response }
+      middleware = described_class.new(capturing_app)
+
+      input_env = { "PATH_INFO" => "/foo" }
+      middleware.call(input_env)
+
+      expect(captured_env).to equal(input_env)
+    end
+  end
+
+  describe "HEADER_VALUE" do
+    it "disables camera access" do
+      expect(described_class::HEADER_VALUE).to include("camera=()")
+    end
+
+    it "disables microphone access" do
+      expect(described_class::HEADER_VALUE).to include("microphone=()")
+    end
+
+    it "disables geolocation access" do
+      expect(described_class::HEADER_VALUE).to include("geolocation=()")
+    end
+
+    it "disables gyroscope access" do
+      expect(described_class::HEADER_VALUE).to include("gyroscope=()")
+    end
+
+    it "disables USB access" do
+      expect(described_class::HEADER_VALUE).to include("usb=()")
+    end
+
+    it "disables payment access" do
+      expect(described_class::HEADER_VALUE).to include("payment=()")
+    end
+
+    it "restricts fullscreen to same origin" do
+      expect(described_class::HEADER_VALUE).to include("fullscreen=(self)")
+    end
+
+    it "is frozen" do
+      expect(described_class::HEADER_VALUE).to be_frozen
+    end
+  end
+end

--- a/spec/requests/security_headers_spec.rb
+++ b/spec/requests/security_headers_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "Security headers" do
+  describe "Permissions-Policy" do
+    it "sets a restrictive Permissions-Policy header on responses" do
+      get root_path
+
+      header = response.headers["Permissions-Policy"]
+      expect(header).to be_present
+    end
+
+    it "disables camera, microphone, geolocation, and payment" do
+      get root_path
+
+      header = response.headers["Permissions-Policy"]
+      expect(header).to include("camera=()")
+      expect(header).to include("microphone=()")
+      expect(header).to include("geolocation=()")
+      expect(header).to include("payment=()")
+    end
+
+    it "restricts fullscreen to same origin" do
+      get root_path
+
+      expect(response.headers["Permissions-Policy"]).to include("fullscreen=(self)")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Production `config.hosts` whitelists `vanilla-mafia.ru` + subdomains (security audit M4 — DNS rebinding / Host header attacks).
- `APPLICATION_HOST` env var can add an extra host for staging/preview.
- `/up` health check excluded from host authorization.
- New `PermissionsPolicyHeader` rack middleware emits the modern `Permissions-Policy` header (security audit M5). Rails' built-in DSL only sets the deprecated `Feature-Policy`, so a custom middleware is required.
- Policy: `camera=()`, `microphone=()`, `geolocation=()`, `gyroscope=()`, `usb=()`, `payment=()`, `fullscreen=(self)`.

Closes #809

## Mutation testing (PermissionsPolicyHeader)
- Evilution: 100% (16/16 killed)
- Mutant: 100% (29/29 killed)

## Test plan
- [x] `bundle exec rspec spec` → 2087 examples, 0 failures
- [x] `bundle exec mutant run -- 'PermissionsPolicyHeader'` → 29/29 killed
- [x] `bundle exec evilution run app/middleware/permissions_policy_header.rb` → 16/16 killed
- [x] `bundle exec rubocop …` → clean
- [x] New: `spec/middleware/permissions_policy_header_spec.rb`, `spec/requests/security_headers_spec.rb`, `spec/config/production_environment_spec.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)