### PR TITLE
feat(telegram): batch consecutive messages into a single news draft

### DIFF
--- a/app/jobs/process_telegram_webhook_job.rb
+++ b/app/jobs/process_telegram_webhook_job.rb
@@ -4,10 +4,15 @@ class ProcessTelegramWebhookJob < ApplicationJob
   MAX_TITLE_LENGTH = 255
   MIN_TEXT_LENGTH = 500
 
+  THREAD_TOGGLE = "telegram_thread_window".freeze
+  THREAD_SECONDS_SETTING = "telegram_thread_window_seconds".freeze
+  THREAD_STRATEGY_SETTING = "telegram_thread_window_strategy".freeze
+  DEFAULT_THREAD_SECONDS = 900
+  DEFAULT_THREAD_STRATEGY = "sliding".freeze
+
   def perform(payload)
     parsed = Telegram::MessageParser.call(payload)
     return if parsed.nil?
-    return if parsed.raw_text_length < MIN_TEXT_LENGTH
 
     author = TelegramAuthor.find_by_telegram_user_id(parsed.from_id)
     return if author.nil?
@@ -18,21 +23,107 @@ class ProcessTelegramWebhookJob < ApplicationJob
       return
     end
 
+    open_thread = find_open_thread(news_author)
+    if open_thread.present?
+      append_to_thread(open_thread, parsed)
+      return
+    end
+
+    return if parsed.raw_text_length < MIN_TEXT_LENGTH
     return if below_score_threshold?(parsed)
 
