### PR TITLE
vm-m8e: Filter podcast episodes by published_at in public endpoints

### DIFF
--- a/app/controllers/podcast/audio_controller.rb
+++ b/app/controllers/podcast/audio_controller.rb
@@ -3,7 +3,7 @@ class Podcast::AudioController < ApplicationController
   before_action :authenticate_via_token!
 
   def show
-    episode = Episode.published.find_by(id: params[:episode_id])
+    episode = Episode.visible.find_by(id: params[:episode_id])
     return head(:not_found) unless episode
     return head(:not_found) unless episode.audio.attached?
 

--- a/app/controllers/podcast/episodes_controller.rb
+++ b/app/controllers/podcast/episodes_controller.rb
@@ -2,12 +2,12 @@ class Podcast::EpisodesController < ApplicationController
   include RequireSubscriber
 
   def index
-    @pagy, @episodes = pagy(Episode.published.recent)
+    @pagy, @episodes = pagy(Episode.visible.recent)
     @feed_token = current_user.podcast_feed_token || current_user.create_podcast_feed_token!
   end
 
   def show
-    @episode = Episode.published.find(params[:id])
+    @episode = Episode.visible.find(params[:id])
     playback = PlaybackPosition.find_by(user: current_user, episode: @episode)
     @saved_position = playback ? playback.position_seconds : 0
     @saved_speed = playback ? playback.playback_speed : 1.0

--- a/app/controllers/podcast/feed_controller.rb
+++ b/app/controllers/podcast/feed_controller.rb
@@ -4,7 +4,7 @@ class Podcast::FeedController < ApplicationController
 
   def show
     @podcast = Podcast.instance
-    @episodes = Episode.published.recent.includes(:audio_attachment, :image_attachment)
+    @episodes = Episode.visible.recent.includes(:audio_attachment, :image_attachment)
     @token = params[:token]
     render formats: :rss
   end

--- a/app/controllers/podcast/playback_positions_controller.rb
+++ b/app/controllers/podcast/playback_positions_controller.rb
@@ -2,7 +2,7 @@ class Podcast::PlaybackPositionsController < ApplicationController
   include RequireSubscriber
 
   def update
-    episode = Episode.published.find(params[:episode_id])
+    episode = Episode.visible.find(params[:episode_id])
     position = PlaybackPosition.find_or_initialize_by(
       user: current_user,
       episode: episode

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -18,6 +18,7 @@ class Episode < ApplicationRecord
   after_save_commit :enqueue_duration_extraction, if: -> { audio.attached? && duration_seconds.nil? }
 
   scope :recent, -> { order(Arel.sql("published_at IS NULL, published_at DESC, id DESC")) }
+  scope :visible, -> { published.where(published_at: ..Time.current) }
 
   def formatted_duration
     return nil unless duration_seconds

--- a/db/migrate/20260426152805_add_index_on_status_and_published_at_to_episodes.rb
+++ b/db/migrate/20260426152805_add_index_on_status_and_published_at_to_episodes.rb
@@ -1,0 +1,5 @@
+class AddIndexOnStatusAndPublishedAtToEpisodes < ActiveRecord::Migration[8.1]
+  def change
+    add_index :episodes, [ :status, :published_at ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_18_123039) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_26_152805) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -105,6 +105,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_18_123039) do
     t.string "status", default: "draft", null: false
     t.string "title", null: false
     t.datetime "updated_at", null: false
+    t.index ["status", "published_at"], name: "index_episodes_on_status_and_published_at"
   end
 
   create_table "feature_toggles", force: :cascade do |t|

--- a/spec/models/episode_spec.rb
+++ b/spec/models/episode_spec.rb
@@ -135,6 +135,34 @@ RSpec.describe Episode, type: :model do
       end
     end
 
