### PR TITLE
vm-m2z: Truncate news previews on paragraph boundary

### DIFF
--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -74,20 +74,27 @@ class News < ApplicationRecord
 
   private
 
+  TRUNCATION_OMISSION = "…"
+  private_constant :TRUNCATION_OMISSION
+
   def truncate_to_paragraph(plain_text, max_length)
     paragraphs = plain_text.split(/\n+/)
-    selected = take_fitting(paragraphs, max_length, separator: "\n\n")
-    return selected.join("\n\n") + "…" if selected.any?
+    selected = take_fitting(paragraphs, budget_for(max_length), separator: "\n\n")
+    return selected.join("\n\n") + TRUNCATION_OMISSION if selected.any?
 
     truncate_to_sentence(paragraphs.first, max_length)
   end
 
   def truncate_to_sentence(paragraph, max_length)
     sentences = paragraph.split(/(?<=[.!?…])\s+/)
-    selected = take_fitting(sentences, max_length, separator: " ")
-    return selected.join(" ") + "…" if selected.any?
+    selected = take_fitting(sentences, budget_for(max_length), separator: " ")
+    return selected.join(" ") + TRUNCATION_OMISSION if selected.any?
 
-    paragraph.truncate(max_length, separator: /\s/, omission: "…")
+    paragraph.truncate(max_length, separator: /\s/, omission: TRUNCATION_OMISSION)
+  end
+
+  def budget_for(max_length)
+    [ max_length - TRUNCATION_OMISSION.length, 0 ].max
   end
 
   def take_fitting(parts, max_length, separator:)

--- a/app/models/news.rb
+++ b/app/models/news.rb
@@ -61,7 +61,7 @@ class News < ApplicationRecord
     plain_text = content.body.to_plain_text
     return content if plain_text.length <= max_length
 
-    truncated_plain = plain_text.truncate(max_length, separator: /\s/, omission: "…")
+    truncated_plain = truncate_to_paragraph(plain_text, max_length)
     html = truncated_plain.split(/\n+/).map { |line| "<p>#{ERB::Util.html_escape(line)}</p>" }.join
     ActionText::Content.new(html)
   end
@@ -73,6 +73,34 @@ class News < ApplicationRecord
   end
 
   private
+
+  def truncate_to_paragraph(plain_text, max_length)
+    paragraphs = plain_text.split(/\n+/)
+    selected = take_fitting(paragraphs, max_length, separator: "\n\n")
+    return selected.join("\n\n") + "…" if selected.any?
+
+    truncate_to_sentence(paragraphs.first, max_length)
+  end
+
+  def truncate_to_sentence(paragraph, max_length)
+    sentences = paragraph.split(/(?<=[.!?…])\s+/)
+    selected = take_fitting(sentences, max_length, separator: " ")
+    return selected.join(" ") + "…" if selected.any?
+
+    paragraph.truncate(max_length, separator: /\s/, omission: "…")
+  end
+
+  def take_fitting(parts, max_length, separator:)
+    selected = []
+    total = 0
+    parts.each_with_index do |part, index|
+      addition = index.zero? ? part.length : separator.length + part.length
+      break if total + addition > max_length
+      selected << part
+      total += addition
+    end
+    selected
+  end
 
   def slug_base
     "#{slug_date.strftime('%Y-%m-%d')}-#{slug_title_part}"

--- a/spec/models/news_spec.rb
+++ b/spec/models/news_spec.rb
@@ -357,6 +357,18 @@ RSpec.describe News, type: :model do
       expect(news.truncated_content(100)).to eq(news.content)
     end
 
+    it "never returns plain text longer than the limit even when the kept paragraph length equals the limit" do
+      news = build(:news, author: author, content: "<p>abcd</p><p>xyz</p>")
+      result = news.truncated_content(4)
+      expect(result.to_plain_text.length).to be <= 4
+    end
+
+    it "never returns plain text longer than the limit even when the kept sentence length equals the limit" do
+      news = build(:news, author: author, content: "<p>aaaa. bbbb.</p>")
+      result = news.truncated_content(5)
+      expect(result.to_plain_text.length).to be <= 5
+    end
+
     it "wraps each kept paragraph in its own <p> tag without producing empty <p> tags" do
       news = build(:news, author: author,
         content: "<p>First.</p><p>Second.</p><p>Third paragraph that is much longer than the rest.</p>")

--- a/spec/models/news_spec.rb
+++ b/spec/models/news_spec.rb
@@ -357,7 +357,15 @@ RSpec.describe News, type: :model do
       expect(news.truncated_content(100)).to eq(news.content)
     end
 
