### PR TITLE
fix(active_storage): discard AnalyzeJob on missing file (vm-m4x)

### DIFF
--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,0 +1,12 @@
+Rails.application.config.after_initialize do
+  ActiveStorage::AnalyzeJob.discard_on ActiveStorage::FileNotFoundError do |job, error|
+    Rails.logger.warn(
+      {
+        event: "active_storage.analyze_job.file_missing",
+        job_id: job.job_id,
+        blob_id: job.arguments.first&.id,
+        error: error.message
+      }.to_json
+    )
+  end
+end

--- a/spec/jobs/active_storage/analyze_job_spec.rb
+++ b/spec/jobs/active_storage/analyze_job_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe ActiveStorage::AnalyzeJob do
+  describe "missing-file handling" do
+    let(:blob) do
+      ActiveStorage::Blob.create_and_upload!(
+        io: StringIO.new("not really a png"),
+        filename: "missing.png",
+        content_type: "image/png"
+      )
+    end
+
+    before { ActiveStorage::Blob.service.delete(blob.key) }
+
+    it "discards ActiveStorage::FileNotFoundError instead of raising" do
+      expect { described_class.perform_now(blob) }.not_to raise_error
+    end
+
+    it "registers a rescue handler for ActiveStorage::FileNotFoundError" do
+      handler_classes = described_class.rescue_handlers.map(&:first)
+      expect(handler_classes).to include("ActiveStorage::FileNotFoundError")
+    end
+
+    it "logs a structured warning when discarding" do
+      allow(Rails.logger).to receive(:warn)
+      allow_any_instance_of(ActiveStorage::Blob).to receive(:analyze)
+        .and_raise(ActiveStorage::FileNotFoundError)
+
+      described_class.perform_now(blob)
+
+      expect(Rails.logger).to have_received(:warn) do |payload|
+        parsed = JSON.parse(payload)
+        expect(parsed["event"]).to eq("active_storage.analyze_job.file_missing")
+        expect(parsed["blob_id"]).to eq(blob.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`ActiveStorage::AnalyzeJob` crashed in production with `ActiveStorage::FileNotFoundError` when the blob row existed but the underlying disk file was missing (purged, never persisted, or storage volume issue). SolidQueue retried indefinitely, generating Sentry noise (RUBY-RAILS-A).

Adds an after-initialize hook that registers `discard_on ActiveStorage::FileNotFoundError` against `ActiveStorage::AnalyzeJob` with a structured-log handler so the job stops retrying and we still get a single audit-grade warning per occurrence.

## Test plan
- [x] Specs verify: handler registered, perform_now does not raise when file missing, structured warning logged with `event=active_storage.analyze_job.file_missing` and `blob_id`
- [x] `bundle exec rspec spec/jobs/active_storage/analyze_job_spec.rb` — 3 examples, 0 failures
- [x] rubocop clean
- [x] Evilution: file has no subjects (top-level config block); mutant skipped for same reason. Behavioral spec coverage stands in.

Closes #875