+    describe ".visible" do
+      let!(:draft_episode) { create(:episode, status: "draft") }
+      let!(:published_now) { create(:episode, status: "published", published_at: Time.current) }
+      let!(:published_past) { create(:episode, status: "published", published_at: 1.day.ago) }
+      let!(:scheduled_future) { create(:episode, status: "published", published_at: 1.day.from_now) }
+      let!(:published_without_timestamp) { create(:episode, status: "published", published_at: nil) }
+
+      it "includes published episodes whose published_at is in the past" do
+        expect(described_class.visible).to include(published_past)
+      end
+
+      it "includes published episodes whose published_at is the current moment" do
+        expect(described_class.visible).to include(published_now)
+      end
+
+      it "excludes draft episodes" do
+        expect(described_class.visible).not_to include(draft_episode)
+      end
+
+      it "excludes published episodes scheduled in the future" do
+        expect(described_class.visible).not_to include(scheduled_future)
+      end
+
+      it "excludes published episodes with nil published_at" do
+        expect(described_class.visible).not_to include(published_without_timestamp)
+      end
+    end
+
     describe ".recent" do
       let!(:older) { create(:episode, status: "published", published_at: 2.days.ago) }
       let!(:newer) { create(:episode, status: "published", published_at: 1.day.ago) }

--- a/spec/requests/podcast/audio_spec.rb
+++ b/spec/requests/podcast/audio_spec.rb
@@ -16,6 +16,16 @@ RSpec.describe "Podcast::Audio" do
     create(:episode, title: "No Audio", status: "published", published_at: Time.current)
   end
   let_it_be(:draft_episode) { create(:episode, status: "draft") }
+  let_it_be(:scheduled_future_episode) do
+    episode = create(:episode, title: "Future Scheduled", status: "published", published_at: 1.day.from_now)
+    episode.audio.attach(io: StringIO.new("a"), filename: "f.mp3", content_type: "audio/mpeg")
+    episode
+  end
+  let_it_be(:published_without_timestamp_episode) do
+    episode = create(:episode, title: "No Timestamp", status: "published", published_at: nil)
+    episode.audio.attach(io: StringIO.new("a"), filename: "n.mp3", content_type: "audio/mpeg")
+    episode
+  end
 
   describe "GET /podcast/episodes/:id/audio" do
     context "when token is missing" do
@@ -55,6 +65,16 @@ RSpec.describe "Podcast::Audio" do
 
       it "returns not found for draft episode" do
         get "/podcast/episodes/#{draft_episode.id}/audio?token=#{token.token}"
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "returns not found for episode scheduled in the future" do
+        get "/podcast/episodes/#{scheduled_future_episode.id}/audio?token=#{token.token}"
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "returns not found for published episode with nil published_at" do
+        get "/podcast/episodes/#{published_without_timestamp_episode.id}/audio?token=#{token.token}"
         expect(response).to have_http_status(:not_found)
       end
 

--- a/spec/requests/podcast/episodes_spec.rb
+++ b/spec/requests/podcast/episodes_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe "Podcast::Episodes" do
            status: "published", published_at: Time.current)
   end
   let_it_be(:draft_episode) { create(:episode, status: "draft") }
+  let_it_be(:scheduled_future_episode) do
+    create(:episode, title: "Future Episode", status: "published", published_at: 1.day.from_now)
+  end
+  let_it_be(:published_without_timestamp_episode) do
+    create(:episode, title: "No Timestamp Episode", status: "published", published_at: nil)
+  end
 
   describe "GET /podcast/episodes" do
     context "when not signed in" do
@@ -43,6 +49,16 @@ RSpec.describe "Podcast::Episodes" do
       it "does not display draft episodes" do
         get "/podcast/episodes"
         expect(response.body).not_to include(draft_episode.title)
+      end
+
+      it "does not display episodes scheduled in the future" do
+        get "/podcast/episodes"
+        expect(response.body).not_to include(scheduled_future_episode.title)
+      end
+
+      it "does not display published episodes with nil published_at" do
+        get "/podcast/episodes"
+        expect(response.body).not_to include(published_without_timestamp_episode.title)
       end
 
       it "links to episode show page" do
@@ -116,6 +132,16 @@ RSpec.describe "Podcast::Episodes" do
       it "returns success for published episode" do
         get "/podcast/episodes/#{published_episode.id}"
         expect(response).to have_http_status(:ok)
+      end
+
+      it "returns not found for episode scheduled in the future" do
+        get "/podcast/episodes/#{scheduled_future_episode.id}"
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "returns not found for published episode with nil published_at" do
+        get "/podcast/episodes/#{published_without_timestamp_episode.id}"
+        expect(response).to have_http_status(:not_found)
       end
 
       it "displays the episode title" do

