### PR TITLE
fix(csp): allow blob: in img-src for Trix attachment previews

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
     policy.default_src     :self
     policy.script_src      :self, :https
     policy.style_src       :self, :https, :unsafe_inline
-    policy.img_src         :self, :https, :data
+    policy.img_src         :self, :https, :data, :blob # blob: — Trix editor image-attachment previews
     policy.font_src        :self, :https, :data
     policy.connect_src     :self, :https
     policy.object_src      :none

--- a/spec/requests/content_security_policy_spec.rb
+++ b/spec/requests/content_security_policy_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe "Content-Security-Policy header" do
       expect(csp).to include("style-src 'self' https: 'unsafe-inline'")
     end
 
-    it "permits img-src self + https + data" do
-      expect(csp).to include("img-src 'self' https: data:")
+    it "permits img-src self + https + data + blob (Trix attachment previews)" do
+      expect(csp).to include("img-src 'self' https: data: blob:")
     end
 
     it "permits font-src self + https + data" do


### PR DESCRIPTION
## Summary
- Production CSP report-only surfaced an `img-src` violation (#860): `blocked-uri: "blob"`, `source-file: trix-*.js`, `document-uri: /admin/news/.../edit`.
- The Trix editor (ActionText) creates `blob:` object URLs to preview image attachments during upload. `img-src` allowed `self`/`https`/`data` but not `blob:`.
- Once vm-1rb (#819) flips CSP to enforce mode, Trix image previews would be **blocked** for every admin editing news. This report-only period exists exactly to catch this.
- Fix: add `:blob` to `policy.img_src`.
- Closes #860

## Test plan
- [x] `spec/requests/content_security_policy_spec.rb` — `img-src` assertion tightened to require `blob:`; fails before the fix, passes after. Full file: 13 examples, 0 failures.
- [ ] In production after deploy: attach an image in the news editor → no new `img-src` CSP report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)