### PR TITLE
feat(active_storage): rake task to scrub orphan AnalyzeJob entries (vm-ox3)

### DIFF
--- a/app/services/active_storage/analyze_job_scrubber.rb
+++ b/app/services/active_storage/analyze_job_scrubber.rb
@@ -15,11 +15,19 @@ class ActiveStorage::AnalyzeJobScrubber
   end
 
   def call
-    @scope.each { |sq_job| handle(sq_job) }
+    iterate { |sq_job| handle(sq_job) }
     Result.new(scanned: @scanned, orphaned: @orphaned)
   end
 
   private
+
+  def iterate(&block)
+    if @scope.respond_to?(:find_each)
+      @scope.find_each(&block)
+    else
+      @scope.each(&block)
+    end
+  end
 
   def handle(sq_job)
     @scanned += 1

--- a/app/services/active_storage/analyze_job_scrubber.rb
+++ b/app/services/active_storage/analyze_job_scrubber.rb
@@ -1,67 +1,65 @@
-module ActiveStorage
-  class AnalyzeJobScrubber
-    Result = Data.define(:scanned, :orphaned)
+class ActiveStorage::AnalyzeJobScrubber
+  Result = Data.define(:scanned, :orphaned)
 
-    DEFAULT_SCOPE = -> { SolidQueue::Job.where(class_name: "ActiveStorage::AnalyzeJob", finished_at: nil) }
+  DEFAULT_SCOPE = -> { SolidQueue::Job.where(class_name: "ActiveStorage::AnalyzeJob", finished_at: nil) }
 
-    def self.call(dry_run: false, scope: DEFAULT_SCOPE.call)
-      new(dry_run: dry_run, scope: scope).call
-    end
+  def self.call(dry_run: false, scope: DEFAULT_SCOPE.call)
+    new(dry_run: dry_run, scope: scope).call
+  end
 
-    def initialize(dry_run:, scope:)
-      @dry_run = dry_run
-      @scope = scope
-      @scanned = 0
-      @orphaned = 0
-    end
+  def initialize(dry_run:, scope:)
+    @dry_run = dry_run
+    @scope = scope
+    @scanned = 0
+    @orphaned = 0
+  end
 
-    def call
-      @scope.each { |sq_job| handle(sq_job) }
-      Result.new(scanned: @scanned, orphaned: @orphaned)
-    end
+  def call
+    @scope.each { |sq_job| handle(sq_job) }
+    Result.new(scanned: @scanned, orphaned: @orphaned)
+  end
 
-    private
+  private
 
-    def handle(sq_job)
-      @scanned += 1
-      blob_id = extract_blob_id(sq_job.arguments)
-      return if blob_id.nil?
+  def handle(sq_job)
+    @scanned += 1
+    blob_id = extract_blob_id(sq_job.arguments)
+    return if blob_id.nil?
 
-      blob = ::ActiveStorage::Blob.find_by(id: blob_id)
-      reason = orphan_reason(blob)
-      return if reason.nil?
+    blob = ::ActiveStorage::Blob.find_by(id: blob_id)
+    reason = orphan_reason(blob)
+    return if reason.nil?
 
-      @orphaned += 1
-      log(sq_job, blob_id, reason)
-      sq_job.discard unless @dry_run
-    end
+    @orphaned += 1
+    log(sq_job, blob_id, reason)
+    sq_job.discard unless @dry_run
+  end
 
-    def orphan_reason(blob)
-      return "blob row missing" if blob.nil?
-      return "blob file missing" unless blob.service.exist?(blob.key)
+  def orphan_reason(blob)
+    return "blob row missing" if blob.nil?
+    return "blob file missing" unless blob.service.exist?(blob.key)
 
-      nil
-    end
+    nil
+  end
 
-    def extract_blob_id(arguments)
-      gid = arguments.dig("arguments", 0, "_aj_globalid")
-      return nil if gid.blank?
+  def extract_blob_id(arguments)
+    gid = arguments.dig("arguments", 0, "_aj_globalid")
+    return nil if gid.blank?
 
