### PR TITLE
vm-e4b: Track player status on GameParticipation

### DIFF
--- a/app/controllers/judge/protocols_controller.rb
+++ b/app/controllers/judge/protocols_controller.rb
@@ -160,7 +160,7 @@ class Judge::ProtocolsController < ApplicationController
       gp.best_move = attrs[:best_move].presence
       gp.first_shoot = attrs[:first_shoot] == "1"
       gp.notes = attrs[:notes].presence
-      gp.status = attrs[:status] if attrs[:status].present?
+      gp.status = attrs[:status] if GameParticipation.statuses.key?(attrs[:status].to_s)
       gp
     end
   end

--- a/app/controllers/judge/protocols_controller.rb
+++ b/app/controllers/judge/protocols_controller.rb
@@ -122,7 +122,7 @@ class Judge::ProtocolsController < ApplicationController
   end
 
   def participations_params
-    permitted_keys = (1..10).map { |i| [ i.to_s, [ :player_name, :role_code, :plus, :minus, :best_move, :first_shoot, :notes ] ] }
+    permitted_keys = (1..10).map { |i| [ i.to_s, [ :player_name, :role_code, :plus, :minus, :best_move, :first_shoot, :notes, :status ] ] }
     params.require(:participations).permit(permitted_keys.to_h)
   end
 
@@ -160,6 +160,7 @@ class Judge::ProtocolsController < ApplicationController
       gp.best_move = attrs[:best_move].presence
       gp.first_shoot = attrs[:first_shoot] == "1"
       gp.notes = attrs[:notes].presence
+      gp.status = attrs[:status] if attrs[:status].present?
       gp
     end
   end

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -13,11 +13,10 @@ module GamesHelper
     parts.join("; ")
   end
 
-  # Stubbed pending real status tracking — see vm-e4b / GH #812.
   def overlay_player_status(participation)
     return nil unless participation
 
-    :alive
+    participation.status.to_sym
   end
 
   def overlay_status_class(status)

--- a/app/javascript/controllers/game_overlay_controller.js
+++ b/app/javascript/controllers/game_overlay_controller.js
@@ -58,7 +58,7 @@ export default class extends Controller {
 
     const statusTarget = this.findTarget("status", seat)
     if (statusTarget) {
-      statusTarget.textContent = ""
+      this.updateStatusDisplay(statusTarget, null)
     }
   }
 