-    news = News.create!(
+    create_new_draft(news_author, parsed)
+  end
+
+  private
+
+  def thread_window_enabled?
+    FeatureToggle.enabled?(THREAD_TOGGLE)
+  end
+
+  def thread_window_seconds
+    FeatureToggle.value_for(THREAD_SECONDS_SETTING, default: DEFAULT_THREAD_SECONDS).to_i
+  end
+
+  def thread_window_strategy
+    FeatureToggle.value_for(THREAD_STRATEGY_SETTING, default: DEFAULT_THREAD_STRATEGY)
+  end
+
+  def find_open_thread(news_author)
+    return nil unless thread_window_enabled?
+
+    cutoff = Time.current - thread_window_seconds
+    column = thread_window_strategy == "fixed" ? :telegram_thread_started_at : :telegram_thread_last_message_at
+
+    News.where(author: news_author, status: :draft)
+        .where("#{column} > ?", cutoff)
+        .order(telegram_thread_last_message_at: :desc)
+        .first
+  end
+
+  def append_to_thread(news, parsed)
+    parts = [ news.content.body.to_html ]
+    parts << embedded_photo_html(news, parsed.photo_file_id) if parsed.photo_file_id.present?
+    parts << parsed.html_content if parsed.text.present?
+
+    news.update!(
+      content: parts.join,
+      telegram_thread_last_message_at: Time.current
+    )
+
+    AutolinkPlayersInNewsService.call(news)
+  end
+
+  def create_new_draft(news_author, parsed)
+    news = News.new(
       title: parsed.text.truncate(MAX_TITLE_LENGTH),
       content: parsed.html_content,
       author: news_author,
       status: :draft
     )
 
-    attach_photo(news, parsed.photo_file_id) if parsed.photo_file_id.present?
+    if thread_window_enabled?
+      now = Time.current
+      news.telegram_thread_started_at = now
+      news.telegram_thread_last_message_at = now
+    end
+
+    news.save!
+
+    if parsed.photo_file_id.present?
+      if thread_window_enabled?
+        news.update!(content: news.content.body.to_html + embedded_photo_html(news, parsed.photo_file_id))
+      else
+        attach_photo_to_gallery(news, parsed.photo_file_id)
+      end
+    end
+
     AutolinkPlayersInNewsService.call(news)
     NotifyEditorsAboutDraftService.call(news)
   end
 
-  private
+  def embedded_photo_html(_news, file_id)
+    result = Telegram::DownloadFileService.call(file_id)
+    return "" unless result.success?
+
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: result.io,
+      filename: result.filename,
+      content_type: result.content_type
+    )
+    ActionText::Attachment.from_attachable(blob).to_html
+  end
+
+  def attach_photo_to_gallery(news, file_id)
+    result = Telegram::DownloadFileService.call(file_id)
+    return unless result.success?
+
+    news.photos.attach(
+      io: result.io,
+      filename: result.filename,
+      content_type: result.content_type
+    )
+  end
 
   def log_no_linked_user(author, parsed)
     Rails.logger.warn(
@@ -57,16 +148,5 @@ class ProcessTelegramWebhookJob < ApplicationJob
       Rails.logger.info(payload)
       false
     end
-  end
-
-  def attach_photo(news, file_id)
-    result = Telegram::DownloadFileService.call(file_id)
-    return unless result.success?
-
-    news.photos.attach(
-      io: result.io,
-      filename: result.filename,
-      content_type: result.content_type
-    )
   end
 end

--- a/app/jobs/process_telegram_webhook_job.rb
+++ b/app/jobs/process_telegram_webhook_job.rb
@@ -63,7 +63,7 @@ class ProcessTelegramWebhookJob < ApplicationJob
 
   def append_to_thread(news, parsed)
     parts = [ news.content.body.to_html ]
-    parts << embedded_photo_html(news, parsed.photo_file_id) if parsed.photo_file_id.present?
+    parts << embedded_photo_html(parsed.photo_file_id) if parsed.photo_file_id.present?
     parts << parsed.html_content if parsed.text.present?
 
     news.update!(
@@ -92,7 +92,7 @@ class ProcessTelegramWebhookJob < ApplicationJob
 
     if parsed.photo_file_id.present?
       if thread_window_enabled?
-        news.update!(content: news.content.body.to_html + embedded_photo_html(news, parsed.photo_file_id))
+        news.update!(content: news.content.body.to_html + embedded_photo_html(parsed.photo_file_id))
       else
         attach_photo_to_gallery(news, parsed.photo_file_id)
       end
@@ -102,7 +102,7 @@ class ProcessTelegramWebhookJob < ApplicationJob
     NotifyEditorsAboutDraftService.call(news)
   end
 
-  def embedded_photo_html(_news, file_id)
+  def embedded_photo_html(file_id)
     result = Telegram::DownloadFileService.call(file_id)
     return "" unless result.success?
 

--- a/app/models/feature_toggle.rb
+++ b/app/models/feature_toggle.rb
@@ -18,6 +18,9 @@ class FeatureToggle < ApplicationRecord
     news_score_keywords
     news_score_threshold
     news_autolink_players
+    telegram_thread_window
+    telegram_thread_window_seconds
+    telegram_thread_window_strategy
   ].freeze
   CACHE_TTL = 5.minutes
 

--- a/db/migrate/20260514044321_add_telegram_thread_fields_to_news.rb
+++ b/db/migrate/20260514044321_add_telegram_thread_fields_to_news.rb
@@ -1,0 +1,10 @@
+class AddTelegramThreadFieldsToNews < ActiveRecord::Migration[8.1]
+  def change
+    change_table :news, bulk: true do |t|
+      t.datetime :telegram_thread_started_at
+      t.datetime :telegram_thread_last_message_at
+    end
+
+    add_index :news, [ :author_id, :status, :telegram_thread_last_message_at ], name: "index_news_on_author_status_thread"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_13_163253) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_14_044321) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -171,8 +171,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_163253) do
     t.datetime "published_at"
     t.string "slug", null: false
     t.string "status", default: "draft", null: false
+    t.datetime "telegram_thread_last_message_at"
+    t.datetime "telegram_thread_started_at"
     t.string "title", null: false
     t.datetime "updated_at", null: false
+    t.index ["author_id", "status", "telegram_thread_last_message_at"], name: "index_news_on_author_status_thread"
     t.index ["author_id"], name: "index_news_on_author_id"
     t.index ["competition_id"], name: "index_news_on_competition_id"
     t.index ["game_id"], name: "index_news_on_game_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -42,7 +42,10 @@ toggle.save!
   { key: "news_max_article_length", description: "Max article length (chars) on news index before truncation", enabled: false },
   { key: "news_score_keywords", description: "Comma-separated keywords for news scoring (e.g. игра,сезон,турнир)", enabled: true, value: "игра,сезон,турнир,рейтинг,мафия" },
   { key: "news_score_threshold", description: "Minimum news score to create a draft from Telegram message", enabled: true, value: "10" },
-  { key: "news_autolink_players", description: "Auto-link player nicknames in news drafts from Telegram" }
+  { key: "news_autolink_players", description: "Auto-link player nicknames in news drafts from Telegram" },
+  { key: "telegram_thread_window", description: "Combine consecutive Telegram messages from the same author into one news draft", enabled: false },
+  { key: "telegram_thread_window_seconds", description: "Window size in seconds for the Telegram message thread", enabled: false, value: "900" },
+  { key: "telegram_thread_window_strategy", description: "Window strategy: 'sliding' (resets on each new message) or 'fixed' (from first message)", enabled: false, value: "sliding" }
 ].each do |attrs|
   block_toggle = FeatureToggle.find_or_initialize_by(key: attrs[:key])
   if block_toggle.new_record?

