### PR TITLE
fix(telegram): log silent drops when whitelisted author has no linked user

### DIFF
--- a/app/jobs/process_telegram_webhook_job.rb
+++ b/app/jobs/process_telegram_webhook_job.rb
@@ -11,7 +11,12 @@ class ProcessTelegramWebhookJob < ApplicationJob
 
     author = TelegramAuthor.find_by_telegram_user_id(parsed.from_id)
     return if author.nil?
-    return if author.user.nil?
+
+    if author.user.nil?
+      log_no_linked_user(author, parsed)
+      return
+    end
+
     return if below_score_threshold?(parsed)
 
     news = News.create!(
@@ -27,6 +32,12 @@ class ProcessTelegramWebhookJob < ApplicationJob
   end
 
   private
+
+  def log_no_linked_user(author, parsed)
+    Rails.logger.warn(
+      { event: "telegram_webhook.no_linked_user", from_id: parsed.from_id, telegram_author_id: author.id }.to_json
+    )
+  end
 
   SCORE_THRESHOLD_SETTING = "news_score_threshold"
   DEFAULT_SCORE_THRESHOLD = 10

--- a/spec/jobs/process_telegram_webhook_job_spec.rb
+++ b/spec/jobs/process_telegram_webhook_job_spec.rb
@@ -238,6 +238,17 @@ RSpec.describe ProcessTelegramWebhookJob do
       it "does not create a news article" do
         expect { described_class.new.perform(payload) }.not_to change(News, :count)
       end
+
+      it "logs the silent drop as structured JSON at warn level" do
+        logged = nil
+        allow(Rails.logger).to receive(:warn) { |msg| logged = msg }
+        described_class.new.perform(payload)
+        expect(JSON.parse(logged)).to eq(
+          "event" => "telegram_webhook.no_linked_user",
+          "from_id" => 55555,
+          "telegram_author_id" => unlinked_author.id
+        )
+      end
     end
 
     context "when message text is blank" do


### PR DESCRIPTION
## Summary

- Telegram webhook messages from whitelisted Telegram users without a linked registered user were silently dropped — no log, no feedback. Operators had no signal that a sender was misconfigured.
- Replaced the bare `return if author.user.nil?` with a structured JSON warn log (`event: telegram_webhook.no_linked_user`) carrying `from_id` and `telegram_author_id`, mirroring the existing `telegram_webhook.{accepted,rejected}` payload convention used elsewhere in the job.
- Refactored from a predicate-with-side-effect (`no_linked_user?` returning `true`) to an inline `if … return` branch with a tidy `log_no_linked_user` helper — mutation testing exposed the implicit-return coupling as fragile.

## Mutation testing

- Evilution: 100% (49/49 mutants killed)
- Mutant: 96.46% (327/339). The 12 surviving mutants are pre-existing in unrelated methods (`status: :draft` default, `.present?` weakening, photo handling). The new `log_no_linked_user` has 1 surviving mutant: `Rails.logger` → `self.logger`, which is equivalent (ActiveJob's `logger` delegates to `Rails.logger`).

## Test plan

- [x] `bundle exec rspec spec/jobs/process_telegram_webhook_job_spec.rb` — 35 examples, 0 failures
- [x] `bundle exec rubocop` on changed files — clean
- [x] `bundle exec evilution run app/jobs/process_telegram_webhook_job.rb --jobs 4` — PASS 100%
- [x] `bundle exec mutant run -- 'ProcessTelegramWebhookJob'` — 96.46% (no new survivors)

Closes #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)