--- a/app/javascript/controllers/game_overlay_controller.js
+++ b/app/javascript/controllers/game_overlay_controller.js
@@ -2,7 +2,12 @@ import { Controller } from "@hotwired/stimulus"
 import { createConsumer } from "@rails/actioncable"
 
 export default class extends Controller {
-  static values = { gameId: Number, roleIconTemplate: String }
+  static values = {
+    gameId: Number,
+    roleIconTemplate: String,
+    statusClasses: Object,
+    statusLabels: Object
+  }
   static targets = ["playerName", "roleCode", "status"]
 
   connect() {
@@ -33,6 +38,8 @@ export default class extends Controller {
     if (target) {
       if (field === "role_code") {
         this.updateRoleDisplay(target, value)
+      } else if (field === "status") {
+        this.updateStatusDisplay(target, value)
       } else {
         target.textContent = value || ""
       }
@@ -70,6 +77,21 @@ export default class extends Controller {
       status: "status"
     }
     return mapping[field]
+  }
+
+  updateStatusDisplay(target, statusKey) {
+    const classMap = this.hasStatusClassesValue ? this.statusClassesValue : {}
+    const labelMap = this.hasStatusLabelsValue ? this.statusLabelsValue : {}
+
+    Object.values(classMap).forEach((classes) => {
+      classes.split(/\s+/).filter(Boolean).forEach((c) => target.classList.remove(c))
+    })
+
+    if (statusKey && classMap[statusKey]) {
+      classMap[statusKey].split(/\s+/).filter(Boolean).forEach((c) => target.classList.add(c))
+    }
+
+    target.textContent = statusKey && labelMap[statusKey] ? labelMap[statusKey] : ""
   }
 
   updateRoleDisplay(target, roleCode) {

--- a/app/models/game_participation.rb
+++ b/app/models/game_participation.rb
@@ -3,6 +3,8 @@ class GameParticipation < ApplicationRecord
   belongs_to :player
   belongs_to :role, foreign_key: :role_code, primary_key: :code, optional: true
 
+  enum :status, { alive: 0, killed_by_mafia: 1, voted_out: 2, banned: 3 }, default: :alive
+
   normalizes :role_code, with: ->(v) { v.presence }
 
   validates :game, :player, presence: true

--- a/app/services/autosave_game_protocol_service.rb
+++ b/app/services/autosave_game_protocol_service.rb
@@ -82,6 +82,10 @@ class AutosaveGameProtocolService
     participation = @game.game_participations.find_by(seat: @seat)
     return Result.new(success: false, errors: [ "No participation at seat #{@seat}" ]) unless participation
 
+    if @field == "status" && !GameParticipation.statuses.key?(@value.to_s)
+      return Result.new(success: false, errors: [ "Invalid status: #{@value}" ])
+    end
+
     participation.assign_attributes(@field => @value)
     if participation.save
       Result.new(success: true, errors: [])

--- a/app/services/autosave_game_protocol_service.rb
+++ b/app/services/autosave_game_protocol_service.rb
@@ -2,7 +2,7 @@ class AutosaveGameProtocolService
   Result = Data.define(:success, :errors)
 
   GAME_FIELDS = %w[game_number played_on name result judge competition_id table_number].freeze
-  PARTICIPATION_FIELDS = %w[player_name role_code plus minus best_move first_shoot notes].freeze
+  PARTICIPATION_FIELDS = %w[player_name role_code plus minus best_move first_shoot notes status].freeze
 
   def self.call(game:, scope:, field:, value:, seat: nil)
     new(game, scope, field, value, seat).call

--- a/app/services/save_game_protocol_service.rb
+++ b/app/services/save_game_protocol_service.rb
@@ -41,6 +41,7 @@ class SaveGameProtocolService
       participation.best_move = attrs[:best_move].presence
       participation.first_shoot = attrs[:first_shoot] == "1"
       participation.notes = attrs[:notes].presence
+      participation.status = attrs[:status] if attrs[:status].present?
       participation.save!
     end
 

--- a/app/services/save_game_protocol_service.rb
+++ b/app/services/save_game_protocol_service.rb
@@ -41,7 +41,7 @@ class SaveGameProtocolService
       participation.best_move = attrs[:best_move].presence
       participation.first_shoot = attrs[:first_shoot] == "1"
       participation.notes = attrs[:notes].presence
-      participation.status = attrs[:status] if attrs[:status].present?
+      participation.status = attrs[:status] if GameParticipation.statuses.key?(attrs[:status].to_s)
       participation.save!
     end
 

--- a/app/views/games/overlay.html.erb
+++ b/app/views/games/overlay.html.erb
@@ -4,6 +4,8 @@
      data-controller="game-overlay"
      data-game-overlay-game-id-value="<%= @game.id %>"
      data-game-overlay-role-icon-template-value="<%= asset_path('roles/peace.png').sub('peace', '%ROLE_CODE%') %>"
+     data-game-overlay-status-classes-value="<%= GamesHelper::OVERLAY_STATUS_CLASSES.transform_keys(&:to_s).to_json %>"
+     data-game-overlay-status-labels-value="<%= GameParticipation.statuses.keys.index_with { |k| t("games.overlay.status.#{k}") }.to_json %>"
      class="flex gap-2 px-2 text-white"
      <% if custom_style.present? %>style="<%= custom_style %>"<% end %>>
   <% (1..10).each do |seat| %>

--- a/app/views/judge/protocols/_form.html.erb
+++ b/app/views/judge/protocols/_form.html.erb
@@ -79,6 +79,7 @@
           <th class="px-3 py-2 font-semibold"><%= GameParticipation.human_attribute_name(:minus) %></th>
           <th class="px-3 py-2 font-semibold"><%= GameParticipation.human_attribute_name(:best_move) %></th>
           <th class="px-3 py-2 font-semibold"><%= GameParticipation.human_attribute_name(:first_shoot) %></th>
+          <th class="px-3 py-2 font-semibold"><%= GameParticipation.human_attribute_name(:status) %></th>
           <th class="px-3 py-2 font-semibold"><%= t("game_protocols.form.notes") %></th>
         </tr>
       </thead>
@@ -131,6 +132,13 @@
             <td class="px-3 py-2 text-center">
               <input type="hidden" name="participations[<%= seat %>][first_shoot]" value="0" />
               <input type="checkbox" name="participations[<%= seat %>][first_shoot]" value="1" <%= "checked" if participation.first_shoot %> class="rounded" />
+            </td>
+            <td class="px-3 py-2">
+              <select name="participations[<%= seat %>][status]" class="w-auto max-w-full border border-gray-300 rounded-md px-2 py-1 text-sm">
+                <% GameParticipation.statuses.each_key do |status_key| %>
+                  <option value="<%= status_key %>" <%= "selected" if participation.status == status_key %>><%= t("games.overlay.status.#{status_key}") %></option>
+                <% end %>
+              </select>
             </td>
             <td class="px-3 py-2">
               <input type="text" name="participations[<%= seat %>][notes]" value="<%= participation.notes %>" class="w-full border border-gray-300 rounded-md px-2 py-1 text-sm" />

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -46,6 +46,7 @@ ru:
         total: "Итого"
         seat: "Место"
         notes: "Примечания"
+        status: "Статус"
       user:
         role: "Роль"
         roles:

--- a/db/migrate/20260418123039_add_status_to_game_participations.rb
+++ b/db/migrate/20260418123039_add_status_to_game_participations.rb
@@ -1,0 +1,6 @@
+class AddStatusToGameParticipations < ActiveRecord::Migration[8.1]
+  def change
+    add_column :game_participations, :status, :integer, default: 0, null: false
+    add_index :game_participations, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_18_123038) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_18_123039) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -128,12 +128,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_18_123038) do
     t.decimal "plus", precision: 5, scale: 2, default: "0.0"
     t.string "role_code"
     t.integer "seat"
+    t.integer "status", default: 0, null: false
     t.datetime "updated_at", null: false
     t.boolean "win", default: false
     t.index ["game_id", "player_id"], name: "index_game_participations_on_game_id_and_player_id", unique: true
     t.index ["game_id", "seat"], name: "index_game_participations_on_game_id_and_seat", unique: true
     t.index ["game_id"], name: "index_game_participations_on_game_id"
     t.index ["player_id"], name: "index_game_participations_on_player_id"
+    t.index ["status"], name: "index_game_participations_on_status"
   end
 
   create_table "games", force: :cascade do |t|

--- a/spec/helpers/games_helper_spec.rb
+++ b/spec/helpers/games_helper_spec.rb
@@ -32,10 +32,28 @@ RSpec.describe GamesHelper do
       expect(helper.overlay_player_status(nil)).to be_nil
     end
 
-    it "returns :alive for an existing participation (stubbed pending vm-e4b)" do
-      participation = instance_double(GameParticipation)
+    it "returns the participation status as a symbol" do
+      participation = instance_double(GameParticipation, status: "killed_by_mafia")
+
+      expect(helper.overlay_player_status(participation)).to eq(:killed_by_mafia)
+    end
+
+    it "returns :alive for a freshly built participation" do
+      participation = GameParticipation.new
 
       expect(helper.overlay_player_status(participation)).to eq(:alive)
+    end
+
+    it "reflects a voted_out participation" do
+      participation = GameParticipation.new(status: :voted_out)
+
+      expect(helper.overlay_player_status(participation)).to eq(:voted_out)
+    end
+
+    it "reflects a banned participation" do
+      participation = GameParticipation.new(status: :banned)
+
+      expect(helper.overlay_player_status(participation)).to eq(:banned)
     end
   end
 

--- a/spec/models/game_participation_spec.rb
+++ b/spec/models/game_participation_spec.rb
@@ -46,6 +46,31 @@ RSpec.describe GameParticipation, type: :model do
     end
   end
 
+  describe "status enum" do
+    it "defines the expected mapping" do
+      expect(described_class.statuses).to eq(
+        "alive" => 0,
+        "killed_by_mafia" => 1,
+        "voted_out" => 2,
+        "banned" => 3
+      )
+    end
+
+    it "defaults new records to alive" do
+      expect(described_class.new.status).to eq("alive")
+    end
+
+    it "exposes predicate methods" do
+      participation = described_class.new(status: :killed_by_mafia)
+      expect(participation).to be_killed_by_mafia
+      expect(participation).not_to be_alive
+    end
+
+    it "raises on unknown statuses" do
+      expect { described_class.new(status: :vaporized) }.to raise_error(ArgumentError)
+    end
+  end
+
   describe '#total' do
     context 'when plus and minus are present' do
       let(:participation) { build(:game_participation, plus: 3, minus: 1) }

--- a/spec/requests/games_overlay_spec.rb
+++ b/spec/requests/games_overlay_spec.rb
@@ -67,6 +67,20 @@ RSpec.describe "Games#overlay" do
       expect(response.body.scan(I18n.t("games.overlay.status.alive")).size).to be >= 2
     end
 
+    it "reflects each participation's persisted status label" do
+      participation_two.update!(status: :voted_out)
+      get overlay_game_path(game)
+
+      expect(response.body).to include(I18n.t("games.overlay.status.voted_out"))
+    end
+
+    it "exposes status class and label maps for the overlay controller" do
+      get overlay_game_path(game)
+
+      expect(response.body).to include("data-game-overlay-status-classes-value")
+      expect(response.body).to include("data-game-overlay-status-labels-value")
+    end
+
     it "includes ActionCable subscription data for the game" do
       get overlay_game_path(game)
 
@@ -151,7 +165,7 @@ RSpec.describe "Games#overlay" do
       it "hides status pill when hide_status param is set" do
         get overlay_game_path(game, hide_status: "1")
 
-        expect(response.body).not_to include(I18n.t("games.overlay.status.alive"))
+        expect(response.body).not_to include('data-game-overlay-target="status"')
       end
     end
   end

--- a/spec/requests/judge/protocols_autosave_spec.rb
+++ b/spec/requests/judge/protocols_autosave_spec.rb
@@ -206,6 +206,17 @@ RSpec.describe "Judge::Protocols#autosave" do
           expect(participation.reload.notes).to eq("Хороший ход")
         end
 
+        it "updates status" do
+          participation = create(:game_participation, game: game, player: player, seat: 8)
+
+          patch autosave_judge_protocol_path(game), params: {
+            scope: "participation", seat: 8, field: "status", value: "voted_out"
+          }, as: :json
+
+          expect(response).to have_http_status(:ok)
+          expect(participation.reload.status).to eq("voted_out")
+        end
+
         it "removes participation when player_name is cleared" do
           create(:game_participation, game: game, player: player, seat: 7)
 

--- a/spec/requests/judge/protocols_spec.rb
+++ b/spec/requests/judge/protocols_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe "Judge::Protocols" do
 
   def valid_participations_params
     params = {}
-    params["1"] = { player_name: "Тестовый", role_code: "don", plus: "1", minus: "0", best_move: "", first_shoot: "0", notes: "" }
-    (2..10).each { |i| params[i.to_s] = { player_name: "", role_code: "", plus: "", minus: "", best_move: "", first_shoot: "0", notes: "" } }
+    params["1"] = { player_name: "Тестовый", role_code: "don", plus: "1", minus: "0", best_move: "", first_shoot: "0", notes: "", status: "alive" }
+    (2..10).each { |i| params[i.to_s] = { player_name: "", role_code: "", plus: "", minus: "", best_move: "", first_shoot: "0", notes: "", status: "alive" } }
     params
   end
 

--- a/spec/requests/judge/protocols_spec.rb
+++ b/spec/requests/judge/protocols_spec.rb
@@ -267,6 +267,20 @@ RSpec.describe "Judge::Protocols" do
         end
       end
 
+      context "with invalid game params and invalid status" do
+        let(:invalid_game_params) { { game_number: 1 } }
+
+        it "re-renders without raising on unknown status" do
+          bad_params = valid_participations_params.deep_dup
+          bad_params["1"][:status] = "vaporized"
+
+          expect {
+            post judge_protocols_path, params: { game: invalid_game_params, participations: bad_params }
+          }.not_to raise_error
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+      end
+
       context "with invalid game params" do
         let(:invalid_game_params) { { game_number: 1 } }
 

--- a/spec/services/autosave_game_protocol_service_spec.rb
+++ b/spec/services/autosave_game_protocol_service_spec.rb
@@ -202,6 +202,16 @@ RSpec.describe AutosaveGameProtocolService do
           expect(result.success).to be true
           expect(participation.reload.status).to eq("killed_by_mafia")
         end
+
+        it "rejects an unknown status value without raising" do
+          result = described_class.call(
+            game: game, scope: "participation", field: "status", value: "vaporized", seat: 4
+          )
+
+          expect(result.success).to be false
+          expect(result.errors).to include(a_string_matching(/Invalid status/))
+          expect(participation.reload.status).to eq("alive")
+        end
       end
 
       context "when field is disallowed" do

--- a/spec/services/autosave_game_protocol_service_spec.rb
+++ b/spec/services/autosave_game_protocol_service_spec.rb
@@ -193,6 +193,15 @@ RSpec.describe AutosaveGameProtocolService do
           expect(result.success).to be true
           expect(participation.reload.notes).to eq("Комментарий")
         end
+
+        it "updates status" do
+          result = described_class.call(
+            game: game, scope: "participation", field: "status", value: "killed_by_mafia", seat: 4
+          )
+
+          expect(result.success).to be true
+          expect(participation.reload.status).to eq("killed_by_mafia")
+        end
       end
 
       context "when field is disallowed" do

--- a/spec/services/save_game_protocol_service_spec.rb
+++ b/spec/services/save_game_protocol_service_spec.rb
@@ -147,6 +147,19 @@ RSpec.describe SaveGameProtocolService do
         )
         expect(old_participation.reload.status).to eq("voted_out")
       end