--- a/spec/jobs/process_telegram_webhook_job_spec.rb
+++ b/spec/jobs/process_telegram_webhook_job_spec.rb
@@ -555,6 +555,18 @@ RSpec.describe ProcessTelegramWebhookJob do
           expect(thread_draft.reload.content.body.to_plain_text).to include("tiny")
         end
 
+        it "re-runs the player autolink service on the updated draft" do
+          allow(AutolinkPlayersInNewsService).to receive(:call)
+          described_class.new.perform(payload_with(text: "tiny", update_id: 304))
+          expect(AutolinkPlayersInNewsService).to have_received(:call).with(thread_draft)
+        end
+
+        it "does not re-notify editors about the existing draft" do
+          allow(NotifyEditorsAboutDraftService).to receive(:call)
+          described_class.new.perform(payload_with(text: "tiny", update_id: 305))
+          expect(NotifyEditorsAboutDraftService).not_to have_received(:call)
+        end
+
         it "embeds inline photos in body and does not attach to gallery" do
           download_result = Telegram::DownloadFileService::SuccessResult.new(
             io: StringIO.new("fake image"),

--- a/spec/jobs/process_telegram_webhook_job_spec.rb
+++ b/spec/jobs/process_telegram_webhook_job_spec.rb
@@ -481,5 +481,224 @@ RSpec.describe ProcessTelegramWebhookJob do
         expect(Telegram::NewsScorer).not_to have_received(:call)
       end
     end
+
+    context "with thread-window feature toggle enabled" do
+      def enable_thread_window(strategy: "sliding", seconds: 900)
+        upsert_toggle("telegram_thread_window", enabled: true, value: "")
+        upsert_toggle("telegram_thread_window_seconds", enabled: true, value: seconds.to_s)
+        upsert_toggle("telegram_thread_window_strategy", enabled: true, value: strategy)
+      end
+
+      def upsert_toggle(key, enabled:, value:)
+        toggle = FeatureToggle.find_or_initialize_by(key: key)
+        toggle.assign_attributes(enabled: enabled, value: value, description: key)
+        toggle.save!
+      end
+
+      def payload_with(text: long_text, from_id: 12345, update_id: 100, photo: nil)
+        msg = { "from" => { "id" => from_id, "username" => "x", "first_name" => "X" }, "chat" => { "id" => -1 }, "date" => 1710000000 }
+        msg["text"] = text if text
+        msg["photo"] = photo if photo
+        { "update_id" => update_id, "message" => msg }
+      end
+
+      before { enable_thread_window }
+
+      context "when no open thread exists" do
+        it "creates a new draft and marks thread timestamps" do
+          freeze_time do
+            described_class.new.perform(payload_with(update_id: 200))
+            news = News.last
+            expect(news.telegram_thread_started_at).to eq(Time.current)
+            expect(news.telegram_thread_last_message_at).to eq(Time.current)
+          end
+        end
+
+        it "still enforces the MIN_TEXT_LENGTH gate for the opener" do
+          expect {
+            described_class.new.perform(payload_with(text: "short", update_id: 201))
+          }.not_to change(News, :count)
+        end
+      end
+
+      context "when an open thread exists for the same author" do
+        let_it_be(:second_text) { "B" * 50 }
+
+        let!(:thread_draft) do
+          news = News.create!(
+            title: "first",
+            content: "<p>First message body</p>",
+            author: user,
+            status: :draft,
+            telegram_thread_started_at: 2.minutes.ago,
+            telegram_thread_last_message_at: 2.minutes.ago
+          )
+          news
+        end
+
+        it "appends the new text to the existing draft instead of creating one" do
+          expect {
+            described_class.new.perform(payload_with(text: second_text, update_id: 300))
+          }.not_to change(News, :count)
+          expect(thread_draft.reload.content.body.to_html).to include("First message body").and include(second_text)
+        end
+
+        it "updates telegram_thread_last_message_at to now" do
+          freeze_time do
+            described_class.new.perform(payload_with(text: second_text, update_id: 301))
+            expect(thread_draft.reload.telegram_thread_last_message_at).to eq(Time.current)
+          end
+        end
+
+        it "appends short text that would otherwise be rejected by MIN_TEXT_LENGTH" do
+          described_class.new.perform(payload_with(text: "tiny", update_id: 302))
+          expect(thread_draft.reload.content.body.to_plain_text).to include("tiny")
+        end
+
+        it "embeds inline photos in body and does not attach to gallery" do
+          download_result = Telegram::DownloadFileService::SuccessResult.new(
+            io: StringIO.new("fake image"),
+            filename: "p.jpg",
+            content_type: "image/jpeg"
+          )
+          allow(Telegram::DownloadFileService).to receive(:call).and_return(download_result)
+
+          described_class.new.perform(payload_with(
+            text: nil,
+            update_id: 303,
+            photo: [ { "file_id" => "big", "file_size" => 100, "width" => 10, "height" => 10 } ]
+          ))
+
+          thread_draft.reload
+          expect(thread_draft.content.body.to_html).to include("action-text-attachment")
+          expect(thread_draft.photos).not_to be_attached
+        end
+      end
+
+      context "when the most recent thread is past the sliding window" do
+        let!(:stale_draft) do
+          News.create!(
+            title: "old",
+            content: "<p>old</p>",
+            author: user,
+            status: :draft,
+            telegram_thread_started_at: 2.hours.ago,
+            telegram_thread_last_message_at: 30.minutes.ago
+          )
+        end
+
+        before { enable_thread_window(strategy: "sliding", seconds: 900) }
+
+        it "creates a new draft and does not touch the stale one" do
+          expect {
+            described_class.new.perform(payload_with(update_id: 400))
+          }.to change(News, :count).by(1)
+          expect(stale_draft.reload.content.body.to_plain_text).to eq("old")
+        end
+      end
+
+      context "with fixed-window strategy" do
+        before { enable_thread_window(strategy: "fixed", seconds: 600) }
+
+        context "when first message is within the fixed window" do
+          let!(:thread_draft) do
+            News.create!(
+              title: "first",
+              content: "<p>F</p>",
+              author: user,
+              status: :draft,
+              telegram_thread_started_at: 5.minutes.ago,
+              telegram_thread_last_message_at: 1.minute.ago
+            )
+          end
+
+          it "appends to the thread" do
+            expect {
+              described_class.new.perform(payload_with(update_id: 500))
+            }.not_to change(News, :count)
+            expect(thread_draft.reload.content.body.to_html).to include("F")
+          end
+        end
+
+        context "when first message is older than the fixed window" do
+          let!(:thread_draft) do
+            News.create!(
+              title: "stale fixed",
+              content: "<p>S</p>",
+              author: user,
+              status: :draft,
+              telegram_thread_started_at: 20.minutes.ago,
+              telegram_thread_last_message_at: 30.seconds.ago
+            )
+          end
+
+          it "creates a new draft (fixed window does not extend with activity)" do
+            expect {
+              described_class.new.perform(payload_with(update_id: 501))
+            }.to change(News, :count).by(1)
+          end
+        end
+      end
+
+      context "when threaded news belongs to a different author" do
+        let_it_be(:other_user) { create(:user) }
+        let!(:other_draft) do
+          News.create!(
+            title: "other",
+            content: "<p>O</p>",
+            author: other_user,
+            status: :draft,
+            telegram_thread_started_at: 1.minute.ago,
+            telegram_thread_last_message_at: 1.minute.ago
+          )
+        end
+
+        it "creates a new draft for the current author" do
+          expect {
+            described_class.new.perform(payload_with(update_id: 600))
+          }.to change(News, :count).by(1)
+          expect(News.last.author).to eq(user)
+        end
+      end
+
+      context "when the only matching draft was already published" do
+        let!(:published) do
+          News.create!(
+            title: "pub",
+            content: "<p>P</p>",
+            author: user,
+            status: :published,
+            published_at: Time.current,
+            telegram_thread_started_at: 1.minute.ago,
+            telegram_thread_last_message_at: 1.minute.ago
+          )
+        end
+
+        it "creates a new draft and leaves the published article alone" do
+          expect {
+            described_class.new.perform(payload_with(update_id: 700))
+          }.to change(News, :count).by(1)
+          expect(published.reload.content.body.to_plain_text).to eq("P")
+        end
+      end
+    end
+
+    context "with thread-window feature toggle disabled (default)" do
+      it "creates a fresh draft on every qualifying message (no append)" do
+        expect {
+          2.times { |i|
+            described_class.new.perform({
+              "update_id" => 900 + i,
+              "message" => {
+                "text" => long_text,
+                "from" => { "id" => 12345, "username" => "r", "first_name" => "A" },
+                "chat" => { "id" => -1 },
+                "date" => 1710000000
+              }
+            })
+          }
+        }.to change(News, :count).by(2)
+      end
+    end
   end
 end

--- a/spec/models/feature_toggle_spec.rb
+++ b/spec/models/feature_toggle_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe FeatureToggle, type: :model do
     it "includes news autolink players toggle key" do
       expect(described_class::KEYS).to include("news_autolink_players")
     end
+
+    it "includes telegram thread window toggle keys" do
+      expect(described_class::KEYS).to include(
+        "telegram_thread_window",
+        "telegram_thread_window_seconds",
+        "telegram_thread_window_strategy"
+      )
+    end
   end
 
   describe ".enabled?" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,6 +32,8 @@ RSpec.configure do |config|
   config.around do |example|
     I18n.with_locale(I18n.default_locale) { example.run }
   end
+
+  config.before { Rails.cache.clear }
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
## Summary

Enables an optional **thread window** for Telegram webhook ingestion. When the `telegram_thread_window` toggle is on, consecutive messages from the same whitelisted author within a configurable window are merged into one news draft rather than each becoming its own article. Photos that arrive inside the window are embedded inline in the draft body so text and images interleave in posting order.

## Behavior

- A new thread opens only when the first message passes the existing `MIN_TEXT_LENGTH` heuristic (and the score-threshold gate, if configured). This matches the issue: bare images can't trigger a draft on their own, but once a thread is open they extend it.
- Follow-up messages append to the open draft (full HTML content + inline photos) and update `telegram_thread_last_message_at`.
- Two strategies are supported, controlled by `telegram_thread_window_strategy`:
  - `"sliding"` (default): the window resets on every new message — good for an author drafting iteratively.
  - `"fixed"`: the window expires `N` seconds after the **first** message regardless of activity — predictable cutoff.
- When the toggle is off (default for fresh installs and existing rows) the original one-message-one-draft behaviour is unchanged.

## Storage

- `news.telegram_thread_started_at` and `news.telegram_thread_last_message_at` (both nullable datetimes).
- Composite index `(author_id, status, telegram_thread_last_message_at)` keeps the per-author open-thread lookup cheap.
- No background scheduler — the window "closes" implicitly when the next lookup no longer matches. Statelessness keeps things race-tolerant and avoids a per-author timer.

## Config

Three `FeatureToggle` keys, all seeded disabled / with safe defaults:

| Key | Default | Notes |
|-----|---------|-------|
| `telegram_thread_window` | `enabled: false` | Master switch. |
| `telegram_thread_window_seconds` | `enabled: false`, `value: "900"` | Window size in seconds. |
| `telegram_thread_window_strategy` | `enabled: false`, `value: "sliding"` | `"sliding"` or `"fixed"`. |

All three are editable in Avo via the existing `Avo::Resources::FeatureToggle` (auto-picks up new entries in `FeatureToggle::KEYS`).

## Photo handling

Inside a thread, photos are embedded as `<action-text-attachment>` blobs in the ActionText body at the position they arrived. The `news.photos` gallery is **not** populated in that mode — this prevents the same image showing up twice when the draft is rendered. With the toggle off, photo behaviour is exactly as before (gallery attach).

## Test plan

- [x] `bundle exec rspec spec/` — 2183 examples, 0 failures (includes new spec coverage in `spec/jobs/process_telegram_webhook_job_spec.rb` for: thread-disabled regression, opener gate, append text, append short text post-open, inline-photo embed + no gallery attach, stale window, sliding vs fixed, per-author isolation, published-draft skip).
- [x] `bundle exec rubocop` — clean
- [x] `bundle exec evilution run app/jobs/process_telegram_webhook_job.rb --jobs 4` — 100% (80/80)
- [ ] `bundle exec mutant run -- 'ProcessTelegramWebhookJob'` — running; will follow up with results before merge

## Open questions / out of scope

- **Webhook retries / duplicate `update_id`**: Telegram occasionally redelivers; this PR doesn't dedupe on `update_id`. Pre-existing behaviour; can be a separate hardening pass.
- **Concurrent webhook jobs for the same author**: two near-simultaneous messages could both miss the open-thread lookup and both create drafts. Acceptable for now (rare, easy to merge editorially); a follow-up could rescue + retry.

Closes #851

🤖 Generated with [Claude Code](https://claude.com/claude-code)