-    it "truncates at paragraph boundary" do
+    it "wraps each kept paragraph in its own <p> tag without producing empty <p> tags" do
+      news = build(:news, author: author,
+        content: "<p>First.</p><p>Second.</p><p>Third paragraph that is much longer than the rest.</p>")
+      html = news.truncated_content(25).to_html
+      expect(html).not_to include("<p></p>")
+      expect(html.scan("<p>").count).to eq(2)
+    end
+
+    it "keeps only whole paragraphs when multiple paragraphs exceed the limit" do
       news = build(:news, author: author, content: "<p>First paragraph.</p><p>Second paragraph.</p><p>Third paragraph.</p>")
       result = news.truncated_content(20)
       html = result.to_html
@@ -365,8 +373,26 @@ RSpec.describe News, type: :model do
       expect(html).not_to include("Third paragraph.")
     end
 
-    it "truncates a long single paragraph mid-sentence at a word boundary" do
-      news = build(:news, author: author, content: "<p>This is a very long first paragraph that exceeds the limit.</p>")
+    it "does not break a paragraph in half when a later paragraph would push past the limit" do
+      news = build(:news, author: author,
+        content: "<p>First paragraph.</p><p>Second paragraph with much more text in it.</p><p>Third paragraph.</p>")
+      result = news.truncated_content(40)
+      plain = result.to_plain_text
+      expect(plain).not_to include("Second paragraph with")
+    end
+
+    it "ends on a sentence boundary when a single paragraph exceeds the limit" do
+      news = build(:news, author: author,
+        content: "<p>One. Two sentence is very long here in this paragraph that goes on. Three.</p>")
+      result = news.truncated_content(50)
+      plain = result.to_plain_text
+      expect(plain).to start_with("One.")
+      expect(plain).to match(/[.!?]…?\z/)
+    end
+
+    it "falls back to a word boundary when the first sentence already exceeds the limit" do
+      news = build(:news, author: author,
+        content: "<p>This is a very long first paragraph that exceeds the limit.</p>")
       result = news.truncated_content(20)
       plain = result.to_plain_text
       expect(plain.length).to be <= 20
@@ -382,17 +408,7 @@ RSpec.describe News, type: :model do
       expect(plain).to end_with("…")
     end
 
-    it "preserves paragraph breaks in the truncated preview" do
-      news = build(:news, author: author, content: "<p>First paragraph.</p><p>Second paragraph with more text.</p>")
-      result = news.truncated_content(30)
-      html = result.to_html
-      expect(html.scan("<p>").size).to be >= 2
-      expect(html).to include("First paragraph.")
-      expect(html).to include("Second")
-      expect(html).not_to include("<p></p>")
-    end
-
-    it "cuts at a word boundary rather than mid-word" do
+    it "cuts at a word boundary rather than mid-word when the first sentence has no terminator" do
       news = build(:news, author: author, content: "hello world foo bar baz qux")
       result = news.truncated_content(10)
       expect(result.to_plain_text).to eq("hello…")


### PR DESCRIPTION
## Summary

\`News#truncated_content\` used \`String#truncate\` with a word-boundary separator across the full plain text, leaving previews that ended mid-sentence with an ellipsis (e.g. \`First paragraph.\n\nSecond paragraph that…\`).

Now walks paragraphs and keeps only those that fit. If the first paragraph alone exceeds \`max_length\`, falls back to a sentence boundary; if the first sentence still doesn't fit, falls back to a word boundary as a last resort.

Closes #838

## Mutation testing

- **Evilution** 0.27.0: 100% (353/353 killed) at \`--jobs 1\`. Note: at \`--jobs 4\` the score also reads 100% but classifies 226/415 mutations as \`:neutral\` due to SQLite contention — see \`.artifacts.local/regular-evilution-feedback.log\` for details.
- **Mutant**: 98.60% on the new methods (212/215). 3 "alive" — 1 equivalent (\`content.body.to_plain_text\` ↔ \`content.to_plain_text\`, RichText delegates), 2 spurious \`neutral\` results caused by an unrelated \`News.recent\` ordering spec failing under test-data pollution (fires on master baseline too).

## Test plan

- [ ] News index/preview pages no longer end mid-sentence
- [ ] Multi-paragraph article: keeps whole paragraphs only
- [ ] Single-paragraph article exceeding limit: ends on sentence boundary
- [ ] First sentence still longer than limit: word-boundary fallback (existing behavior)
- [ ] Empty / blank / under-limit content: unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)