+
+      it "ignores an invalid status value without raising" do
+        params = { "1" => { player_name: "Алексей", role_code: "don", plus: "2", minus: "0", best_move: "", first_shoot: "0", notes: "", status: "vaporized" } }
+        (2..10).each { |i| params[i.to_s] = { player_name: "", role_code: "" } }
+        expect {
+          described_class.call(
+            game: game_to_update,
+            game_params: update_game_params,
+            participations_params: ActionController::Parameters.new(params).permit!
+          )
+        }.not_to raise_error
+        expect(old_participation.reload.status).to eq("alive")
+      end
     end
 
     context "when clearing a previously filled seat" do

--- a/spec/services/save_game_protocol_service_spec.rb
+++ b/spec/services/save_game_protocol_service_spec.rb
@@ -136,6 +136,17 @@ RSpec.describe SaveGameProtocolService do
         described_class.call(game: game_to_update, game_params: update_game_params, participations_params: participations_params)
         expect(old_participation.reload.win).to be true
       end
+
+      it "persists status when provided" do
+        params = { "1" => { player_name: "Алексей", role_code: "don", plus: "2", minus: "0", best_move: "", first_shoot: "0", notes: "", status: "voted_out" } }
+        (2..10).each { |i| params[i.to_s] = { player_name: "", role_code: "" } }
+        described_class.call(
+          game: game_to_update,
+          game_params: update_game_params,
+          participations_params: ActionController::Parameters.new(params).permit!
+        )
+        expect(old_participation.reload.status).to eq("voted_out")
+      end
     end
 
     context "when clearing a previously filled seat" do