-      Integer(gid.split("/").last, 10)
-    rescue ArgumentError, TypeError
-      nil
-    end
+    Integer(gid.split("/").last, 10)
+  rescue ArgumentError, TypeError
+    nil
+  end
 
-    def log(sq_job, blob_id, reason)
-      Rails.logger.warn(
-        {
-          event: "active_storage.scrub.orphan_analyze_job",
-          sq_job_id: sq_job.id,
-          blob_id: blob_id,
-          reason: reason,
-          dry_run: @dry_run
-        }.to_json
-      )
-    end
+  def log(sq_job, blob_id, reason)
+    Rails.logger.warn(
+      {
+        event: "active_storage.scrub.orphan_analyze_job",
+        sq_job_id: sq_job.id,
+        blob_id: blob_id,
+        reason: reason,
+        dry_run: @dry_run
+      }.to_json
+    )
   end
 end

--- a/app/services/active_storage/analyze_job_scrubber.rb
+++ b/app/services/active_storage/analyze_job_scrubber.rb
@@ -1,0 +1,67 @@
+module ActiveStorage
+  class AnalyzeJobScrubber
+    Result = Data.define(:scanned, :orphaned)
+
+    DEFAULT_SCOPE = -> { SolidQueue::Job.where(class_name: "ActiveStorage::AnalyzeJob", finished_at: nil) }
+
+    def self.call(dry_run: false, scope: DEFAULT_SCOPE.call)
+      new(dry_run: dry_run, scope: scope).call
+    end
+
+    def initialize(dry_run:, scope:)
+      @dry_run = dry_run
+      @scope = scope
+      @scanned = 0
+      @orphaned = 0
+    end
+
+    def call
+      @scope.each { |sq_job| handle(sq_job) }
+      Result.new(scanned: @scanned, orphaned: @orphaned)
+    end
+
+    private
+
+    def handle(sq_job)
+      @scanned += 1
+      blob_id = extract_blob_id(sq_job.arguments)
+      return if blob_id.nil?
+
+      blob = ::ActiveStorage::Blob.find_by(id: blob_id)
+      reason = orphan_reason(blob)
+      return if reason.nil?
+
+      @orphaned += 1
+      log(sq_job, blob_id, reason)
+      sq_job.discard unless @dry_run
+    end
+
+    def orphan_reason(blob)
+      return "blob row missing" if blob.nil?
+      return "blob file missing" unless blob.service.exist?(blob.key)
+
+      nil
+    end
+
+    def extract_blob_id(arguments)
+      gid = arguments.dig("arguments", 0, "_aj_globalid")
+      return nil if gid.blank?
+
+      Integer(gid.split("/").last, 10)
+    rescue ArgumentError, TypeError
+      nil
+    end
+
+    def log(sq_job, blob_id, reason)
+      Rails.logger.warn(
+        {
+          event: "active_storage.scrub.orphan_analyze_job",
+          sq_job_id: sq_job.id,
+          blob_id: blob_id,
+          reason: reason,
+          dry_run: @dry_run
+        }.to_json
+      )
+    end
+  end
+end

--- a/lib/tasks/active_storage.rake
+++ b/lib/tasks/active_storage.rake
@@ -1,0 +1,8 @@
+namespace :active_storage do
+  desc "Discard queued AnalyzeJob entries whose blob row or file is missing. DRY_RUN=1 to preview."
+  task scrub_orphan_analyze_jobs: :environment do
+    dry_run = ENV["DRY_RUN"] == "1"
+    result = ActiveStorage::AnalyzeJobScrubber.call(dry_run: dry_run)
+    puts "scanned=#{result.scanned} orphaned=#{result.orphaned} dry_run=#{dry_run}"
+  end
+end

--- a/spec/services/active_storage/analyze_job_scrubber_spec.rb
+++ b/spec/services/active_storage/analyze_job_scrubber_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ActiveStorage::AnalyzeJobScrubber do
-  FakeJob = Struct.new(:id, :arguments, keyword_init: true) do
+  fake_job_class = Struct.new(:id, :arguments, keyword_init: true) do
     def discard
       @discarded = true
     end