--- a/spec/requests/podcast/feed_spec.rb
+++ b/spec/requests/podcast/feed_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe "Podcast::Feed" do
            status: "published", published_at: Time.current)
   end
   let_it_be(:draft_episode) { create(:episode, status: "draft") }
+  let_it_be(:scheduled_future_episode) do
+    create(:episode, title: "Future Scheduled Episode", description: "scheduled",
+           status: "published", published_at: 1.day.from_now)
+  end
+  let_it_be(:published_without_timestamp_episode) do
+    create(:episode, title: "No Timestamp Episode", description: "no ts",
+           status: "published", published_at: nil)
+  end
 
   describe "GET /podcast/feed.rss" do
     context "when token is missing" do
@@ -72,6 +80,16 @@ RSpec.describe "Podcast::Feed" do
       it "excludes draft episodes" do
         get "/podcast/feed.rss?token=#{token.token}"
         expect(response.body).not_to include(draft_episode.title)
+      end
+
+      it "excludes episodes scheduled in the future" do
+        get "/podcast/feed.rss?token=#{token.token}"
+        expect(response.body).not_to include(scheduled_future_episode.title)
+      end
+
+      it "excludes published episodes with nil published_at" do
+        get "/podcast/feed.rss?token=#{token.token}"
+        expect(response.body).not_to include(published_without_timestamp_episode.title)
       end
 
       it "orders episodes by published_at descending" do

--- a/spec/requests/podcast/playback_positions_spec.rb
+++ b/spec/requests/podcast/playback_positions_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe "Podcast::PlaybackPositions" do
   let_it_be(:user) { create(:user) }
   let_it_be(:episode) { create(:episode, status: "published", published_at: Time.current) }
   let_it_be(:draft_episode) { create(:episode, status: "draft") }
+  let_it_be(:scheduled_future_episode) do
+    create(:episode, status: "published", published_at: 1.day.from_now)
+  end
+  let_it_be(:published_without_timestamp_episode) do
+    create(:episode, status: "published", published_at: nil)
+  end
 
   describe "PATCH /podcast/episodes/:episode_id/position" do
     let(:params) { { position_seconds: 120 } }
@@ -92,6 +98,16 @@ RSpec.describe "Podcast::PlaybackPositions" do
 
       it "returns not found for draft episode" do
         patch "/podcast/episodes/#{draft_episode.id}/position", params: params
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "returns not found for episode scheduled in the future" do
+        patch "/podcast/episodes/#{scheduled_future_episode.id}/position", params: params
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "returns not found for published episode with nil published_at" do
+        patch "/podcast/episodes/#{published_without_timestamp_episode.id}/position", params: params
         expect(response).to have_http_status(:not_found)
       end
     end


### PR DESCRIPTION
## Summary

- Adds \`Episode.visible\` scope (\`published.where(published_at: ..Time.current)\`) mirroring \`News.visible\`.
- Replaces \`Episode.published\` with \`Episode.visible\` in the four public podcast controllers: \`episodes\`, \`feed\`, \`audio\`, \`playback_positions\`.
- Fixes RSS feed crash (\`NoMethodError\` on \`episode.published_at.rfc2822\`) for any published episode with nil \`published_at\`.

Closes #836

## Mutation testing

- **Evilution** 0.27.0: 100% (186/186 killed, 0 survived; 4 equivalent + 2 unparseable excluded)
- **Mutant**: 95.11% (292/307 killed, 15 alive). All 15 alive exist on \`master\` baseline — pre-existing tech debt in \`extract_duration_from_audio\` / \`validate_audio\` / \`validate_image\`. New \`:visible\` scope adds zero new survivors (DSL not mutated by mutant).

## Test plan

- [ ] Subscriber \`/podcast/episodes\` excludes future-scheduled and nil-\`published_at\` episodes
- [ ] \`/podcast/episodes/:id\` returns 404 for future-scheduled / nil-\`published_at\`
- [ ] \`/podcast/feed.rss\` excludes future-scheduled / nil; no \`NoMethodError\`
- [ ] \`/podcast/episodes/:id/audio\` returns 404 for future-scheduled / nil
- [ ] \`PATCH /podcast/episodes/:id/position\` returns 404 for future-scheduled / nil

🤖 Generated with [Claude Code](https://claude.com/claude-code)