### PR TITLE
fix(news): stop duplicate-mention crash in player autolinking

### DIFF
--- a/app/services/autolink_players_in_news_service.rb
+++ b/app/services/autolink_players_in_news_service.rb
@@ -43,7 +43,10 @@ class AutolinkPlayersInNewsService
 
   def sync_mentions(player_ids)
     player_ids.each do |player_id|
-      NewsPlayerMention.create_or_find_by!(news: @news, player_id: player_id)
+      NewsPlayerMention.find_or_create_by!(news: @news, player_id: player_id)
+    rescue ActiveRecord::RecordInvalid
+      # A concurrent autolink run inserted this mention between our find and
+      # create. The uniqueness validation proves it exists — nothing to do.
     end
   end
 

--- a/spec/services/autolink_players_in_news_service_spec.rb
+++ b/spec/services/autolink_players_in_news_service_spec.rb
@@ -228,6 +228,26 @@ RSpec.describe AutolinkPlayersInNewsService do
         expect { described_class.call(news) }.not_to change(NewsPlayerMention, :count)
       end
 
+      it "does not raise when the player already has a mention from a previous run" do
+        news = build_news("<div>Alex scored a goal</div>")
+        NewsPlayerMention.create!(news: news, player: alex)
+        expect { described_class.call(news) }.not_to raise_error
+      end
+
+      it "keeps a single mention when the player already has one" do
+        news = build_news("<div>Alex scored a goal</div>")
+        NewsPlayerMention.create!(news: news, player: alex)
+        described_class.call(news)
+        expect(news.reload.player_mentions.where(player: alex).count).to eq(1)
+      end
+
+      it "tolerates a RecordInvalid from a concurrent mention insert" do
+        news = build_news("<div>Alex scored a goal</div>")
+        allow(NewsPlayerMention).to receive(:find_or_create_by!)
+          .and_raise(ActiveRecord::RecordInvalid.new(NewsPlayerMention.new))
+        expect { described_class.call(news) }.not_to raise_error
+      end
+
       it "records only one mention per player even when the name appears multiple times" do
         news = build_news("<div>Alex passed to Alex again</div>")
         described_class.call(news)


### PR DESCRIPTION
## Summary
- `ProcessTelegramWebhookJob` crashed in production with `ActiveRecord::RecordInvalid: Player уже существует` (#861).
- Root cause: `AutolinkPlayersInNewsService#sync_mentions` used `create_or_find_by!`, which only rescues the **DB-level** `RecordNotUnique`. `NewsPlayerMention` also has a **model-level** `validates :player_id, uniqueness: { scope: :news_id }` — that validation runs a SELECT before the INSERT and raises `RecordInvalid`, which `create_or_find_by!` does not rescue.
- Triggered when autolinking re-runs on a news that already has the mention — the vm-z20 (#856) threaded-message append path re-runs autolinking on every appended message.
- Fix: `find_or_create_by!` (find-first — the common path never reaches `create!`, so the validation never fires) + `rescue ActiveRecord::RecordInvalid` for the concurrent-insert race.
- Closes #861

## Root cause confirmed
Two new specs reproduce the exact production error (`RecordInvalid: Player уже существует`) — they fail before the fix, pass after.

## Mutation testing
- Evilution: 7/10 killed, 0 survived (3 equivalent mutants).
- Mutant: 21/21 killed, 100%.

## Test plan
- [x] `spec/services/autolink_players_in_news_service_spec.rb` — +3 examples (pre-existing mention → no raise; no duplicate; concurrent-race tolerance). Full file 37 examples, 0 failures.
- [x] No regressions: `ProcessTelegramWebhookJob`, `ForceImportService`, `NewsPlayerMention` specs — 127 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)