### PR DESCRIPTION
## Summary

- Adds `status` enum (alive / killed_by_mafia / voted_out / banned, default `alive`) to `GameParticipation`.
- Replaces the stub `GamesHelper#overlay_player_status` with real data driven by `participation.status`.
- Extends the judge protocol form, `AutosaveGameProtocolService` + `SaveGameProtocolService` allow-lists, and the controller's strong params with the new field.
- Extends the ActionCable overlay controller to swap CSS classes and localized labels when a status broadcast arrives.

## Mutation testing
- Evilution: 100% on all modified files (model 89/89, autosave 233/233, save 231/231, helper 78/78).
- Mutant: model 120/120 (100%); autosave 415/424 (97.87%, all 9 alive are pre-existing neutral failures, verified on baseline); save 453/459 (98.69%, all 30 new mutations from the status= line killed, 6 pre-existing alive); helper 98/102 (96.07%, all 3 new overlay_player_status mutations killed, 4 pre-existing alive in overlay_custom_style).

Closes #812

## Test plan
- [x] `bundle exec rspec` — 2099 examples, 0 failures
- [x] `bundle exec rubocop` on all modified non-erb files — no offences
- [x] `bundle exec evilution` on model/services/helper — 100%
- [x] `bundle exec mutant` — all new mutations killed

🤖 Generated with [Claude Code](https://claude.com/claude-code)