### PR TITLE
fix(telegram): serialize webhook jobs per sender (vm-jtj)

### DIFF
--- a/app/jobs/process_telegram_webhook_job.rb
+++ b/app/jobs/process_telegram_webhook_job.rb
@@ -1,6 +1,13 @@
 class ProcessTelegramWebhookJob < ApplicationJob
   queue_as :default
 
+  limits_concurrency to: 1,
+                     key: ->(payload) {
+                       message = payload["message"] || payload["edited_message"]
+                       message&.dig("from", "id")
+                     },
+                     duration: 5.minutes
+
   MAX_TITLE_LENGTH = 255
   MIN_TEXT_LENGTH = 500
 

--- a/spec/jobs/process_telegram_webhook_job_spec.rb
+++ b/spec/jobs/process_telegram_webhook_job_spec.rb
@@ -798,4 +798,29 @@ RSpec.describe ProcessTelegramWebhookJob do
       end
     end
   end
+
+  describe "concurrency controls" do
+    it "serializes jobs to one at a time per Telegram sender" do
+      expect(described_class.concurrency_limit).to eq(1)
+    end
+
+    it "keys the concurrency lock on the sender's Telegram user id" do
+      job = described_class.new(payload)
+      expect(job.concurrency_key).to include("12345")
+    end
+
+    it "falls back to edited_message sender when message is absent" do
+      edited_payload = {
+        "update_id" => 2,
+        "edited_message" => {
+          "text" => long_text,
+          "from" => { "id" => 99999, "username" => "reporter" },
+          "chat" => { "id" => -100123 },
+          "date" => 1710000000
+        }
+      }
+      job = described_class.new(edited_payload)
+      expect(job.concurrency_key).to include("99999")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Two Telegram messages from the same author arriving within ~200ms were processed by parallel SolidQueue workers. Both jobs called `find_open_thread` before either had saved its draft, so both fell through to `create_new_draft`. Later messages in the burst appended to one of them, producing the observed "two drafts, one with the body tripled" pattern.
- Adds `limits_concurrency to: 1, key: <sender_id>, duration: 5.minutes` on `ProcessTelegramWebhookJob` so SolidQueue serializes processing per Telegram sender.

## Why this works

By the time the second job for a given author runs, the first has saved its draft. `find_open_thread` returns it, and `append_to_thread` extends it as designed by the batching feature. No two-draft race remains.

## Reproduction confirmation

SQLite query against `news` showed three duplicate-draft pairs over 7 days, gaps 33ms–217ms — clearly concurrent worker processing rather than retries or human action.

## Test plan
- [x] New specs verify `concurrency_limit`, `concurrency_key` from `message`, and fallback to `edited_message`
- [x] All 61 job specs pass
- [x] 237 telegram-domain specs pass
- [x] rubocop clean
- [x] Evilution on changed file: 0 survived (score 0.981, 496 mutations)
- [x] Mutant on `ProcessTelegramWebhookJob`: 826/836 killed, 10 alive predate this change (class-level DSL not mutable)

Closes #868