@@ -10,6 +10,8 @@ RSpec.describe ActiveStorage::AnalyzeJobScrubber do
       @discarded == true
     end
   end
+
+  define_method(:fake_job) { |**attrs| fake_job_class.new(**attrs) }
 
   def gid_for(blob_id)
     { "arguments" => [ { "_aj_globalid" => "gid://vanilla-mafia/ActiveStorage::Blob/#{blob_id}" } ] }
@@ -27,7 +29,7 @@ RSpec.describe ActiveStorage::AnalyzeJobScrubber do
 
   describe "blob row missing" do
     it "counts orphan and discards the job" do
-      job = FakeJob.new(id: 1, arguments: gid_for(999_999))
+      job = fake_job(id: 1, arguments: gid_for(999_999))
 
       result = described_class.call(scope: [ job ])
 
@@ -37,7 +39,7 @@ RSpec.describe ActiveStorage::AnalyzeJobScrubber do
 
     it "logs the orphan with the correct blob_id, sq_job_id, and reason" do
       allow(Rails.logger).to receive(:warn)
-      job = FakeJob.new(id: 42, arguments: gid_for(999_999))
+      job = fake_job(id: 42, arguments: gid_for(999_999))
 
       described_class.call(scope: [ job ])
 
@@ -57,7 +59,7 @@ RSpec.describe ActiveStorage::AnalyzeJobScrubber do
   describe "blob present but file missing on disk" do
     it "counts orphan and discards" do
       blob = build_blob(file_missing: true)
-      job = FakeJob.new(id: 2, arguments: gid_for(blob.id))
+      job = fake_job(id: 2, arguments: gid_for(blob.id))
 
       result = described_class.call(scope: [ job ])
 
@@ -68,7 +70,7 @@ RSpec.describe ActiveStorage::AnalyzeJobScrubber do
     it "logs the orphan with reason 'blob file missing'" do
       allow(Rails.logger).to receive(:warn)
       blob = build_blob(file_missing: true)
-      job = FakeJob.new(id: 7, arguments: gid_for(blob.id))
+      job = fake_job(id: 7, arguments: gid_for(blob.id))
 
       described_class.call(scope: [ job ])
 
@@ -82,7 +84,7 @@ RSpec.describe ActiveStorage::AnalyzeJobScrubber do
   describe "blob and file both present" do
     it "leaves the job in place" do
       blob = build_blob
-      job = FakeJob.new(id: 3, arguments: gid_for(blob.id))
+      job = fake_job(id: 3, arguments: gid_for(blob.id))
 
       result = described_class.call(scope: [ job ])
 
@@ -93,7 +95,7 @@ RSpec.describe ActiveStorage::AnalyzeJobScrubber do
 
   describe "dry_run: true" do
     it "counts orphans but does not discard" do
-      job = FakeJob.new(id: 4, arguments: gid_for(999_999))
+      job = fake_job(id: 4, arguments: gid_for(999_999))
 
       result = described_class.call(scope: [ job ], dry_run: true)
 
@@ -103,7 +105,7 @@ RSpec.describe ActiveStorage::AnalyzeJobScrubber do
 
     it "marks the log payload as dry_run" do
       allow(Rails.logger).to receive(:warn)
-      job = FakeJob.new(id: 5, arguments: gid_for(999_999))
+      job = fake_job(id: 5, arguments: gid_for(999_999))
 
       described_class.call(scope: [ job ], dry_run: true)
 
@@ -116,7 +118,7 @@ RSpec.describe ActiveStorage::AnalyzeJobScrubber do
   describe "blob_id extraction" do
     it "parses the final integer segment of the GlobalID" do
       blob = build_blob(file_missing: true)
-      job = FakeJob.new(id: 8, arguments: gid_for(blob.id))
+      job = fake_job(id: 8, arguments: gid_for(blob.id))
       allow(Rails.logger).to receive(:warn)
 
       described_class.call(scope: [ job ])
