### PR TITLE
fix(avo): replace ILIKE with LOWER LIKE for SQLite compat (vm-2y0)

### DIFF
--- a/app/avo/resources/award.rb
+++ b/app/avo/resources/award.rb
@@ -3,7 +3,7 @@ class Avo::Resources::Award < Avo::BaseResource
   self.default_view_type = :table
 
   self.search = {
-    query: -> { query.where("title ILIKE ?", "%#{params[:q]}%") }
+    query: -> { query.where("LOWER(title) LIKE LOWER(?)", "%#{params[:q]}%") }
   }
 
   self.index_query = -> {

--- a/app/avo/resources/episode.rb
+++ b/app/avo/resources/episode.rb
@@ -5,7 +5,7 @@ class Avo::Resources::Episode < Avo::BaseResource
   self.default_view_type = :table
 
   self.search = {
-    query: -> { query.where("title ILIKE ?", "%#{params[:q]}%") }
+    query: -> { query.where("LOWER(title) LIKE LOWER(?)", "%#{params[:q]}%") }
   }
 
   def fields

--- a/app/avo/resources/game.rb
+++ b/app/avo/resources/game.rb
@@ -6,7 +6,7 @@ class Avo::Resources::Game < Avo::BaseResource
   }
 
   self.search = {
-    query: -> { query.where("name ILIKE ?", "%#{params[:q]}%") }
+    query: -> { query.where("LOWER(name) LIKE LOWER(?)", "%#{params[:q]}%") }
   }
 
   def fields

--- a/app/avo/resources/grant.rb
+++ b/app/avo/resources/grant.rb
@@ -2,7 +2,7 @@ class Avo::Resources::Grant < Avo::BaseResource
   self.title = :code
 
   self.search = {
-    query: -> { query.where("code ILIKE ?", "%#{params[:q]}%") }
+    query: -> { query.where("LOWER(code) LIKE LOWER(?)", "%#{params[:q]}%") }
   }
 
   def fields

--- a/app/avo/resources/player.rb
+++ b/app/avo/resources/player.rb
@@ -6,7 +6,7 @@ class Avo::Resources::Player < Avo::BaseResource
   }
 
   self.search = {
-    query: -> { query.where("name ILIKE ?", "%#{params[:q]}%") }
+    query: -> { query.where("LOWER(name) LIKE LOWER(?)", "%#{params[:q]}%") }
   }
 
   def fields

--- a/app/avo/resources/playlist.rb
+++ b/app/avo/resources/playlist.rb
@@ -5,7 +5,7 @@ class Avo::Resources::Playlist < Avo::BaseResource
   self.default_view_type = :table
 
   self.search = {
-    query: -> { query.where("title ILIKE ?", "%#{params[:q]}%") }
+    query: -> { query.where("LOWER(title) LIKE LOWER(?)", "%#{params[:q]}%") }
   }
 
   def fields

--- a/app/avo/resources/user.rb
+++ b/app/avo/resources/user.rb
@@ -3,7 +3,7 @@ class Avo::Resources::User < Avo::BaseResource
   self.includes = [ :player ]
 
   self.search = {
-    query: -> { query.left_joins(:player).where("users.email ILIKE :q OR players.name ILIKE :q", q: "%#{params[:q]}%") }
+    query: -> { query.left_joins(:player).where("LOWER(users.email) LIKE LOWER(:q) OR LOWER(players.name) LIKE LOWER(:q)", q: "%#{params[:q]}%") }
   }
 
   def fields

--- a/spec/avo/resources/player_spec.rb
+++ b/spec/avo/resources/player_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Avo::Resources::Player do
     end
 
     it "executes without raising a SQLite syntax error" do
-      expect { run_search("anything") }.not_to raise_error
+      expect { run_search("anything").to_a }.not_to raise_error
     end
 
     it "matches ASCII names case-insensitively" do

--- a/spec/avo/resources/player_spec.rb
+++ b/spec/avo/resources/player_spec.rb
@@ -14,4 +14,29 @@ RSpec.describe Avo::Resources::Player do
       expect(resource.items.map(&:id)).not_to include(:position)
     end
   end
+
+  describe "search query" do
+    let_it_be(:cyrillic_player) { create(:player, name: "Иван") }
+    let_it_be(:ascii_player) { create(:player, name: "Alexei") }
+
+    def run_search(q)
+      Avo::ExecutionContext.new(
+        target: described_class.search[:query],
+        query: Player.all,
+        params: { q: q }
+      ).handle
+    end
+
+    it "executes without raising a SQLite syntax error" do
+      expect { run_search("anything") }.not_to raise_error
+    end
+
+    it "matches ASCII names case-insensitively" do
+      expect(run_search("ALEX")).to contain_exactly(ascii_player)
+    end
+
+    it "matches Cyrillic names by exact-case substring" do
+      expect(run_search("Иван")).to contain_exactly(cyrillic_player)
+    end
+  end
 end

--- a/spec/avo/resources/user_spec.rb
+++ b/spec/avo/resources/user_spec.rb
@@ -18,6 +18,32 @@ RSpec.describe Avo::Resources::User do
       expect(described_class.search).to be_a(Hash)
       expect(described_class.search[:query]).to be_present
     end
+
+    context "query execution" do
+      let_it_be(:by_email) { create(:user, email: "alex@example.com") }
+      let_it_be(:player) { create(:player, name: "Maria") }
+      let_it_be(:by_player_name) { create(:user, player: player) }
+
+      def run_search(q)
+        Avo::ExecutionContext.new(
+          target: described_class.search[:query],
+          query: User.all,
+          params: { q: q }
+        ).handle
+      end
+
+      it "executes without raising a SQLite syntax error" do
+        expect { run_search("anything") }.not_to raise_error
+      end
+
+      it "matches by email case-insensitively" do
+        expect(run_search("ALEX@EXAMPLE")).to include(by_email)
+      end
+
+      it "matches by linked player name case-insensitively" do
+        expect(run_search("MARIA")).to include(by_player_name)
+      end
+    end
   end
 
   describe "actions" do

--- a/spec/avo/resources/user_spec.rb
+++ b/spec/avo/resources/user_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Avo::Resources::User do
       end
 
       it "executes without raising a SQLite syntax error" do
-        expect { run_search("anything") }.not_to raise_error
+        expect { run_search("anything").to_a }.not_to raise_error
       end
 
       it "matches by email case-insensitively" do


### PR DESCRIPTION
## Summary

Avo resource search blocks used `ILIKE`, which is Postgres-only syntax. The app runs SQLite, so every Avo search request hit the production exception captured by Sentry as RUBY-RAILS-9: `SQLite3::SQLException: near "ILIKE": syntax error`.

Affected resources (all reproduce the crash on first search keystroke):
- Player, User, Game, Award, Grant, Playlist, Episode

Replaced `ILIKE` with `LOWER(col) LIKE LOWER(?)`. Works on SQLite and Postgres, preserves ASCII case-insensitivity, falls back to case-sensitive matching for Cyrillic since SQLite's stock `lower()` is ASCII-only — acceptable degradation for the admin search box.

## Test plan
- [x] New spec on `Avo::Resources::Player`: no SQLite syntax error, ASCII case-insensitive match, Cyrillic substring match
- [x] New spec on `Avo::Resources::User`: both email and joined player.name branches of the OR
- [x] `bundle exec rspec spec/avo/` — 58 examples, 0 failures
- [x] rubocop clean
- [x] Evilution on player+user resources: 70 mutations, 0 survived, score 1.0
- [x] Mutant skipped: only `def` bodies mutated, Avo resources are pure DSL

Closes #873