@@ -129,7 +131,7 @@ RSpec.describe ActiveStorage::AnalyzeJobScrubber do
 
   describe "unparseable globalid" do
     it "skips the job without raising" do
-      job = FakeJob.new(id: 5, arguments: { "arguments" => [ { "_aj_globalid" => "not-a-gid" } ] })
+      job = fake_job(id: 5, arguments: { "arguments" => [ { "_aj_globalid" => "not-a-gid" } ] })
 
       expect { described_class.call(scope: [ job ]) }.not_to raise_error
       expect(job).not_to be_discarded
@@ -138,7 +140,7 @@ RSpec.describe ActiveStorage::AnalyzeJobScrubber do
 
   describe "missing arguments key" do
     it "skips the job" do
-      job = FakeJob.new(id: 6, arguments: {})
+      job = fake_job(id: 6, arguments: {})
 
       result = described_class.call(scope: [ job ])
 

--- a/spec/services/active_storage/analyze_job_scrubber_spec.rb
+++ b/spec/services/active_storage/analyze_job_scrubber_spec.rb
@@ -1,0 +1,150 @@
+require "rails_helper"
+
+RSpec.describe ActiveStorage::AnalyzeJobScrubber do
+  FakeJob = Struct.new(:id, :arguments, keyword_init: true) do
+    def discard
+      @discarded = true
+    end
+
+    def discarded?
+      @discarded == true
+    end
+  end
+
+  def gid_for(blob_id)
+    { "arguments" => [ { "_aj_globalid" => "gid://vanilla-mafia/ActiveStorage::Blob/#{blob_id}" } ] }
+  end
+
+  def build_blob(file_missing: false)
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new("payload"),
+      filename: "f.png",
+      content_type: "image/png"
+    )
+    blob.service.delete(blob.key) if file_missing
+    blob
+  end
+
+  describe "blob row missing" do
+    it "counts orphan and discards the job" do
+      job = FakeJob.new(id: 1, arguments: gid_for(999_999))
+
+      result = described_class.call(scope: [ job ])
+
+      expect(result).to have_attributes(scanned: 1, orphaned: 1)
+      expect(job).to be_discarded
+    end
+
+    it "logs the orphan with the correct blob_id, sq_job_id, and reason" do
+      allow(Rails.logger).to receive(:warn)
+      job = FakeJob.new(id: 42, arguments: gid_for(999_999))
+
+      described_class.call(scope: [ job ])
+
+      expect(Rails.logger).to have_received(:warn) do |payload|
+        parsed = JSON.parse(payload)
+        expect(parsed).to include(
+          "event" => "active_storage.scrub.orphan_analyze_job",
+          "sq_job_id" => 42,
+          "blob_id" => 999_999,
+          "reason" => "blob row missing",
+          "dry_run" => false
+        )
+      end
+    end
+  end
+
+  describe "blob present but file missing on disk" do
+    it "counts orphan and discards" do
+      blob = build_blob(file_missing: true)
+      job = FakeJob.new(id: 2, arguments: gid_for(blob.id))
+
+      result = described_class.call(scope: [ job ])
+
+      expect(result.orphaned).to eq(1)
+      expect(job).to be_discarded
+    end
+
+    it "logs the orphan with reason 'blob file missing'" do
+      allow(Rails.logger).to receive(:warn)
+      blob = build_blob(file_missing: true)
+      job = FakeJob.new(id: 7, arguments: gid_for(blob.id))
+
+      described_class.call(scope: [ job ])
+
+      expect(Rails.logger).to have_received(:warn) do |payload|
+        parsed = JSON.parse(payload)
+        expect(parsed).to include("reason" => "blob file missing", "blob_id" => blob.id)
+      end
+    end
+  end
+
+  describe "blob and file both present" do
+    it "leaves the job in place" do
+      blob = build_blob
+      job = FakeJob.new(id: 3, arguments: gid_for(blob.id))
+
+      result = described_class.call(scope: [ job ])
+
+      expect(result.orphaned).to eq(0)
+      expect(job).not_to be_discarded
+    end
+  end
+
+  describe "dry_run: true" do
+    it "counts orphans but does not discard" do
+      job = FakeJob.new(id: 4, arguments: gid_for(999_999))
+
+      result = described_class.call(scope: [ job ], dry_run: true)
+
+      expect(result.orphaned).to eq(1)
+      expect(job).not_to be_discarded
+    end
+
+    it "marks the log payload as dry_run" do
+      allow(Rails.logger).to receive(:warn)
+      job = FakeJob.new(id: 5, arguments: gid_for(999_999))
+
+      described_class.call(scope: [ job ], dry_run: true)
+
+      expect(Rails.logger).to have_received(:warn) do |payload|
+        expect(JSON.parse(payload)["dry_run"]).to be(true)
+      end
+    end
+  end
+
+  describe "blob_id extraction" do
+    it "parses the final integer segment of the GlobalID" do
+      blob = build_blob(file_missing: true)
+      job = FakeJob.new(id: 8, arguments: gid_for(blob.id))
+      allow(Rails.logger).to receive(:warn)
+
+      described_class.call(scope: [ job ])
+
+      expect(Rails.logger).to have_received(:warn) do |payload|
+        expect(JSON.parse(payload)["blob_id"]).to eq(blob.id)
+      end
+    end
+  end
+
+  describe "unparseable globalid" do
+    it "skips the job without raising" do
+      job = FakeJob.new(id: 5, arguments: { "arguments" => [ { "_aj_globalid" => "not-a-gid" } ] })
+
+      expect { described_class.call(scope: [ job ]) }.not_to raise_error
+      expect(job).not_to be_discarded
+    end
+  end
+
+  describe "missing arguments key" do
+    it "skips the job" do
+      job = FakeJob.new(id: 6, arguments: {})
+
+      result = described_class.call(scope: [ job ])
+
+      expect(result.scanned).to eq(1)
+      expect(result.orphaned).to eq(0)
+      expect(job).not_to be_discarded
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Follow-up to PR #877 (vm-m4x). That PR added \`discard_on ActiveStorage::FileNotFoundError\` so new AnalyzeJob failures stop retrying. This PR clears the backlog — queued rows whose blob row or file is already gone get discarded up-front instead of waiting for their next run.

* New \`ActiveStorage::AnalyzeJobScrubber\` service walks \`SolidQueue::Job.where(class_name: \"ActiveStorage::AnalyzeJob\", finished_at: nil)\`, extracts the blob id from the serialized GlobalID, and discards rows where the blob row is missing OR the blob file is missing on disk.
* New \`rake active_storage:scrub_orphan_analyze_jobs\` task wraps it. \`DRY_RUN=1\` previews without discarding.
* Structured \`active_storage.scrub.orphan_analyze_job\` warning per orphan with \`sq_job_id\`, \`blob_id\`, \`reason\`, \`dry_run\` for audit.

## Operational note

Origin of these orphans was the Telegram duplicate-draft race fixed in PR #874 — concurrent webhook jobs created two News records, the photo blob attached to the loser, and on cleanup the blob was destroyed mid-flight leaving the AnalyzeJob retrying indefinitely. PR #874 prevents new occurrences; this task clears the historical queue.

## Run on prod
\`\`\`
kamal app exec --reuse 'bin/rails active_storage:scrub_orphan_analyze_jobs DRY_RUN=1'
# inspect output, then:
kamal app exec --reuse 'bin/rails active_storage:scrub_orphan_analyze_jobs'
\`\`\`

## Test plan
- [x] \`bundle exec rspec spec/services/active_storage/analyze_job_scrubber_spec.rb\` — 10 examples, 0 failures
- [x] Covered: blob row missing → discard, file missing → discard, all-present → skip, dry_run → skip, unparseable GID → skip, empty arguments → skip
- [x] Log payload assertions verify event/blob_id/sq_job_id/reason
- [x] rubocop clean
- [x] Evilution: 94.64% score, 6 survivors documented in feedback log (Ruby-equivalent returns + default-arg lazy-eval needing real SolidQueue table)